### PR TITLE
refactor: remove repository duplication (DRY) (#42)

### DIFF
--- a/lib/features/weight/data/in_memory_weight_repository.dart
+++ b/lib/features/weight/data/in_memory_weight_repository.dart
@@ -1,27 +1,12 @@
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
 
-class InMemoryWeightRepository implements WeightRepository {
+class InMemoryWeightRepository with WeightRepositoryHelper implements WeightRepository {
   final Map<String, Weight> _weights = {};
-  final Map<String, double?> _lowestWeightCache = {};
-
-  String _getKey(DateTime date) {
-    return '${date.year}-${date.month}-${date.day}';
-  }
-
-  String _getCacheKey(DateTime? since) {
-    if (since == null) return 'all_time';
-    final normalizedSince = DateTime(since.year, since.month, since.day);
-    return 'since_${normalizedSince.toIso8601String()}';
-  }
-
-  void _invalidateCache() {
-    _lowestWeightCache.clear();
-  }
 
   @override
   Weight? getWeightForDay(DateTime date) {
-    return _weights[_getKey(date)];
+    return _weights[getKey(date)];
   }
 
   @override
@@ -31,60 +16,19 @@ class InMemoryWeightRepository implements WeightRepository {
 
   @override
   Future<void> saveWeight(Weight weight) async {
-    _invalidateCache();
-    _weights[_getKey(weight.date)] = weight;
+    invalidateCache();
+    _weights[getKey(weight.date)] = weight;
   }
 
   @override
   Future<void> deleteWeight(DateTime date) async {
-    _invalidateCache();
-    _weights.remove(_getKey(date));
+    invalidateCache();
+    _weights.remove(getKey(date));
   }
 
   @override
   Future<void> clear() async {
-    _invalidateCache();
+    invalidateCache();
     _weights.clear();
-  }
-
-  @override
-  double? getLowestWeight({DateTime? since}) {
-    final cacheKey = _getCacheKey(since);
-    
-    if (_lowestWeightCache.containsKey(cacheKey)) {
-      return _lowestWeightCache[cacheKey];
-    }
-    
-    if (_weights.isEmpty) {
-      _lowestWeightCache[cacheKey] = null;
-      return null;
-    }
-    
-    var weights = _weights.values;
-    
-    if (since != null) {
-      final sinceDateOnly = DateTime(since.year, since.month, since.day);
-      weights = weights.where((w) {
-        final weightDateOnly = DateTime(w.date.year, w.date.month, w.date.day);
-        return weightDateOnly.isAfter(sinceDateOnly) || weightDateOnly.isAtSameMomentAs(sinceDateOnly);
-      });
-    }
-    
-    if (weights.isEmpty) {
-      _lowestWeightCache[cacheKey] = null;
-      return null;
-    }
-    
-    final result = weights.map((w) => w.value).reduce((a, b) => a < b ? a : b);
-    _lowestWeightCache[cacheKey] = result;
-    return result;
-  }
-
-  @override
-  DateTime? getOldestWeightDate() {
-    if (_weights.isEmpty) return null;
-    return _weights.values
-        .map((w) => w.date)
-        .reduce((a, b) => a.isBefore(b) ? a : b);
   }
 }

--- a/lib/features/weight/data/persistent_weight_repository.dart
+++ b/lib/features/weight/data/persistent_weight_repository.dart
@@ -2,29 +2,14 @@ import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
 import 'package:hive/hive.dart';
 
-class PersistentWeightRepository implements WeightRepository {
+class PersistentWeightRepository with WeightRepositoryHelper implements WeightRepository {
   final Box<Weight> _box;
-  final Map<String, double?> _lowestWeightCache = {};
 
   PersistentWeightRepository(this._box);
 
-  String _getKey(DateTime date) {
-    return '${date.year}-${date.month}-${date.day}';
-  }
-
-  String _getCacheKey(DateTime? since) {
-    if (since == null) return 'all_time';
-    final normalizedSince = DateTime(since.year, since.month, since.day);
-    return 'since_${normalizedSince.toIso8601String()}';
-  }
-
-  void _invalidateCache() {
-    _lowestWeightCache.clear();
-  }
-
   @override
   Weight? getWeightForDay(DateTime date) {
-    return _box.get(_getKey(date));
+    return _box.get(getKey(date));
   }
 
   @override
@@ -34,60 +19,19 @@ class PersistentWeightRepository implements WeightRepository {
 
   @override
   Future<void> saveWeight(Weight weight) async {
-    _invalidateCache();
-    await _box.put(_getKey(weight.date), weight);
+    invalidateCache();
+    await _box.put(getKey(weight.date), weight);
   }
 
   @override
   Future<void> deleteWeight(DateTime date) async {
-    _invalidateCache();
-    await _box.delete(_getKey(date));
+    invalidateCache();
+    await _box.delete(getKey(date));
   }
 
   @override
   Future<void> clear() async {
-    _invalidateCache();
+    invalidateCache();
     await _box.clear();
-  }
-
-  @override
-  double? getLowestWeight({DateTime? since}) {
-    final cacheKey = _getCacheKey(since);
-    
-    if (_lowestWeightCache.containsKey(cacheKey)) {
-      return _lowestWeightCache[cacheKey];
-    }
-    
-    if (_box.isEmpty) {
-      _lowestWeightCache[cacheKey] = null;
-      return null;
-    }
-    
-    var weights = _box.values;
-    
-    if (since != null) {
-      final sinceDateOnly = DateTime(since.year, since.month, since.day);
-      weights = weights.where((w) {
-        final weightDateOnly = DateTime(w.date.year, w.date.month, w.date.day);
-        return weightDateOnly.isAfter(sinceDateOnly) || weightDateOnly.isAtSameMomentAs(sinceDateOnly);
-      });
-    }
-    
-    if (weights.isEmpty) {
-      _lowestWeightCache[cacheKey] = null;
-      return null;
-    }
-    
-    final result = weights.map((w) => w.value).reduce((a, b) => a < b ? a : b);
-    _lowestWeightCache[cacheKey] = result;
-    return result;
-  }
-
-  @override
-  DateTime? getOldestWeightDate() {
-    if (_box.isEmpty) return null;
-    return _box.values
-        .map((w) => w.date)
-        .reduce((a, b) => a.isBefore(b) ? a : b);
   }
 }

--- a/lib/features/weight/data/weight_repository.dart
+++ b/lib/features/weight/data/weight_repository.dart
@@ -14,3 +14,64 @@ abstract class WeightRepository {
   /// Returns the date of the oldest weight record, or null if empty.
   DateTime? getOldestWeightDate();
 }
+
+mixin WeightRepositoryHelper implements WeightRepository {
+  final Map<String, double?> _lowestWeightCache = {};
+
+  String getKey(DateTime date) {
+    return '${date.year}-${date.month}-${date.day}';
+  }
+
+  String getCacheKey(DateTime? since) {
+    if (since == null) return 'all_time';
+    final normalizedSince = DateTime(since.year, since.month, since.day);
+    return 'since_${normalizedSince.toIso8601String()}';
+  }
+
+  void invalidateCache() {
+    _lowestWeightCache.clear();
+  }
+
+  @override
+  double? getLowestWeight({DateTime? since}) {
+    final cacheKey = getCacheKey(since);
+    
+    if (_lowestWeightCache.containsKey(cacheKey)) {
+      return _lowestWeightCache[cacheKey];
+    }
+    
+    final weights = getAllWeights();
+    if (weights.isEmpty) {
+      _lowestWeightCache[cacheKey] = null;
+      return null;
+    }
+    
+    Iterable<Weight> filtered = weights;
+    
+    if (since != null) {
+      final sinceDateOnly = DateTime(since.year, since.month, since.day);
+      filtered = filtered.where((w) {
+        final weightDateOnly = DateTime(w.date.year, w.date.month, w.date.day);
+        return weightDateOnly.isAfter(sinceDateOnly) || weightDateOnly.isAtSameMomentAs(sinceDateOnly);
+      });
+    }
+    
+    if (filtered.isEmpty) {
+      _lowestWeightCache[cacheKey] = null;
+      return null;
+    }
+    
+    final result = filtered.map((w) => w.value).reduce((a, b) => a < b ? a : b);
+    _lowestWeightCache[cacheKey] = result;
+    return result;
+  }
+
+  @override
+  DateTime? getOldestWeightDate() {
+    final weights = getAllWeights();
+    if (weights.isEmpty) return null;
+    return weights
+        .map((w) => w.date)
+        .reduce((a, b) => a.isBefore(b) ? a : b);
+  }
+}

--- a/test/features/weight/weight_repository_test.dart
+++ b/test/features/weight/weight_repository_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+
+void main() {
+  group('WeightRepositoryHelper / InMemoryWeightRepository', () {
+    late InMemoryWeightRepository repository;
+
+    setUp(() {
+      repository = InMemoryWeightRepository();
+    });
+
+    test('getKey returns formatted date string', () {
+      final date = DateTime(2023, 5, 20);
+      expect(repository.getKey(date), '2023-5-20');
+    });
+
+    test('getCacheKey returns correct key based on since date', () {
+      expect(repository.getCacheKey(null), 'all_time');
+      final since = DateTime(2023, 5, 20);
+      expect(
+        repository.getCacheKey(since),
+        'since_${DateTime(2023, 5, 20).toIso8601String()}',
+      );
+    });
+
+    test('getLowestWeight returns null when empty', () {
+      expect(repository.getLowestWeight(), isNull);
+    });
+
+    test('getLowestWeight returns minimum value', () async {
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 10), value: 80.0));
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 11), value: 75.0));
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 12), value: 78.0));
+
+      expect(repository.getLowestWeight(), 75.0);
+    });
+
+    test('getLowestWeight with since parameter filters correctly', () async {
+      final baseDate = DateTime(2023, 5, 10);
+      await repository.saveWeight(Weight(date: baseDate, value: 70.0)); // older, lower
+      await repository.saveWeight(Weight(date: baseDate.add(const Duration(days: 2)), value: 75.0));
+      await repository.saveWeight(Weight(date: baseDate.add(const Duration(days: 4)), value: 72.0));
+
+      expect(repository.getLowestWeight(since: baseDate.add(const Duration(days: 1))), 72.0);
+    });
+
+    test('getLowestWeight caches result and invalidates correctly', () async {
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 10), value: 80.0));
+      expect(repository.getLowestWeight(), 80.0);
+
+      // Save a new lower weight, which should invalidate cache
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 11), value: 75.0));
+      expect(repository.getLowestWeight(), 75.0);
+
+      // Delete weight, which should invalidate cache
+      await repository.deleteWeight(DateTime(2023, 5, 11));
+      expect(repository.getLowestWeight(), 80.0);
+
+      // Clear, which should invalidate cache
+      await repository.clear();
+      expect(repository.getLowestWeight(), isNull);
+    });
+
+    test('getOldestWeightDate returns oldest date', () async {
+      expect(repository.getOldestWeightDate(), isNull);
+
+      final date1 = DateTime(2023, 5, 12);
+      final date2 = DateTime(2023, 5, 10);
+      final date3 = DateTime(2023, 5, 15);
+
+      await repository.saveWeight(Weight(date: date1, value: 80.0));
+      await repository.saveWeight(Weight(date: date2, value: 75.0));
+      await repository.saveWeight(Weight(date: date3, value: 78.0));
+
+      expect(repository.getOldestWeightDate(), date2);
+    });
+  });
+}


### PR DESCRIPTION
Closes #42. Extract common query, helper, and caching methods into a shared WeightRepositoryHelper mixin.