### PR TITLE
feat: add pacing_config table with default seed (bite-pacing Phase 2)

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -209,9 +209,9 @@ tooling swap, not a data migration.
 - [x] Run codegen; confirm the DB opens and a row round-trips
 
 **Phase 2 — `pacing_config` table + default**
-- [ ] Define `pacing_config`: `effective_ms`, `b1_s`, `b2_s`
-- [ ] Seed a default row on first run (`b1 = 15`, `b2 = 30`)
-- [ ] Add a helper to read the config effective at a given instant
+- [x] Define `pacing_config`: `effective_ms`, `b1_s`, `b2_s`
+- [x] Seed a default row on first run (`b1 = 15`, `b2 = 30`)
+- [x] Add a helper to read the config effective at a given instant
 
 **Phase 3 — `BiteRepository`**
 - [ ] Define the interface: `logBite`, `lastBite`, `bitesInRange`, `biteCount`, `setPacingConfig`

--- a/lib/features/bite/data/bite_database.dart
+++ b/lib/features/bite/data/bite_database.dart
@@ -24,7 +24,39 @@ class Bites extends Table {
   IntColumn get atMs => integer().named('at_ms')();
 }
 
-@DriftDatabase(tables: [Bites])
+/// Versioned pacing thresholds — a slowly-changing dimension.
+///
+/// A bite's pacing zone depends on the thresholds in effect *when it
+/// happened*, so retuning the thresholds later appends a new version rather
+/// than mutating an existing one. Every historical bite stays gradable against
+/// the version effective at its timestamp, so longitudinal comparisons don't
+/// get silently contaminated by a later retune.
+///
+/// Three fixed zones means exactly two boundaries, so two columns suffice and
+/// no separate boundaries table is needed.
+@DataClassName('PacingConfig')
+class PacingConfigs extends Table {
+  /// The table name follows the plan's schema (`pacing_config`); the drift
+  /// accessor stays `pacingConfigs` (derived from the Dart class name).
+  @override
+  String get tableName => 'pacing_config';
+
+  IntColumn get id => integer().autoIncrement()();
+
+  /// Epoch millis (a UTC instant): the moment this config version took effect.
+  IntColumn get effectiveMs => integer().named('effective_ms')();
+
+  /// End of the "too soon" zone, in seconds. `[0, b1)` is too soon.
+  IntColumn get b1S => integer().named('b1_s')();
+
+  /// Start of the "in the clear" zone, in seconds — the point at which biting
+  /// is recommended and the haptic fires. `[b1, b2)` is "ok — hold on",
+  /// `[b2, ∞)` is "in the clear". Derived boundary, stored so past bites stay
+  /// reconstructable.
+  IntColumn get b2S => integer().named('b2_s')();
+}
+
+@DriftDatabase(tables: [Bites, PacingConfigs])
 class BiteDatabase extends _$BiteDatabase {
   /// Production constructor: opens the on-disk `bites` database.
   BiteDatabase() : super(driftDatabase(name: 'bites'));
@@ -34,5 +66,50 @@ class BiteDatabase extends _$BiteDatabase {
   BiteDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) async {
+      await m.createAll();
+    },
+    onUpgrade: (m, from, to) async {
+      // v1 (Phase 1) shipped with only `bites`; v2 adds `pacing_config`.
+      if (from < 2) {
+        await m.createTable(pacingConfigs);
+      }
+    },
+    beforeOpen: (details) async {
+      await _seedDefaultPacingConfig();
+    },
+  );
+
+  /// The pacing config in effect at [instant]: the newest version whose
+  /// effective instant is at or before it.
+  ///
+  /// Returns null only when no config exists at all — which the default seed
+  /// prevents in practice, since it is effective from the epoch onward.
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) {
+    final atMs = instant.millisecondsSinceEpoch;
+    return (select(pacingConfigs)
+          ..where((c) => c.effectiveMs.isSmallerOrEqualValue(atMs))
+          ..orderBy([(c) => OrderingTerm.desc(c.effectiveMs)])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// Seeds the v1 starting thresholds (`b1 = 15 s`, `b2 = 30 s`) on first run.
+  ///
+  /// Effective from the epoch (`effective_ms = 0`) so that every bite — past or
+  /// present — resolves to it. Idempotent: a no-op once any config row exists,
+  /// so it never clobbers a user's retuned thresholds.
+  Future<void> _seedDefaultPacingConfig() async {
+    final existing = await (select(
+      pacingConfigs,
+    )..limit(1)).getSingleOrNull();
+    if (existing != null) return;
+    await into(pacingConfigs).insert(
+      PacingConfigsCompanion.insert(effectiveMs: 0, b1S: 15, b2S: 30),
+    );
+  }
 }

--- a/lib/features/bite/data/bite_database.g.dart
+++ b/lib/features/bite/data/bite_database.g.dart
@@ -194,6 +194,312 @@ class BitesCompanion extends UpdateCompanion<Bite> {
   }
 }
 
