### PR TITLE
docs: add CLAUDE.md and refresh README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+FoodLocker is a Flutter (mobile, primarily Android) app for tracking daily weight and derived health stats. Data is stored locally with Hive CE; state is exposed to the UI via Provider. Despite the name and README, the shipped feature set is weight tracking and analytics (a `food`/`days` feature described in the README no longer exists in `lib/`).
+
+## Commands
+
+- `flutter pub get` — install dependencies
+- `flutter analyze` — static analysis / lint (rules from `analysis_options.yaml` → `flutter_lints`)
+- `flutter test` — run all tests
+- `flutter test test/features/weight/weight_manager_test.dart` — run a single test file
+- `flutter test --name "substring"` — run tests whose description matches
+- `flutter run` — run on a connected device/emulator (see `.agents/skills/flutter-emulator-run/SKILL.md` for the emulator workflow)
+- `dart run build_runner build --delete-conflicting-outputs` — regenerate Hive adapters after changing any `@HiveType`/`@HiveField` model
+- `./setup.sh` — one-time local setup; points `core.hooksPath` at `.githooks`
+
+`flutter analyze` and `flutter test` both gate pushes locally (`.githooks/pre-push`) and PRs to `main` (`.github/workflows/flutter_ci.yml`). Run them before pushing.
+
+## Code Generation
+
+`*.g.dart` files (e.g. `lib/features/weight/data/weight.g.dart`) and `lib/hive_registrar.g.dart` are generated and checked in — do not edit them by hand. After adding or changing a Hive model, or adding a new `@HiveType`, rerun `build_runner`. Hive `typeId`s must be unique and stable across the app's history (weight uses 3 and 4); reusing an old id breaks existing users' stored boxes, so pick a fresh id rather than renumbering.
+
+## Architecture
+
+Code is organized as `lib/features/<feature>/data` (domain + persistence) and `lib/ui` (`pages/`, `widgets/`, shell, theme). The dependency wiring lives in `lib/main.dart`: Hive is initialized, the `weights` box is opened, and everything is provided through a `MultiProvider` before `runApp`. `AppShell` is a three-tab `BottomNavigationBar` (Home / Weight / Settings) over an `IndexedStack`.
+
+Key layering for the weight feature:
+
+- **`Weight` / `WeightUnit`** (`weight.dart`) — Hive-annotated domain model.
+- **`WeightRepository`** — abstract persistence interface. `WeightRepositoryHelper` is a mixin providing shared lowest-weight logic + caching. Three implementations exist: `PersistentWeightRepository` (Hive-backed, production), `InMemoryWeightRepository` (tests), and it is injected as a `Provider<WeightRepository>` so callers depend on the interface, not the box.
+- **`WeightManager extends ChangeNotifier`** — the UI-facing state holder (`ChangeNotifierProvider`). It owns the in-memory `_weights` list and, after every mutation, re-reads from the repository and `notifyListeners()` to stay consistent. Wraps `WeightAnalytics` and re-exports its `StreakType`/`OvereatingStats` types.
+- **`WeightAnalytics`** — pure computation over the repository (lowest all-time / last 30 / last 7 days, overeating & streak stats).
+
+Dates are treated as day-granular throughout: repository keys and equality normalize to `(year, month, day)`, so "one entry per day" is the invariant. When adding mutation paths, follow the existing pattern (write through the repository, then refresh `_weights` from it).
+
+### Backup / restore
+
+`SerializationService` (Settings tab) exports/imports a zip. `WeightBackupCodec` handles CSV-in-zip encode/decode; `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable. Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
+
+## Testing
+
+Tests mirror `lib/` under `test/`. Prefer `InMemoryWeightRepository` over Hive in unit tests. `test/features/weight/hive_ce_migration_test.dart` guards persistence/migration behavior — treat it as a compatibility contract when touching models or `typeId`s.
+
+## Releases
+
+Versioning is automated via release-please (`.github/workflows/release-please.yml`); use Conventional Commit messages (`feat:`, `fix:`, etc.) since they drive the changelog and version bump. `RELEASING.md` documents the full flow and `build_install_release.sh` builds/installs a release APK.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,6 @@ Dates are treated as day-granular throughout: repository keys and equality norma
 
 Tests mirror `lib/` under `test/`. Prefer `InMemoryWeightRepository` over Hive in unit tests. `test/features/weight/hive_ce_migration_test.dart` guards persistence/migration behavior — treat it as a compatibility contract when touching models or `typeId`s.
 
-## Releases
+## Commit Messages & Releases
 
-Versioning is automated via release-please (`.github/workflows/release-please.yml`); use Conventional Commit messages (`feat:`, `fix:`, etc.) since they drive the changelog and version bump. `RELEASING.md` documents the full flow and `build_install_release.sh` builds/installs a release APK.
+This project uses **Conventional Commits** — always prefix commit messages and PR titles with `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, etc. On every push to `main`, the **release-please** CI workflow (`.github/workflows/release-please.yml`) reads these commits to calculate the next version, bump `pubspec.yaml`, and update `CHANGELOG.md` via a release PR — so the prefix directly drives versioning (`feat:` → minor, `fix:` → patch, `!`/`BREAKING CHANGE:` → major). Do not bump the version manually. `RELEASING.md` documents the full flow and `build_install_release.sh` builds/installs a release APK.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # FoodLocker
 
