### PR TITLE
Implement history page with collapsible days

### DIFF
--- a/lib/features/days/data/day_manager.dart
+++ b/lib/features/days/data/day_manager.dart
@@ -27,6 +27,12 @@ class FoodDayManager extends ChangeNotifier {
 
   FoodDay? get currentDay => _currentDay;
 
+  List<FoodDay> get history {
+    final days = _foodDayRepository.getAllDays();
+    days.sort((a, b) => b.date.compareTo(a.date));
+    return days;
+  }
+
   Future<void> initialize(DateTime now) async {
     _currentDay = _foodDayRepository.getDay(now) ?? _createDay(now);
     _handleDayProgression(now);

--- a/lib/features/days/data/food_day_repository.dart
+++ b/lib/features/days/data/food_day_repository.dart
@@ -3,4 +3,5 @@ import 'package:food_locker/features/days/data/day.dart';
 abstract class FoodDayRepository {
   FoodDay? getDay(DateTime date);
   Future<void> saveDay(FoodDay day);
+  List<FoodDay> getAllDays();
 }

--- a/lib/features/days/data/in_memory_food_day_repository.dart
+++ b/lib/features/days/data/in_memory_food_day_repository.dart
@@ -17,4 +17,9 @@ class InMemoryFoodDayRepository implements FoodDayRepository {
   Future<void> saveDay(FoodDay day) async {
     _days[_getKey(day.date)] = day;
   }
+
+  @override
+  List<FoodDay> getAllDays() {
+    return _days.values.toList();
+  }
 }

--- a/lib/features/days/data/persistent_food_day_repository.dart
+++ b/lib/features/days/data/persistent_food_day_repository.dart
@@ -20,4 +20,9 @@ class PersistentFoodDayRepository implements FoodDayRepository {
   Future<void> saveDay(FoodDay day) async {
     await _box.put(_getKey(day.date), day);
   }
+
+  @override
+  List<FoodDay> getAllDays() {
+    return _box.values.toList();
+  }
 }

--- a/lib/ui/pages/history_page.dart
+++ b/lib/ui/pages/history_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:food_locker/features/days/data/day.dart';
 import 'package:food_locker/features/days/data/day_manager.dart';
-import 'package:food_locker/features/food/data/food.dart';
 import 'package:provider/provider.dart';
 
 class HistoryPage extends StatelessWidget {
@@ -14,9 +12,7 @@ class HistoryPage extends StatelessWidget {
         final history = manager.history;
 
         if (history.isEmpty) {
-          return const Center(
-            child: Text('No history available'),
-          );
+          return const Center(child: Text('No history available'));
         }
 
         return ListView.builder(

--- a/lib/ui/pages/history_page.dart
+++ b/lib/ui/pages/history_page.dart
@@ -1,32 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/features/days/data/day.dart';
+import 'package:food_locker/features/days/data/day_manager.dart';
+import 'package:food_locker/features/food/data/food.dart';
+import 'package:provider/provider.dart';
 
 class HistoryPage extends StatelessWidget {
   const HistoryPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    return Consumer<FoodDayManager>(
+      builder: (context, manager, child) {
+        final history = manager.history;
 
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.history_rounded,
-            size: 80,
-            color: theme.colorScheme.primary,
-          ),
-          const SizedBox(height: 16),
-          Text('History', style: theme.textTheme.headlineMedium),
-          const SizedBox(height: 8),
-          Text(
-            'Review past days',
-            style: theme.textTheme.bodyLarge?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
+        if (history.isEmpty) {
+          return const Center(
+            child: Text('No history available'),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: history.length,
+          itemBuilder: (context, index) {
+            final day = history[index];
+            final consumedFoods = [
+              ...day.meals.where((f) => f.wasEaten),
+              ...day.snacks.where((f) => f.wasEaten),
+            ];
+            consumedFoods.sort((a, b) => a.eatenAt!.compareTo(b.eatenAt!));
+
+            return ExpansionTile(
+              key: ValueKey(day.date),
+              title: Text(_formatDate(day.date)),
+              children: consumedFoods.map((food) {
+                return ListTile(
+                  title: Text(food.name),
+                  trailing: Text(_formatTime(food.eatenAt!)),
+                );
+              }).toList(),
+            );
+          },
+        );
+      },
     );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  String _formatTime(DateTime time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
   }
 }

--- a/test/features/days/data/day_manager_test.dart
+++ b/test/features/days/data/day_manager_test.dart
@@ -229,5 +229,40 @@ void main() {
       final savedDay = foodDayRepository.getDay(now);
       expect(savedDay!.meals.length, 2);
     });
+
+    test('history returns sorted days', () async {
+      final day1 = FoodDay(
+        date: DateTime(2023, 10, 26),
+        meals: [],
+        snacks: [],
+      );
+      final day2 = FoodDay(
+        date: DateTime(2023, 10, 27),
+        meals: [],
+        snacks: [],
+      );
+      final day3 = FoodDay(
+        date: DateTime(2023, 10, 25),
+        meals: [],
+        snacks: [],
+      );
+
+      await foodDayRepository.saveDay(day1);
+      await foodDayRepository.saveDay(day2);
+      await foodDayRepository.saveDay(day3);
+
+      dayManager = FoodDayManager(
+        null,
+        foodConfigRepository,
+        foodDayRepository,
+      );
+
+      final history = dayManager.history;
+
+      expect(history.length, 3);
+      expect(history[0].date, day2.date);
+      expect(history[1].date, day1.date);
+      expect(history[2].date, day3.date);
+    });
   });
 }

--- a/test/features/days/data/persistent_food_day_repository_test.dart
+++ b/test/features/days/data/persistent_food_day_repository_test.dart
@@ -61,5 +61,27 @@ void main() {
       final retrievedDay = repository.getDay(now);
       expect(retrievedDay, isNull);
     });
+
+    test('getAllDays returns all days', () async {
+      final day1 = FoodDay(
+        date: DateTime(2023, 10, 26),
+        meals: [],
+        snacks: [],
+      );
+      final day2 = FoodDay(
+        date: DateTime(2023, 10, 27),
+        meals: [],
+        snacks: [],
+      );
+
+      await repository.saveDay(day1);
+      await repository.saveDay(day2);
+
+      final allDays = repository.getAllDays();
+
+      expect(allDays.length, 2);
+      expect(allDays.any((d) => d.date.day == 26), isTrue);
+      expect(allDays.any((d) => d.date.day == 27), isTrue);
+    });
   });
 }


### PR DESCRIPTION
This PR implements the history page functionality. It modifies the `FoodDayRepository` to support retrieving all days, updates the `FoodDayManager` to expose the history, and implements the UI in `HistoryPage.dart` to display the history as a list of collapsible days, showing consumed foods ordered by time.

---
*PR created automatically by Jules for task [1757974988147769991](https://jules.google.com/task/1757974988147769991) started by @igorbasko01*