### PR TITLE
fix: break overeating streak when food tracking day is missing

### DIFF
--- a/lib/features/days/data/day_manager.dart
+++ b/lib/features/days/data/day_manager.dart
@@ -161,6 +161,9 @@ class FoodDayManager extends ChangeNotifier {
   }
 
   bool? isOvereaten(DateTime date, WeightManager weightManager) {
+    final hasFoodDay = _foodDayRepository.getDay(date) != null;
+    if (!hasFoodDay) return null;
+
     final weightOnDay = weightManager.getWeightForDate(date);
     final weightNextDay = weightManager.getWeightForDate(DateTime(date.year, date.month, date.day + 1));
 

--- a/test/features/days/data/day_manager_test.dart
+++ b/test/features/days/data/day_manager_test.dart
@@ -356,7 +356,7 @@ void main() {
         );
       });
 
-      Future<void> _createFoodDay(DateTime date) async {
+      Future<void> createFoodDay(DateTime date) async {
         await foodDayRepository.saveDay(FoodDay(
           date: date,
           meals: [],
@@ -370,10 +370,10 @@ void main() {
         final dayBefore = today.subtract(const Duration(days: 2));
         final threeDaysAgo = today.subtract(const Duration(days: 3));
 
-        await _createFoodDay(threeDaysAgo);
-        await _createFoodDay(dayBefore);
-        await _createFoodDay(yesterday);
-        await _createFoodDay(today);
+        await createFoodDay(threeDaysAgo);
+        await createFoodDay(dayBefore);
+        await createFoodDay(yesterday);
+        await createFoodDay(today);
 
         await weightManager.addWeight(threeDaysAgo, 80.0);
         await weightManager.addWeight(dayBefore, 79.0);
@@ -393,10 +393,10 @@ void main() {
         final dayBefore = today.subtract(const Duration(days: 2));
         final threeDaysAgo = today.subtract(const Duration(days: 3));
 
-        await _createFoodDay(threeDaysAgo);
-        await _createFoodDay(dayBefore);
-        await _createFoodDay(yesterday);
-        await _createFoodDay(today);
+        await createFoodDay(threeDaysAgo);
+        await createFoodDay(dayBefore);
+        await createFoodDay(yesterday);
+        await createFoodDay(today);
 
         await weightManager.addWeight(threeDaysAgo, 80.0);
         await weightManager.addWeight(dayBefore, 81.0);
@@ -415,9 +415,9 @@ void main() {
         final yesterday = today.subtract(const Duration(days: 1));
         final dayBefore = today.subtract(const Duration(days: 2));
         
-        await _createFoodDay(dayBefore);
-        await _createFoodDay(yesterday);
-        await _createFoodDay(today);
+        await createFoodDay(dayBefore);
+        await createFoodDay(yesterday);
+        await createFoodDay(today);
 
         await weightManager.addWeight(dayBefore, 80.0);
         await weightManager.addWeight(yesterday, 80.0);
@@ -435,8 +435,8 @@ void main() {
         final yesterday = today.subtract(const Duration(days: 1));
         final dayBefore = today.subtract(const Duration(days: 2));
         
-        await _createFoodDay(dayBefore);
-        await _createFoodDay(yesterday);
+        await createFoodDay(dayBefore);
+        await createFoodDay(yesterday);
         // today food day is missing!
 
         await weightManager.addWeight(dayBefore, 80.0);
@@ -452,14 +452,13 @@ void main() {
       
       test('missing a day in the middle breaks longest streak', () async {
         final today = DateTime.now();
-        final yesterday = today.subtract(const Duration(days: 1));
         final twoDaysAgo = today.subtract(const Duration(days: 2));
         final threeDaysAgo = today.subtract(const Duration(days: 3));
         
-        await _createFoodDay(threeDaysAgo);
-        await _createFoodDay(twoDaysAgo);
+        await createFoodDay(threeDaysAgo);
+        await createFoodDay(twoDaysAgo);
         // yesterday food day is missing!
-        await _createFoodDay(today);
+        await createFoodDay(today);
 
         await weightManager.addWeight(threeDaysAgo, 80.0);
         await weightManager.addWeight(twoDaysAgo, 79.0);

--- a/test/features/days/data/day_manager_test.dart
+++ b/test/features/days/data/day_manager_test.dart
@@ -8,6 +8,8 @@ import 'package:food_locker/features/food/data/food_config.dart';
 import 'package:food_locker/features/food/data/food_config_repository.dart';
 import 'package:food_locker/features/food/data/food_type.dart';
 import 'package:food_locker/features/food/data/in_memory_food_config_repository.dart';
+import 'package:food_locker/features/weight/data/weight_manager.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
 
 void main() {
   late FoodDayManager dayManager;
@@ -338,6 +340,138 @@ void main() {
 
       expect(dayManager.currentDay, isNotNull);
       expect(dayManager.currentDay, isNot(same(currentDayBefore)));
+    });
+
+    group('getOvereatingStats', () {
+      late WeightManager weightManager;
+      late InMemoryWeightRepository weightRepository;
+
+      setUp(() {
+        weightRepository = InMemoryWeightRepository();
+        weightManager = WeightManager(weightRepository);
+        dayManager = FoodDayManager(
+          null,
+          foodConfigRepository,
+          foodDayRepository,
+        );
+      });
+
+      Future<void> _createFoodDay(DateTime date) async {
+        await foodDayRepository.saveDay(FoodDay(
+          date: date,
+          meals: [],
+          snacks: [],
+        ));
+      }
+
+      test('continuous weight loss increases clean streak', () async {
+        final today = DateTime.now();
+        final yesterday = today.subtract(const Duration(days: 1));
+        final dayBefore = today.subtract(const Duration(days: 2));
+        final threeDaysAgo = today.subtract(const Duration(days: 3));
+
+        await _createFoodDay(threeDaysAgo);
+        await _createFoodDay(dayBefore);
+        await _createFoodDay(yesterday);
+        await _createFoodDay(today);
+
+        await weightManager.addWeight(threeDaysAgo, 80.0);
+        await weightManager.addWeight(dayBefore, 79.0);
+        await weightManager.addWeight(yesterday, 78.0);
+        await weightManager.addWeight(today, 77.0);
+
+        final stats = dayManager.getOvereatingStats(weightManager);
+        
+        expect(stats.cleanStreak, 3);
+        expect(stats.overeatingStreak, 0);
+        expect(stats.longestCleanStreak, 3);
+      });
+
+      test('continuous weight gain increases overeating streak', () async {
+        final today = DateTime.now();
+        final yesterday = today.subtract(const Duration(days: 1));
+        final dayBefore = today.subtract(const Duration(days: 2));
+        final threeDaysAgo = today.subtract(const Duration(days: 3));
+
+        await _createFoodDay(threeDaysAgo);
+        await _createFoodDay(dayBefore);
+        await _createFoodDay(yesterday);
+        await _createFoodDay(today);
+
+        await weightManager.addWeight(threeDaysAgo, 80.0);
+        await weightManager.addWeight(dayBefore, 81.0);
+        await weightManager.addWeight(yesterday, 82.0);
+        await weightManager.addWeight(today, 83.0);
+
+        final stats = dayManager.getOvereatingStats(weightManager);
+        
+        expect(stats.cleanStreak, 0);
+        expect(stats.overeatingStreak, 3);
+        expect(stats.longestCleanStreak, 0);
+      });
+
+      test('same weight is considered a clean day', () async {
+        final today = DateTime.now();
+        final yesterday = today.subtract(const Duration(days: 1));
+        final dayBefore = today.subtract(const Duration(days: 2));
+        
+        await _createFoodDay(dayBefore);
+        await _createFoodDay(yesterday);
+        await _createFoodDay(today);
+
+        await weightManager.addWeight(dayBefore, 80.0);
+        await weightManager.addWeight(yesterday, 80.0);
+        await weightManager.addWeight(today, 80.0);
+
+        final stats = dayManager.getOvereatingStats(weightManager);
+        
+        expect(stats.cleanStreak, 2);
+        expect(stats.overeatingStreak, 0);
+        expect(stats.longestCleanStreak, 2);
+      });
+
+      test('missing today breaks the current streak', () async {
+        final today = DateTime.now();
+        final yesterday = today.subtract(const Duration(days: 1));
+        final dayBefore = today.subtract(const Duration(days: 2));
+        
+        await _createFoodDay(dayBefore);
+        await _createFoodDay(yesterday);
+        // today food day is missing!
+
+        await weightManager.addWeight(dayBefore, 80.0);
+        await weightManager.addWeight(yesterday, 79.0);
+        // today weight is missing!
+
+        final stats = dayManager.getOvereatingStats(weightManager);
+        
+        expect(stats.cleanStreak, 0);
+        // Longest clean streak is still 1 from dayBefore -> yesterday
+        expect(stats.longestCleanStreak, 1);
+      });
+      
+      test('missing a day in the middle breaks longest streak', () async {
+        final today = DateTime.now();
+        final yesterday = today.subtract(const Duration(days: 1));
+        final twoDaysAgo = today.subtract(const Duration(days: 2));
+        final threeDaysAgo = today.subtract(const Duration(days: 3));
+        
+        await _createFoodDay(threeDaysAgo);
+        await _createFoodDay(twoDaysAgo);
+        // yesterday food day is missing!
+        await _createFoodDay(today);
+
+        await weightManager.addWeight(threeDaysAgo, 80.0);
+        await weightManager.addWeight(twoDaysAgo, 79.0);
+        // yesterday is missing!
+        await weightManager.addWeight(today, 78.0);
+
+        final stats = dayManager.getOvereatingStats(weightManager);
+        
+        expect(stats.cleanStreak, 0);
+        // The streak from 3 days ago to 2 days ago is 1.
+        expect(stats.longestCleanStreak, 1);
+      });
     });
   });
 }


### PR DESCRIPTION
This pull request resolves an issue where untracked food days (missing `FoodDay` entries in the repository) were not breaking the overeating streak. 

### Changes:
- Modified `isOvereaten` in `day_manager.dart` to verify that a `FoodDay` exists for the checked date before evaluating weight. If no `FoodDay` is found, it returns `null` (N/A) which breaks the current streak.
- Added comprehensive unit tests in `day_manager_test.dart` to cover:
  - Happy path weight changes.
  - Missing weights/days breaking streaks correctly.
  - Longest clean streak behavior with missing days.

All unit tests have been successfully verified.