+class $PacingConfigsTable extends PacingConfigs
+    with TableInfo<$PacingConfigsTable, PacingConfig> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PacingConfigsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _effectiveMsMeta = const VerificationMeta(
+    'effectiveMs',
+  );
+  @override
+  late final GeneratedColumn<int> effectiveMs = GeneratedColumn<int>(
+    'effective_ms',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _b1SMeta = const VerificationMeta('b1S');
+  @override
+  late final GeneratedColumn<int> b1S = GeneratedColumn<int>(
+    'b1_s',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _b2SMeta = const VerificationMeta('b2S');
+  @override
+  late final GeneratedColumn<int> b2S = GeneratedColumn<int>(
+    'b2_s',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, effectiveMs, b1S, b2S];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pacing_config';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PacingConfig> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('effective_ms')) {
+      context.handle(
+        _effectiveMsMeta,
+        effectiveMs.isAcceptableOrUnknown(
+          data['effective_ms']!,
+          _effectiveMsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_effectiveMsMeta);
+    }
+    if (data.containsKey('b1_s')) {
+      context.handle(
+        _b1SMeta,
+        b1S.isAcceptableOrUnknown(data['b1_s']!, _b1SMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_b1SMeta);
+    }
+    if (data.containsKey('b2_s')) {
+      context.handle(
+        _b2SMeta,
+        b2S.isAcceptableOrUnknown(data['b2_s']!, _b2SMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_b2SMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PacingConfig map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PacingConfig(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      effectiveMs: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}effective_ms'],
+      )!,
+      b1S: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}b1_s'],
+      )!,
+      b2S: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}b2_s'],
+      )!,
+    );
+  }
+
+  @override
+  $PacingConfigsTable createAlias(String alias) {
+    return $PacingConfigsTable(attachedDatabase, alias);
+  }
+}
+
+class PacingConfig extends DataClass implements Insertable<PacingConfig> {
+  final int id;
+
+  /// Epoch millis (a UTC instant): the moment this config version took effect.
+  final int effectiveMs;
+
+  /// End of the "too soon" zone, in seconds. `[0, b1)` is too soon.
+  final int b1S;
+
+  /// Start of the "in the clear" zone, in seconds — the point at which biting
+  /// is recommended and the haptic fires. `[b1, b2)` is "ok — hold on",
+  /// `[b2, ∞)` is "in the clear". Derived boundary, stored so past bites stay
+  /// reconstructable.
+  final int b2S;
+  const PacingConfig({
+    required this.id,
+    required this.effectiveMs,
+    required this.b1S,
+    required this.b2S,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['effective_ms'] = Variable<int>(effectiveMs);
+    map['b1_s'] = Variable<int>(b1S);
+    map['b2_s'] = Variable<int>(b2S);
+    return map;
+  }
+
+  PacingConfigsCompanion toCompanion(bool nullToAbsent) {
+    return PacingConfigsCompanion(
+      id: Value(id),
+      effectiveMs: Value(effectiveMs),
+      b1S: Value(b1S),
+      b2S: Value(b2S),
+    );
+  }
+
+  factory PacingConfig.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PacingConfig(
+      id: serializer.fromJson<int>(json['id']),
+      effectiveMs: serializer.fromJson<int>(json['effectiveMs']),
+      b1S: serializer.fromJson<int>(json['b1S']),
+      b2S: serializer.fromJson<int>(json['b2S']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'effectiveMs': serializer.toJson<int>(effectiveMs),
+      'b1S': serializer.toJson<int>(b1S),
+      'b2S': serializer.toJson<int>(b2S),
+    };
+  }
+
+  PacingConfig copyWith({int? id, int? effectiveMs, int? b1S, int? b2S}) =>
+      PacingConfig(
+        id: id ?? this.id,
+        effectiveMs: effectiveMs ?? this.effectiveMs,
+        b1S: b1S ?? this.b1S,
+        b2S: b2S ?? this.b2S,
+      );
+  PacingConfig copyWithCompanion(PacingConfigsCompanion data) {
+    return PacingConfig(
+      id: data.id.present ? data.id.value : this.id,
+      effectiveMs: data.effectiveMs.present
+          ? data.effectiveMs.value
+          : this.effectiveMs,
+      b1S: data.b1S.present ? data.b1S.value : this.b1S,
+      b2S: data.b2S.present ? data.b2S.value : this.b2S,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PacingConfig(')
+          ..write('id: $id, ')
+          ..write('effectiveMs: $effectiveMs, ')
+          ..write('b1S: $b1S, ')
+          ..write('b2S: $b2S')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, effectiveMs, b1S, b2S);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PacingConfig &&
+          other.id == this.id &&
+          other.effectiveMs == this.effectiveMs &&
+          other.b1S == this.b1S &&
+          other.b2S == this.b2S);
+}
+
+class PacingConfigsCompanion extends UpdateCompanion<PacingConfig> {
+  final Value<int> id;
+  final Value<int> effectiveMs;
+  final Value<int> b1S;
+  final Value<int> b2S;
+  const PacingConfigsCompanion({
+    this.id = const Value.absent(),
+    this.effectiveMs = const Value.absent(),
+    this.b1S = const Value.absent(),
+    this.b2S = const Value.absent(),
+  });
+  PacingConfigsCompanion.insert({
+    this.id = const Value.absent(),
+    required int effectiveMs,
+    required int b1S,
+    required int b2S,
+  }) : effectiveMs = Value(effectiveMs),
+       b1S = Value(b1S),
+       b2S = Value(b2S);
+  static Insertable<PacingConfig> custom({
+    Expression<int>? id,
+    Expression<int>? effectiveMs,
+    Expression<int>? b1S,
+    Expression<int>? b2S,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (effectiveMs != null) 'effective_ms': effectiveMs,
+      if (b1S != null) 'b1_s': b1S,
+      if (b2S != null) 'b2_s': b2S,
+    });
+  }
+
+  PacingConfigsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? effectiveMs,
+    Value<int>? b1S,
+    Value<int>? b2S,
+  }) {
+    return PacingConfigsCompanion(
+      id: id ?? this.id,
+      effectiveMs: effectiveMs ?? this.effectiveMs,
+      b1S: b1S ?? this.b1S,
+      b2S: b2S ?? this.b2S,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (effectiveMs.present) {
+      map['effective_ms'] = Variable<int>(effectiveMs.value);
+    }
+    if (b1S.present) {
+      map['b1_s'] = Variable<int>(b1S.value);
+    }
+    if (b2S.present) {
+      map['b2_s'] = Variable<int>(b2S.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PacingConfigsCompanion(')
+          ..write('id: $id, ')
+          ..write('effectiveMs: $effectiveMs, ')
+          ..write('b1S: $b1S, ')
+          ..write('b2S: $b2S')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$BiteDatabase extends GeneratedDatabase {
   _$BiteDatabase(QueryExecutor e) : super(e);
   $BiteDatabaseManager get managers => $BiteDatabaseManager(this);
@@ -202,11 +508,16 @@ abstract class _$BiteDatabase extends GeneratedDatabase {
     'idx_bites_at_ms',
     'CREATE INDEX idx_bites_at_ms ON bites (at_ms)',
   );
+  late final $PacingConfigsTable pacingConfigs = $PacingConfigsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [bites, idxBitesAtMs];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    bites,
+    idxBitesAtMs,
+    pacingConfigs,
+  ];
 }
 
 typedef $$BitesTableCreateCompanionBuilder =
@@ -326,9 +637,193 @@ typedef $$BitesTableProcessedTableManager =
       PrefetchHooks Function()
     >;
 
+typedef $$PacingConfigsTableCreateCompanionBuilder =
+    PacingConfigsCompanion Function({
+      Value<int> id,
+      required int effectiveMs,
+      required int b1S,
+      required int b2S,
+    });
+typedef $$PacingConfigsTableUpdateCompanionBuilder =
+    PacingConfigsCompanion Function({
+      Value<int> id,
+      Value<int> effectiveMs,
+      Value<int> b1S,
+      Value<int> b2S,
+    });
+
+class $$PacingConfigsTableFilterComposer
+    extends Composer<_$BiteDatabase, $PacingConfigsTable> {
+  $$PacingConfigsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get effectiveMs => $composableBuilder(
+    column: $table.effectiveMs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get b1S => $composableBuilder(
+    column: $table.b1S,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get b2S => $composableBuilder(
+    column: $table.b2S,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PacingConfigsTableOrderingComposer
+    extends Composer<_$BiteDatabase, $PacingConfigsTable> {
+  $$PacingConfigsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get effectiveMs => $composableBuilder(
+    column: $table.effectiveMs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get b1S => $composableBuilder(
+    column: $table.b1S,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get b2S => $composableBuilder(
+    column: $table.b2S,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PacingConfigsTableAnnotationComposer
+    extends Composer<_$BiteDatabase, $PacingConfigsTable> {
+  $$PacingConfigsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get effectiveMs => $composableBuilder(
+    column: $table.effectiveMs,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get b1S =>
+      $composableBuilder(column: $table.b1S, builder: (column) => column);
+
+  GeneratedColumn<int> get b2S =>
+      $composableBuilder(column: $table.b2S, builder: (column) => column);
+}
+
+class $$PacingConfigsTableTableManager
+    extends
+        RootTableManager<
+          _$BiteDatabase,
+          $PacingConfigsTable,
+          PacingConfig,
+          $$PacingConfigsTableFilterComposer,
+          $$PacingConfigsTableOrderingComposer,
+          $$PacingConfigsTableAnnotationComposer,
+          $$PacingConfigsTableCreateCompanionBuilder,
+          $$PacingConfigsTableUpdateCompanionBuilder,
+          (
+            PacingConfig,
+            BaseReferences<
+              _$BiteDatabase,
+              $PacingConfigsTable,
+              PacingConfig
+            >,
+          ),
+          PacingConfig,
+          PrefetchHooks Function()
+        > {
+  $$PacingConfigsTableTableManager(_$BiteDatabase db, $PacingConfigsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PacingConfigsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PacingConfigsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PacingConfigsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> effectiveMs = const Value.absent(),
+                Value<int> b1S = const Value.absent(),
+                Value<int> b2S = const Value.absent(),
+              }) => PacingConfigsCompanion(
+                id: id,
+                effectiveMs: effectiveMs,
+                b1S: b1S,
+                b2S: b2S,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int effectiveMs,
+                required int b1S,
+                required int b2S,
+              }) => PacingConfigsCompanion.insert(
+                id: id,
+                effectiveMs: effectiveMs,
+                b1S: b1S,
+                b2S: b2S,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PacingConfigsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$BiteDatabase,
+      $PacingConfigsTable,
+      PacingConfig,
+      $$PacingConfigsTableFilterComposer,
+      $$PacingConfigsTableOrderingComposer,
+      $$PacingConfigsTableAnnotationComposer,
+      $$PacingConfigsTableCreateCompanionBuilder,
+      $$PacingConfigsTableUpdateCompanionBuilder,
+      (
+        PacingConfig,
+        BaseReferences<_$BiteDatabase, $PacingConfigsTable, PacingConfig>,
+      ),
+      PacingConfig,
+      PrefetchHooks Function()
+    >;
+
 class $BiteDatabaseManager {
   final _$BiteDatabase _db;
   $BiteDatabaseManager(this._db);
   $$BitesTableTableManager get bites =>
       $$BitesTableTableManager(_db, _db.bites);
+  $$PacingConfigsTableTableManager get pacingConfigs =>
+      $$PacingConfigsTableTableManager(_db, _db.pacingConfigs);
 }

--- a/test/features/bite/data/bite_database_test.dart
+++ b/test/features/bite/data/bite_database_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 
 /// Phase 1 verification: the Drift database opens and a bite row round-trips.
+/// Phase 2 verification: `pacing_config` seeds a default and resolves by instant.
 void main() {
   late BiteDatabase db;
 
@@ -50,5 +51,72 @@ void main() {
         .insert(BitesCompanion.insert(atMs: 2000));
 
     expect(second, greaterThan(first));
+  });
+
+  group('pacing_config', () {
+    test('a default row is seeded on first run (b1 = 15, b2 = 30)', () async {
+      final configs = await db.select(db.pacingConfigs).get();
+
+      expect(configs, hasLength(1));
+      expect(configs.single.b1S, 15);
+      expect(configs.single.b2S, 30);
+      // Effective from the epoch so every bite resolves to it.
+      expect(configs.single.effectiveMs, 0);
+    });
+
+    test('seeding is idempotent — no duplicate default rows', () async {
+      // The database is already open (seeded) from setUp; touching it again
+      // must not append a second default.
+      await db.select(db.pacingConfigs).get();
+      final configs = await db.select(db.pacingConfigs).get();
+
+      expect(configs, hasLength(1));
+    });
+
+    test('pacingConfigAt returns the default for any real instant', () async {
+      final cfg = await db.pacingConfigAt(DateTime(2026, 7, 13));
+
+      expect(cfg, isNotNull);
+      expect(cfg!.b1S, 15);
+      expect(cfg.b2S, 30);
+    });
+
+    test('pacingConfigAt returns the newest version at or before the '
+        'instant', () async {
+      // A retune that takes effect mid-2026.
+      final retuneMs = DateTime(2026, 7, 1).millisecondsSinceEpoch;
+      await db
+          .into(db.pacingConfigs)
+          .insert(
+            PacingConfigsCompanion.insert(
+              effectiveMs: retuneMs,
+              b1S: 10,
+              b2S: 20,
+            ),
+          );
+
+      // Just before the retune: still the default (effective from the epoch).
+      final before = await db.pacingConfigAt(DateTime(2026, 6, 30));
+      expect(before!.b1S, 15);
+      expect(before.b2S, 30);
+
+      // Exactly at the retune instant and after: the new version.
+      final atRetune = await db.pacingConfigAt(DateTime(2026, 7, 1));
+      expect(atRetune!.b1S, 10);
+      expect(atRetune.b2S, 20);
+
+      final after = await db.pacingConfigAt(DateTime(2026, 8, 1));
+      expect(after!.b1S, 10);
+      expect(after.b2S, 20);
+    });
+
+    test('pacingConfigAt returns null before the earliest config', () async {
+      // Nothing is effective before the epoch-anchored default.
+      final beforeEpoch = await db.pacingConfigAt(
+        DateTime.fromMillisecondsSinceEpoch(-1),
+      );
+
+      expect(beforeEpoch, isNull);
+    });
   });
 }


### PR DESCRIPTION
Implements **Phase 2 — `pacing_config` table + default** from `docs/bite_pacing_plan.md`. Phases 0 and 1 were already complete; this adds the versioned pacing thresholds alongside the Phase 1 bite log.

## What changed

- **New `pacing_config` Drift table** (`effective_ms`, `b1_s`, `b2_s`) — a slowly-changing dimension so retuning thresholds later never silently re-grades past bites.
- **Schema bumped to v2** with a `MigrationStrategy`: `onUpgrade` creates the table for existing v1 (Phase 1) installs; `onCreate` builds everything on fresh installs.
- **Default seed on first run** (`b1 = 15 s`, `b2 = 30 s`) via idempotent `beforeOpen`, effective from the epoch (`effective_ms = 0`) so every bite — past or present — resolves to it, and re-seeding never clobbers a user's retune.
- **`pacingConfigAt(instant)` helper** — resolves the newest config version effective at or before a given instant, so a bite's zone is always graded against the thresholds in force when it happened.
- Regenerated `bite_database.g.dart` for the new table (data class, companion, table managers, registration).
- Tests covering: default seeded once, idempotency, `pacingConfigAt` resolving the default, resolving the newest version at/before an instant (with a retune), and null before the earliest config.

## Notes for review

The `.g.dart` was hand-written to mirror the existing generated `Bites` code, because this environment has no Dart/Flutter toolchain to run `build_runner`. It should match codegen output, but worth regenerating locally to confirm no formatting deltas:

```
dart run build_runner build --delete-conflicting-outputs
flutter analyze && flutter test
```

CI (`flutter_ci.yml`) also gates analyze + test on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017aKf8GYPYZBQtNkXL1hRUB)_