### PR TITLE
feat: add bite logging screen with today's count (bite-pacing Phase 4)

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -219,8 +219,8 @@ tooling swap, not a data migration.
 - [x] Expose it through `provider`
 
 **Phase 4 — Bite logging screen (the main screen)**
-- [ ] Tap button → `logBite(DateTime.now())`, recorded immediately, never blocked
-- [ ] Today's count (`biteCount` for the current local day), re-queried after each tap
+- [x] Tap button → `logBite(DateTime.now())`, recorded immediately, never blocked
+- [x] Today's count (`biteCount` for the current local day), re-queried after each tap
 
 **Phase 5 — Pacing visualization (on the same screen as the tap button)**
 - [ ] Local ticker (`Timer.periodic`, ~200–500 ms), started on tap, reading last-bite time from memory

--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+
+/// UI-facing state holder for the bite-logging screen (Phase 4).
+///
+/// Owns the running bite count for the current local day in memory and, after
+/// every tap, writes through the [BiteRepository] then re-reads the count so the
+/// surfaced number stays consistent with the store — mirroring the weight
+/// feature's write-through-then-refresh pattern.
+///
+/// Bite count is the headline metric (§0): [logBite] never blocks (§3a) and the
+/// count re-queries after each tap (§4, Phase 4).
+class BiteManager extends ChangeNotifier {
+  BiteManager(this._repository);
+
+  final BiteRepository _repository;
+
+  int _todayCount = 0;
+
+  /// Bites logged so far during the current local day — the headline metric
+  /// (§3c). Zero until [initialize] (or a [logBite]) has run.
+  int get todayCount => _todayCount;
+
+  /// Loads today's count from the store so the screen opens with the right
+  /// number even after an app restart.
+  Future<void> initialize() async {
+    await _refreshTodayCount();
+  }
+
+  /// Records one bite at the current instant — one tap = one bite, persisted
+  /// immediately and never blocked (§3a) — then refreshes today's count.
+  Future<void> logBite() async {
+    await _repository.logBite(DateTime.now());
+    await _refreshTodayCount();
+  }
+
+  Future<void> _refreshTodayCount() async {
+    final now = DateTime.now();
+    // Local-day bounds as a half-open window `[startOfDay, startOfNextDay)`.
+    // Building the next day via the DateTime constructor (day + 1) normalizes
+    // month/year rollovers and lands on local midnight — DST-correct, unlike
+    // adding a fixed 24-hour Duration.
+    final startOfDay = DateTime(now.year, now.month, now.day);
+    final startOfNextDay = DateTime(now.year, now.month, now.day + 1);
+    _todayCount = await _repository.biteCount(startOfDay, startOfNextDay);
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
@@ -26,6 +27,9 @@ void main() async {
 
   final biteRepository = DriftBiteRepository(BiteDatabase());
 
+  final biteManager = BiteManager(biteRepository);
+  await biteManager.initialize();
+
   runApp(
     MultiProvider(
       providers: [
@@ -33,6 +37,7 @@ void main() async {
         Provider<BiteRepository>.value(value: biteRepository),
         Provider<SerializationService>(create: (_) => SerializationService()),
         ChangeNotifierProvider<WeightManager>.value(value: weightManager),
+        ChangeNotifierProvider<BiteManager>.value(value: biteManager),
       ],
       child: const MainApp(),
     ),

--- a/lib/ui/app_shell.dart
+++ b/lib/ui/app_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/ui/pages/bite_page.dart';
 import 'package:food_locker/ui/pages/home_page.dart';
 import 'package:food_locker/ui/pages/settings_page.dart';
 import 'package:food_locker/ui/pages/weight_page.dart';
@@ -14,12 +15,13 @@ class _AppShellState extends State<AppShell> {
   int _currentIndex = 0;
 
   static const List<Widget> _pages = [
+    BitePage(),
     HomePage(),
     WeightPage(),
     SettingsPage(),
   ];
 
-  static const List<String> _titles = ['Home', 'Weight', 'Settings'];
+  static const List<String> _titles = ['Bite', 'Home', 'Weight', 'Settings'];
 
   void _onTabTapped(int index) {
     setState(() {
@@ -33,9 +35,15 @@ class _AppShellState extends State<AppShell> {
       appBar: AppBar(title: Text(_titles[_currentIndex])),
       body: IndexedStack(index: _currentIndex, children: _pages),
       bottomNavigationBar: BottomNavigationBar(
+        type: BottomNavigationBarType.fixed,
         currentIndex: _currentIndex,
         onTap: _onTabTapped,
         items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.restaurant_outlined),
+            activeIcon: Icon(Icons.restaurant_rounded),
+            label: 'Bite',
+          ),
           BottomNavigationBarItem(
             icon: Icon(Icons.home_outlined),
             activeIcon: Icon(Icons.home_rounded),

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:provider/provider.dart';
+
+/// The main bite-logging screen (Phase 4).
+///
+/// One big tap = one bite, recorded immediately and never blocked (§3a); the
+/// day's running count — the headline metric — sits above the button and
+/// re-queries after every tap. Pacing visualization (Phase 5) lands on this
+/// same screen.
+class BitePage extends StatelessWidget {
+  const BitePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final biteManager = context.watch<BiteManager>();
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            children: [
+              const Spacer(),
+              Text(
+                "Today's Bites",
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 0.5,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '${biteManager.todayCount}',
+                style: theme.textTheme.displayLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+              const Spacer(),
+              _BiteButton(onTap: biteManager.logBite),
+              const Spacer(),
+              Text(
+                'Tap for each bite',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The large circular tap target — the primary action of the whole screen.
+class _BiteButton extends StatelessWidget {
+  const _BiteButton({required this.onTap});
+
+  final Future<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Semantics(
+      button: true,
+      label: 'Log a bite',
+      child: Material(
+        color: theme.colorScheme.primary,
+        shape: const CircleBorder(),
+        elevation: 4,
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const CircleBorder(),
+          child: SizedBox(
+            width: 220,
+            height: 220,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.restaurant_rounded,
+                  size: 72,
+                  color: theme.colorScheme.onPrimary,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Bite',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: theme.colorScheme.onPrimary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/bite/data/bite_manager_test.dart
+++ b/test/features/bite/data/bite_manager_test.dart
@@ -1,0 +1,63 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+
+/// Phase 4 verification: [BiteManager] logs bites through the repository and
+/// keeps today's count consistent with the store. An in-memory drift database
+/// stands in for the on-disk store, matching the repository tests.
+void main() {
+  late BiteDatabase db;
+  late DriftBiteRepository repo;
+  late BiteManager manager;
+
+  setUp(() {
+    db = BiteDatabase.forTesting(NativeDatabase.memory());
+    repo = DriftBiteRepository(db);
+    manager = BiteManager(repo);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('todayCount starts at zero', () {
+    expect(manager.todayCount, 0);
+  });
+
+  test('initialize loads today\'s existing count from the store', () async {
+    // Two bites logged today, one logged yesterday — only today's should count.
+    final now = DateTime.now();
+    await repo.logBite(now);
+    await repo.logBite(now);
+    await repo.logBite(now.subtract(const Duration(days: 1)));
+
+    await manager.initialize();
+
+    expect(manager.todayCount, 2);
+  });
+
+  test('logBite records a bite and increments today\'s count', () async {
+    await manager.initialize();
+    expect(manager.todayCount, 0);
+
+    await manager.logBite();
+    expect(manager.todayCount, 1);
+
+    await manager.logBite();
+    expect(manager.todayCount, 2);
+
+    // The taps are persisted, not just counted in memory.
+    expect(await repo.lastBite(), isNotNull);
+  });
+
+  test('logBite notifies listeners', () async {
+    var notifications = 0;
+    manager.addListener(() => notifications++);
+
+    await manager.logBite();
+
+    expect(notifications, greaterThan(0));
+  });
+}


### PR DESCRIPTION
## Summary

Implements **Phase 4 — Bite logging screen (the main screen)** from `docs/bite_pacing_plan.md`, the next unchecked phase after the completed Phases 0–3 (Hive CE migration, Drift setup, `pacing_config`, and the `BiteRepository` seam).

This adds the main bite-logging screen: a big tap target that records a bite immediately, with today's count surfaced above it.

## Changes

- **`BiteManager`** (`lib/features/bite/data/bite_manager.dart`) — a `ChangeNotifier` that owns the current local day's bite count in memory. On each tap it writes through the `BiteRepository` at `DateTime.now()`, then re-reads the count so the surfaced number stays consistent with the store — mirroring the weight feature's write-through-then-refresh pattern. Day bounds use a half-open `[startOfDay, startOfNextDay)` window built via the `DateTime` constructor so month/DST rollovers stay correct.
- **`BitePage`** (`lib/ui/pages/bite_page.dart`) — one large circular tap target logs a bite immediately and never blocks (one tap = one bite); today's count sits above it and re-queries after every tap.
- **Wiring** — `BiteManager` provided via `ChangeNotifierProvider` in `main.dart` (initialized before `runApp`); a new **"Bite"** tab added as the app's landing tab in `AppShell` (nav bar switched to `fixed` type now that there are four tabs).
- **Plan** — checked off the Phase 4 boxes in `docs/bite_pacing_plan.md`.

Pacing visualization (Phase 5) lands on this same screen.

## Testing

- `flutter analyze` → no issues found
- `flutter test` → all 77 tests pass, including a new `test/features/bite/data/bite_manager_test.dart` covering initial state, loading an existing count on init, increment-on-tap with persistence, and listener notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqkBbV5RZqAD2JcKc4sJEr)_