### PR TITLE
feat: add BiteRepository seam over Drift (bite-pacing Phase 3)

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -214,9 +214,9 @@ tooling swap, not a data migration.
 - [x] Add a helper to read the config effective at a given instant
 
 **Phase 3 — `BiteRepository`**
-- [ ] Define the interface: `logBite`, `lastBite`, `bitesInRange`, `biteCount`, `setPacingConfig`
-- [ ] Implement it against Drift
-- [ ] Expose it through `provider`
+- [x] Define the interface: `logBite`, `lastBite`, `bitesInRange`, `biteCount`, `setPacingConfig`
+- [x] Implement it against Drift
+- [x] Expose it through `provider`
 
 **Phase 4 — Bite logging screen (the main screen)**
 - [ ] Tap button → `logBite(DateTime.now())`, recorded immediately, never blocked

--- a/lib/features/bite/data/bite_repository.dart
+++ b/lib/features/bite/data/bite_repository.dart
@@ -1,0 +1,45 @@
+import 'package:food_locker/features/bite/data/bite_database.dart';
+
+/// The seam in front of the bite dataset (§1b of the pacing plan).
+///
+/// The rest of the app depends on this interface, never on the engine backing
+/// it — today Drift/SQLite, but that choice stays an implementation detail. It
+/// is the single place the two-store tax (§1c) gets coordinated, and it keeps
+/// the bite store independently testable.
+///
+/// The [Bite] and [PacingConfig] data classes it trades in are plain,
+/// engine-agnostic value types (drift's generated data classes for this
+/// greenfield feature carry no query machinery), so exposing them here doesn't
+/// leak the engine.
+abstract interface class BiteRepository {
+  /// Records a single bite at [at]. One tap = one bite; never blocked
+  /// (§3a) — the timestamp is persisted immediately.
+  Future<void> logBite(DateTime at);
+
+  /// The most recent bite, or null if none has been logged.
+  ///
+  /// The reference point for the pacing ticker: the live view seeds itself from
+  /// this once per session and derives every zone from `now − lastBite` in
+  /// memory thereafter (§3b).
+  Future<Bite?> lastBite();
+
+  /// Every bite whose timestamp falls in the half-open window `[from, to)`,
+  /// in chronological order.
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to);
+
+  /// The number of bites in the half-open window `[from, to)` — the headline
+  /// metric (§3c). Callers pass a local day's bounds for "today's count".
+  Future<int> biteCount(DateTime from, DateTime to);
+
+  /// Appends [cfg] as a new pacing-config version (a config-change marker).
+  ///
+  /// Thresholds are a slowly-changing dimension (§2b): retuning appends rather
+  /// than mutates, so every past bite stays gradable against the version
+  /// effective at its own timestamp. The version takes effect from
+  /// [PacingConfig.effectiveMs]; its [PacingConfig.id] is assigned by the store.
+  Future<void> setPacingConfig(PacingConfig cfg);
+
+  /// The pacing config in effect at [instant]: the newest version whose
+  /// effective instant is at or before it, or null if none precedes it.
+  Future<PacingConfig?> pacingConfigAt(DateTime instant);
+}

