### PR TITLE
feat: add Drift bite log store (bite-pacing Phase 1)

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -203,10 +203,10 @@ tooling swap, not a data migration.
 - [x] Verify a `Weight` round-trips through a real on-disk box (adapters + binary format intact)
 
 **Phase 1 — Drift setup + `bites` table**
-- [ ] Add Drift deps (`drift`, `drift_flutter` or `sqlite3_flutter_libs`, dev `drift_dev` + `build_runner`)
-- [ ] Define the database class and connection
-- [ ] Define `bites`: `id` autoincrement, `at_ms` plain `integer()` (epoch millis), indexed
-- [ ] Run codegen; confirm the DB opens and a row round-trips
+- [x] Add Drift deps (`drift`, `drift_flutter` or `sqlite3_flutter_libs`, dev `drift_dev` + `build_runner`)
+- [x] Define the database class and connection
+- [x] Define `bites`: `id` autoincrement, `at_ms` plain `integer()` (epoch millis), indexed
+- [x] Run codegen; confirm the DB opens and a row round-trips
 
 **Phase 2 — `pacing_config` table + default**
 - [ ] Define `pacing_config`: `effective_ms`, `b1_s`, `b2_s`

--- a/lib/features/bite/data/bite_database.dart
+++ b/lib/features/bite/data/bite_database.dart
@@ -1,0 +1,38 @@
+import 'package:drift/drift.dart';
+import 'package:drift_flutter/drift_flutter.dart';
+
+part 'bite_database.g.dart';
+
+/// Append-only stream of bite timestamps — the atomic fact the pacing feature
+/// is built on. Only the raw millisecond timestamp is stored; counts, deltas,
+/// and pacing zones are all derived at read time, so keeping the raw log keeps
+/// future options open with zero data loss.
+@DataClassName('Bite')
+@TableIndex(name: 'idx_bites_at_ms', columns: {#atMs})
+class Bites extends Table {
+  /// Insertion order is chronological (append-only), so the autoincrement id
+  /// doubles as a stable chronological key.
+  IntColumn get id => integer().autoIncrement()();
+
+  /// Epoch milliseconds (a UTC instant), millisecond precision.
+  ///
+  /// Deliberately a plain [integer], not drift's `dateTime()`: the default
+  /// datetime mode stores unix *seconds* and would silently truncate the
+  /// millisecond precision the inter-bite deltas depend on. Integer epoch
+  /// millis keep deltas an exact subtraction and stay DST-safe (monotonic
+  /// across midnight and clock changes).
+  IntColumn get atMs => integer().named('at_ms')();
+}
+
+@DriftDatabase(tables: [Bites])
+class BiteDatabase extends _$BiteDatabase {
+  /// Production constructor: opens the on-disk `bites` database.
+  BiteDatabase() : super(driftDatabase(name: 'bites'));
+
+  /// Test constructor: injects a custom (e.g. in-memory) executor so the
+  /// schema can be exercised without touching the device filesystem.
+  BiteDatabase.forTesting(super.executor);
+
+  @override
+  int get schemaVersion => 1;
+}

--- a/lib/features/bite/data/bite_database.g.dart
+++ b/lib/features/bite/data/bite_database.g.dart
@@ -1,0 +1,334 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bite_database.dart';
+
+// ignore_for_file: type=lint
+class $BitesTable extends Bites with TableInfo<$BitesTable, Bite> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $BitesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _atMsMeta = const VerificationMeta('atMs');
+  @override
+  late final GeneratedColumn<int> atMs = GeneratedColumn<int>(
+    'at_ms',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, atMs];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'bites';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Bite> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('at_ms')) {
+      context.handle(
+        _atMsMeta,
+        atMs.isAcceptableOrUnknown(data['at_ms']!, _atMsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_atMsMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Bite map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Bite(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      atMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}at_ms'],
+      )!,
+    );
+  }
+
+  @override
+  $BitesTable createAlias(String alias) {
+    return $BitesTable(attachedDatabase, alias);
+  }
+}
+
+class Bite extends DataClass implements Insertable<Bite> {
+  /// Insertion order is chronological (append-only), so the autoincrement id
+  /// doubles as a stable chronological key.
+  final int id;
+
+  /// Epoch milliseconds (a UTC instant), millisecond precision.
+  ///
+  /// Deliberately a plain [integer], not drift's `dateTime()`: the default
+  /// datetime mode stores unix *seconds* and would silently truncate the
+  /// millisecond precision the inter-bite deltas depend on. Integer epoch
+  /// millis keep deltas an exact subtraction and stay DST-safe (monotonic
+  /// across midnight and clock changes).
+  final int atMs;
+  const Bite({required this.id, required this.atMs});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['at_ms'] = Variable<int>(atMs);
+    return map;
+  }
+
+  BitesCompanion toCompanion(bool nullToAbsent) {
+    return BitesCompanion(id: Value(id), atMs: Value(atMs));
+  }
+
+  factory Bite.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Bite(
+      id: serializer.fromJson<int>(json['id']),
+      atMs: serializer.fromJson<int>(json['atMs']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'atMs': serializer.toJson<int>(atMs),
+    };
+  }
+
+  Bite copyWith({int? id, int? atMs}) =>
+      Bite(id: id ?? this.id, atMs: atMs ?? this.atMs);
+  Bite copyWithCompanion(BitesCompanion data) {
+    return Bite(
+      id: data.id.present ? data.id.value : this.id,
+      atMs: data.atMs.present ? data.atMs.value : this.atMs,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Bite(')
+          ..write('id: $id, ')
+          ..write('atMs: $atMs')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, atMs);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Bite && other.id == this.id && other.atMs == this.atMs);
+}
+
+class BitesCompanion extends UpdateCompanion<Bite> {
+  final Value<int> id;
+  final Value<int> atMs;
+  const BitesCompanion({
+    this.id = const Value.absent(),
+    this.atMs = const Value.absent(),
+  });
+  BitesCompanion.insert({this.id = const Value.absent(), required int atMs})
+    : atMs = Value(atMs);
+  static Insertable<Bite> custom({Expression<int>? id, Expression<int>? atMs}) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (atMs != null) 'at_ms': atMs,
+    });
+  }
+
+  BitesCompanion copyWith({Value<int>? id, Value<int>? atMs}) {
+    return BitesCompanion(id: id ?? this.id, atMs: atMs ?? this.atMs);
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (atMs.present) {
+      map['at_ms'] = Variable<int>(atMs.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BitesCompanion(')
+          ..write('id: $id, ')
+          ..write('atMs: $atMs')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$BiteDatabase extends GeneratedDatabase {
+  _$BiteDatabase(QueryExecutor e) : super(e);
+  $BiteDatabaseManager get managers => $BiteDatabaseManager(this);
+  late final $BitesTable bites = $BitesTable(this);
+  late final Index idxBitesAtMs = Index(
+    'idx_bites_at_ms',
+    'CREATE INDEX idx_bites_at_ms ON bites (at_ms)',
+  );
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [bites, idxBitesAtMs];
+}
+
+typedef $$BitesTableCreateCompanionBuilder =
+    BitesCompanion Function({Value<int> id, required int atMs});
+typedef $$BitesTableUpdateCompanionBuilder =
+    BitesCompanion Function({Value<int> id, Value<int> atMs});
+
+class $$BitesTableFilterComposer extends Composer<_$BiteDatabase, $BitesTable> {
+  $$BitesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get atMs => $composableBuilder(
+    column: $table.atMs,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$BitesTableOrderingComposer
+    extends Composer<_$BiteDatabase, $BitesTable> {
+  $$BitesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get atMs => $composableBuilder(
+    column: $table.atMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$BitesTableAnnotationComposer
+    extends Composer<_$BiteDatabase, $BitesTable> {
+  $$BitesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get atMs =>
+      $composableBuilder(column: $table.atMs, builder: (column) => column);
+}
+
+class $$BitesTableTableManager
+    extends
+        RootTableManager<
+          _$BiteDatabase,
+          $BitesTable,
+          Bite,
+          $$BitesTableFilterComposer,
+          $$BitesTableOrderingComposer,
+          $$BitesTableAnnotationComposer,
+          $$BitesTableCreateCompanionBuilder,
+          $$BitesTableUpdateCompanionBuilder,
+          (Bite, BaseReferences<_$BiteDatabase, $BitesTable, Bite>),
+          Bite,
+          PrefetchHooks Function()
+        > {
+  $$BitesTableTableManager(_$BiteDatabase db, $BitesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$BitesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BitesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BitesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> atMs = const Value.absent(),
+              }) => BitesCompanion(id: id, atMs: atMs),
+          createCompanionCallback:
+              ({Value<int> id = const Value.absent(), required int atMs}) =>
+                  BitesCompanion.insert(id: id, atMs: atMs),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$BitesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$BiteDatabase,
+      $BitesTable,
+      Bite,
+      $$BitesTableFilterComposer,
+      $$BitesTableOrderingComposer,
+      $$BitesTableAnnotationComposer,
+      $$BitesTableCreateCompanionBuilder,
+      $$BitesTableUpdateCompanionBuilder,
+      (Bite, BaseReferences<_$BiteDatabase, $BitesTable, Bite>),
+      Bite,
+      PrefetchHooks Function()
+    >;
+
+class $BiteDatabaseManager {
+  final _$BiteDatabase _db;
+  $BiteDatabaseManager(this._db);
+  $$BitesTableTableManager get bites =>
+      $$BitesTableTableManager(_db, _db.bites);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -193,6 +201,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.34.1"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.34.0"
+  drift_flutter:
+    dependency: "direct main"
+    description:
+      name: drift_flutter
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   equatable:
     dependency: transitive
     description:
@@ -608,6 +640,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -725,6 +765,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: f8f8ba7f9454f2761d4b416e030c4528ebc45e9290798d848f4dc08890c42a7c
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.7"
+  sqlite3_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlite3_flutter_libs
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0+eol"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   archive: ^4.0.7
   csv: ^6.0.0
+  drift: ^2.28.2
+  drift_flutter: ^0.3.1
   file_picker: ^10.3.10
   fl_chart: ^1.2.0
   flutter:
@@ -26,6 +28,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   hive_ce_generator: ^1.11.2
   build_runner: ^2.4.13
+  drift_dev: ^2.28.2
   flutter_launcher_icons: ^0.13.1
 
 flutter_icons:

--- a/test/features/bite/data/bite_database_test.dart
+++ b/test/features/bite/data/bite_database_test.dart
@@ -1,0 +1,54 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+
+/// Phase 1 verification: the Drift database opens and a bite row round-trips.
+void main() {
+  late BiteDatabase db;
+
+  setUp(() {
+    db = BiteDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('a bite row round-trips through the database', () async {
+    final atMs = DateTime(2026, 7, 13, 12, 30, 45, 123).millisecondsSinceEpoch;
+
+    final id = await db
+        .into(db.bites)
+        .insert(BitesCompanion.insert(atMs: atMs));
+
+    final rows = await db.select(db.bites).get();
+
+    expect(rows, hasLength(1));
+    expect(rows.single.id, id);
+    expect(rows.single.atMs, atMs);
+  });
+
+  test('at_ms preserves millisecond precision', () async {
+    // The whole point of storing epoch millis as a plain integer: no silent
+    // truncation to whole seconds.
+    final atMs = DateTime(2026, 7, 13, 0, 0, 0, 789).millisecondsSinceEpoch;
+    expect(atMs % 1000, 789);
+
+    await db.into(db.bites).insert(BitesCompanion.insert(atMs: atMs));
+
+    final stored = await db.select(db.bites).getSingle();
+    expect(stored.atMs, atMs);
+    expect(stored.atMs % 1000, 789);
+  });
+
+  test('ids autoincrement in chronological (insertion) order', () async {
+    final first = await db
+        .into(db.bites)
+        .insert(BitesCompanion.insert(atMs: 1000));
+    final second = await db
+        .into(db.bites)
+        .insert(BitesCompanion.insert(atMs: 2000));
+
+    expect(second, greaterThan(first));
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 — Drift setup + `bites` table** from `docs/bite_pacing_plan.md`. This introduces Drift alongside the existing Hive store for the new bite data. Scope is deliberately just the database and the append-only `bites` table — the pacing config, repository seam, logging UI, and CSV export/import arrive in later phases.

## Changes

- **Deps** — add `drift` + `drift_flutter` and dev `drift_dev`. `drift_flutter` is pinned to `^0.3.1` so its transitive `sqlite3` constraint reconciles with the analyzer pulled in by `hive_ce_generator`; the older `^0.2.x` line pins an incompatible sqlite3.
- **`BiteDatabase`** (`lib/features/bite/data/bite_database.dart`) — the Drift database with a production connection (`driftDatabase(name: 'bites')`) plus a `forTesting` constructor for injecting an in-memory executor.
- **`bites` table** — autoincrement `id` (insertion order == chronological, append-only) and an indexed `at_ms` stored as a plain `integer()` (epoch millis). Deliberately not drift's `dateTime()`, whose default mode stores unix *seconds* and would silently truncate the millisecond precision the inter-bite deltas depend on.
- **Codegen** — `bite_database.g.dart` regenerated via `build_runner` and checked in, per the repo's generated-file convention.
- **Tests** (`test/features/bite/data/bite_database_test.dart`) — DB opens and a row round-trips; `at_ms` retains millisecond precision; ids autoincrement in insertion order.

## Verification

- `flutter analyze` — no issues
- `flutter test` — all 56 tests pass (including the 3 new ones)

## Plan progress

Phase 1 checkboxes in `docs/bite_pacing_plan.md` are now ticked. Next up is Phase 2 (`pacing_config` table + default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCYgX68t7q7F3EXVMwanio)_