-A Flutter application designed to track food intake and manage daily nutritional goals efficiently. This project leverages `Hive CE` for fast local data storage and `Provider` for state management.
+A Flutter application for tracking your daily weight and understanding your progress over time. FoodLocker stores everything locally using `Hive CE` and uses `Provider` for state management.
 
 ## Features
 
-- **Daily Food Tracking**: Log your daily food consumption easily.
-- **Persistent Storage**: Data is saved locally using [Hive CE](https://pub.dev/packages/hive_ce) and [SharedPreferences](https://pub.dev/packages/shared_preferences), ensuring your records are kept safe even after the app is closed.
-- **Food Configuration**: Manage and customize your food items and their nutritional values.
-- **Theming**: Includes a custom app theme for a consistent and pleasant user interface.
-- **State Management**: Utilizes the `Provider` package for efficient state management across the application.
+- **Daily Weight Tracking**: Log one weight entry per day, in kilograms or pounds.
+- **Analytics & Insights**: See your lowest weight all-time and over the last 7 / 30 days, plus "clean" vs. "overeating" streaks derived from day-over-day changes.
+- **Weight History & Chart**: Browse past entries and visualize trends with a chart (`fl_chart`).
+- **Backup & Restore**: Export your data to a zip file and import it back later from the Settings tab.
+- **Persistent Storage**: Data is saved locally using [Hive CE](https://pub.dev/packages/hive_ce), so your records survive app restarts.
+- **State Management**: Uses the [Provider](https://pub.dev/packages/provider) package for state management across the app.
 
 ## Getting Started
-
-This project is a starting point for a Flutter application.
 
 ### Prerequisites
 
@@ -24,8 +23,8 @@ This project is a starting point for a Flutter application.
 1.  **Clone the repository:**
 
     ```bash
-    git clone https://github.com/yourusername/food_locker.git
-    cd food_locker
+    git clone https://github.com/igorbasko01/food-locker.git
+    cd food-locker
     ```
 
 2.  **Install dependencies:**
@@ -34,7 +33,13 @@ This project is a starting point for a Flutter application.
     flutter pub get
     ```
 
-3.  **Run the application:**
+3.  **(Optional) Set up git hooks** to run `flutter analyze` and `flutter test` before every push:
+
+    ```bash
+    ./setup.sh
+    ```
+
+4.  **Run the application:**
 
     ```bash
     flutter run
@@ -42,17 +47,22 @@ This project is a starting point for a Flutter application.
 
 ### Code Generation
 
-This project uses `build_runner` for code generation (e.g., for Hive CE adapters). If you make changes to models that require code generation, run:
+This project uses `build_runner` for code generation (e.g. for Hive CE adapters). If you change a model that requires code generation, regenerate the `*.g.dart` files:
 
 ```bash
-flutter pub run build_runner build
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 ## Project Structure
 
-- `lib/features`: Contains feature-specific code (e.g., `days`, `food`).
-- `lib/ui`: UI components and pages.
-- `lib/main.dart`: Application entry point.
+- `lib/features`: Feature-specific domain and persistence code (e.g. `weight`, `settings`).
+- `lib/ui`: UI pages, widgets, the app shell, and theme.
+- `lib/core`: Shared helpers (CSV serialization, query utilities).
+- `lib/main.dart`: Application entry point and dependency wiring.
+
+## Contributing
+
+This project uses **Conventional Commits** and **release-please** to automate versioning and changelog generation. Prefix commits / PR titles with `feat:`, `fix:`, `chore:`, etc. See [RELEASING.md](RELEASING.md) for details.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` to guide future Claude Code sessions: common commands (analyze/test/single-test, `build_runner`, `setup.sh`), the code-generation rules for Hive adapters and stable `typeId`s, the weight feature's architecture (repository interface + `WeightManager` + `WeightAnalytics`), backup/restore layout, testing conventions, and the Conventional Commits / release-please flow.
- Rewrite `README.md` to match the app as shipped — daily weight tracking (kg/lbs), analytics (lowest all-time / 7 / 30 days, clean-vs-overeating streaks), history + chart, and backup/restore. The old README described `days`/`food` features that no longer exist in `lib/`.
- Fix the README clone URL, correct the `build_runner` command, add the `./setup.sh` git-hooks step, update the project-structure list, and add a Contributing section pointing at Conventional Commits + release-please.

## Notes

Docs-only change — no code touched, so `flutter analyze` / `flutter test` behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9aFHwModaPuQgUa11tsc1)_