--- a/lib/features/bite/data/drift_bite_repository.dart
+++ b/lib/features/bite/data/drift_bite_repository.dart
@@ -1,0 +1,79 @@
+import 'package:drift/drift.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+
+/// Drift/SQLite-backed [BiteRepository].
+///
+/// Every range in this store is a half-open `[from, to)` window over `at_ms`
+/// (epoch millis), which is what the plan's day-granular counts expect: a
+/// local day is `[startOfDay, startOfNextDay)`, so consecutive days never
+/// double-count the boundary instant.
+class DriftBiteRepository implements BiteRepository {
+  DriftBiteRepository(this._db);
+
+  final BiteDatabase _db;
+
+  @override
+  Future<void> logBite(DateTime at) async {
+    await _db
+        .into(_db.bites)
+        .insert(BitesCompanion.insert(atMs: at.millisecondsSinceEpoch));
+  }
+
+  @override
+  Future<Bite?> lastBite() {
+    // Insertion order is chronological (append-only), so the largest id is the
+    // most recent bite — no need to sort on at_ms.
+    return (_db.select(_db.bites)
+          ..orderBy([(b) => OrderingTerm.desc(b.id)])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) {
+    final fromMs = from.millisecondsSinceEpoch;
+    final toMs = to.millisecondsSinceEpoch;
+    return (_db.select(_db.bites)
+          ..where(
+            (b) =>
+                b.atMs.isBiggerOrEqualValue(fromMs) &
+                b.atMs.isSmallerThanValue(toMs),
+          )
+          ..orderBy([(b) => OrderingTerm.asc(b.atMs)]))
+        .get();
+  }
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) async {
+    final fromMs = from.millisecondsSinceEpoch;
+    final toMs = to.millisecondsSinceEpoch;
+    final count = _db.bites.id.count();
+    final query = _db.selectOnly(_db.bites)
+      ..addColumns([count])
+      ..where(
+        _db.bites.atMs.isBiggerOrEqualValue(fromMs) &
+            _db.bites.atMs.isSmallerThanValue(toMs),
+      );
+    final row = await query.getSingle();
+    return row.read(count) ?? 0;
+  }
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async {
+    await _db
+        .into(_db.pacingConfigs)
+        .insert(
+          PacingConfigsCompanion.insert(
+            effectiveMs: cfg.effectiveMs,
+            b1S: cfg.b1S,
+            b2S: cfg.b2S,
+          ),
+        );
+  }
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) {
+    return _db.pacingConfigAt(instant);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
@@ -21,10 +24,13 @@ void main() async {
   final weightManager = WeightManager(weightRepository);
   await weightManager.initialize();
 
+  final biteRepository = DriftBiteRepository(BiteDatabase());
+
   runApp(
     MultiProvider(
       providers: [
         Provider<WeightRepository>.value(value: weightRepository),
+        Provider<BiteRepository>.value(value: biteRepository),
         Provider<SerializationService>(create: (_) => SerializationService()),
         ChangeNotifierProvider<WeightManager>.value(value: weightManager),
       ],

--- a/test/features/bite/data/drift_bite_repository_test.dart
+++ b/test/features/bite/data/drift_bite_repository_test.dart
@@ -1,0 +1,188 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+
+/// Phase 3 verification: the [BiteRepository] seam over Drift. An in-memory
+/// drift database stands in for the on-disk store, so the seam is exercised
+/// without touching the filesystem.
+void main() {
+  late BiteDatabase db;
+  late BiteRepository repo;
+
+  setUp(() {
+    db = BiteDatabase.forTesting(NativeDatabase.memory());
+    repo = DriftBiteRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('logBite', () {
+    test('records the bite at millisecond precision', () async {
+      final at = DateTime(2026, 7, 13, 12, 30, 45, 789);
+
+      await repo.logBite(at);
+
+      final rows = await db.select(db.bites).get();
+      expect(rows, hasLength(1));
+      expect(rows.single.atMs, at.millisecondsSinceEpoch);
+      expect(rows.single.atMs % 1000, 789);
+    });
+
+    test('appends — each tap is its own row', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 30));
+
+      final rows = await db.select(db.bites).get();
+      expect(rows, hasLength(2));
+    });
+  });
+
+  group('lastBite', () {
+    test('is null when nothing has been logged', () async {
+      expect(await repo.lastBite(), isNull);
+    });
+
+    test('returns the most recently logged bite', () async {
+      final earlier = DateTime(2026, 7, 13, 12, 0, 0);
+      final later = DateTime(2026, 7, 13, 12, 0, 30);
+
+      await repo.logBite(earlier);
+      await repo.logBite(later);
+
+      final last = await repo.lastBite();
+      expect(last, isNotNull);
+      expect(last!.atMs, later.millisecondsSinceEpoch);
+    });
+
+    test('tracks insertion order even when a later tap has an earlier '
+        'timestamp', () async {
+      // Insertion order — not at_ms — defines "last": a bite logged now is the
+      // reference point even if its clock reading trails a prior one.
+      final wallClock = DateTime(2026, 7, 13, 12, 0, 30);
+      final rewound = DateTime(2026, 7, 13, 12, 0, 0);
+
+      await repo.logBite(wallClock);
+      await repo.logBite(rewound);
+
+      final last = await repo.lastBite();
+      expect(last!.atMs, rewound.millisecondsSinceEpoch);
+    });
+  });
+
+  group('bitesInRange', () {
+    test('includes from, excludes to (half-open window)', () async {
+      final from = DateTime(2026, 7, 13, 12, 0, 0);
+      final to = DateTime(2026, 7, 13, 13, 0, 0);
+
+      await repo.logBite(from); // on the lower bound — included
+      await repo.logBite(DateTime(2026, 7, 13, 12, 30, 0)); // inside
+      await repo.logBite(to); // on the upper bound — excluded
+      await repo.logBite(DateTime(2026, 7, 13, 11, 59, 59)); // before
+
+      final inRange = await repo.bitesInRange(from, to);
+
+      expect(inRange, hasLength(2));
+      expect(
+        inRange.map((b) => b.atMs),
+        [from.millisecondsSinceEpoch, DateTime(2026, 7, 13, 12, 30, 0).millisecondsSinceEpoch],
+      );
+    });
+
+    test('returns bites in chronological order', () async {
+      final from = DateTime(2026, 7, 13, 0, 0, 0);
+      final to = DateTime(2026, 7, 14, 0, 0, 0);
+
+      // Logged out of order; the query orders by at_ms.
+      await repo.logBite(DateTime(2026, 7, 13, 15, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 9, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 0));
+
+      final inRange = await repo.bitesInRange(from, to);
+
+      expect(inRange.map((b) => b.atMs), [
+        DateTime(2026, 7, 13, 9, 0, 0).millisecondsSinceEpoch,
+        DateTime(2026, 7, 13, 12, 0, 0).millisecondsSinceEpoch,
+        DateTime(2026, 7, 13, 15, 0, 0).millisecondsSinceEpoch,
+      ]);
+    });
+
+    test('is empty when no bite falls in the window', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 0));
+
+      final inRange = await repo.bitesInRange(
+        DateTime(2026, 7, 14, 0, 0, 0),
+        DateTime(2026, 7, 15, 0, 0, 0),
+      );
+
+      expect(inRange, isEmpty);
+    });
+  });
+
+  group('biteCount', () {
+    test('counts only bites in the half-open window', () async {
+      final dayStart = DateTime(2026, 7, 13);
+      final nextDayStart = DateTime(2026, 7, 14);
+
+      await repo.logBite(dayStart); // lower bound — counted
+      await repo.logBite(DateTime(2026, 7, 13, 20, 0, 0)); // counted
+      await repo.logBite(nextDayStart); // upper bound — not counted
+      await repo.logBite(DateTime(2026, 7, 12, 23, 59, 59)); // day before
+
+      expect(await repo.biteCount(dayStart, nextDayStart), 2);
+    });
+
+    test('is zero for an empty window', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 0));
+
+      expect(
+        await repo.biteCount(
+          DateTime(2026, 7, 14),
+          DateTime(2026, 7, 15),
+        ),
+        0,
+      );
+    });
+  });
+
+  group('pacing config', () {
+    test('pacingConfigAt resolves the seeded default', () async {
+      final cfg = await repo.pacingConfigAt(DateTime(2026, 7, 13));
+
+      expect(cfg, isNotNull);
+      expect(cfg!.b1S, 15);
+      expect(cfg.b2S, 30);
+    });
+
+    test('setPacingConfig appends a new version without regrading the '
+        'past', () async {
+      final retuneAt = DateTime(2026, 7, 1);
+      await repo.setPacingConfig(
+        PacingConfig(
+          // id is assigned by the store; the value here is ignored on insert.
+          id: 0,
+          effectiveMs: retuneAt.millisecondsSinceEpoch,
+          b1S: 10,
+          b2S: 20,
+        ),
+      );
+
+      // Before the retune: still the epoch-anchored default.
+      final before = await repo.pacingConfigAt(DateTime(2026, 6, 30));
+      expect(before!.b1S, 15);
+      expect(before.b2S, 30);
+
+      // At and after: the appended version.
+      final after = await repo.pacingConfigAt(retuneAt);
+      expect(after!.b1S, 10);
+      expect(after.b2S, 20);
+
+      // The default row is preserved, not overwritten.
+      final all = await db.select(db.pacingConfigs).get();
+      expect(all, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Phase 3** of the bite-pacing plan (`docs/bite_pacing_plan.md`): the `BiteRepository` seam (§1b) in front of the bite dataset, so the rest of the app depends on an interface rather than the Drift engine.

## Changes

- **`lib/features/bite/data/bite_repository.dart`** — the `BiteRepository` interface: `logBite`, `lastBite`, `bitesInRange`, `biteCount`, `setPacingConfig`, plus `pacingConfigAt` (the read half of the config capability, needed by the Phase 5 pacing view, kept behind the seam so consumers never touch `BiteDatabase` directly).
- **`lib/features/bite/data/drift_bite_repository.dart`** — Drift-backed implementation:
  - All ranges are half-open `[from, to)` windows over `at_ms`, so day-granular counts don't double-count the boundary instant.
  - `lastBite()` uses insertion order (append-only `id`), so a just-logged bite is the ticker's reference even if its clock reading trails a prior one.
  - `setPacingConfig` **appends** a new config version rather than mutating, preserving past-bite gradability (§2b).
  - `biteCount` uses a SQL `COUNT` aggregate rather than loading rows.
- **`lib/main.dart`** — exposes it as `Provider<BiteRepository>` alongside the existing weight providers.
- **`test/features/bite/data/drift_bite_repository_test.dart`** — exercises the seam through an in-memory Drift database (half-open boundaries, chronological ordering, insertion-order `lastBite`, append-not-regrade config).
- **`docs/bite_pacing_plan.md`** — checks off the Phase 3 tasks.

## Testing

`flutter analyze` / `flutter test` were not runnable in the authoring environment (no Flutter SDK); validation runs via the `flutter_ci.yml` workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAdqg8mTXYzJ48XyZHUcry)_