### PR TITLE
feat: add pacing visualization to bite screen (bite-pacing Phase 5)

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -223,10 +223,10 @@ tooling swap, not a data migration.
 - [x] Today's count (`biteCount` for the current local day), re-queried after each tap
 
 **Phase 5 — Pacing visualization (on the same screen as the tap button)**
-- [ ] Local ticker (`Timer.periodic`, ~200–500 ms), started on tap, reading last-bite time from memory
-- [ ] Current zone from `now − lastBite` against `b1`/`b2`; colours + messages as app constants (too soon/red, hold on/amber, clear/green)
-- [ ] On reaching `b2`: haptic, freeze on the static "in the clear" state, cancel the ticker
-- [ ] Next tap resets the reference and restarts the ticker; on open with no recent bite, show the static clear state (no ticker)
+- [x] Local ticker (`Timer.periodic`, ~200–500 ms), started on tap, reading last-bite time from memory
+- [x] Current zone from `now − lastBite` against `b1`/`b2`; colours + messages as app constants (too soon/red, hold on/amber, clear/green)
+- [x] On reaching `b2`: haptic, freeze on the static "in the clear" state, cancel the ticker
+- [x] Next tap resets the reference and restarts the ticker; on open with no recent bite, show the static clear state (no ticker)
 
 **Phase 6 — CSV export**
 - [ ] Extend the existing CSV export to include the bite data

--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -1,19 +1,48 @@
-import 'package:flutter/foundation.dart';
-import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'dart:async';
 
-/// UI-facing state holder for the bite-logging screen (Phase 4).
+import 'package:clock/clock.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/pacing_zone.dart';
+
+/// UI-facing state holder for the bite-logging screen (Phases 4–5).
 ///
-/// Owns the running bite count for the current local day in memory and, after
-/// every tap, writes through the [BiteRepository] then re-reads the count so the
-/// surfaced number stays consistent with the store — mirroring the weight
-/// feature's write-through-then-refresh pattern.
+/// Owns the running bite count for the current local day and, after every tap,
+/// writes through the [BiteRepository] then re-reads the count so the surfaced
+/// number stays consistent with the store — mirroring the weight feature's
+/// write-through-then-refresh pattern. Bite count is the headline metric (§0):
+/// [logBite] never blocks (§3a) and the count re-queries after each tap.
 ///
-/// Bite count is the headline metric (§0): [logBite] never blocks (§3a) and the
-/// count re-queries after each tap (§4, Phase 4).
+/// It also drives the pacing visualization (§3b, Phase 5). The live pacing view
+/// is *clock-driven, not data-driven*: the current [pacingZone] is a function of
+/// `now − lastBite`, so a local ticker rebuilds it from the last-bite time held
+/// in memory. The store is touched only to seed that reference once per session
+/// ([BiteRepository.lastBite]) and to read the effective thresholds. Zones are
+/// derived, never stored.
 class BiteManager extends ChangeNotifier {
-  BiteManager(this._repository);
+  /// [tickInterval] is how often the pacing ticker recomputes the zone while a
+  /// countdown is running (~200–500 ms, §3b). [onReachedClear] fires once when
+  /// the gap since the last bite reaches `b2` — the haptic tick that lets you
+  /// watch your plate instead of the phone (§3b); it defaults to a real device
+  /// haptic and is injectable so the lifecycle stays testable.
+  BiteManager(
+    this._repository, {
+    Duration tickInterval = const Duration(milliseconds: 300),
+    Future<void> Function()? onReachedClear,
+  })  : _tickInterval = tickInterval,
+        _onReachedClear = onReachedClear ?? HapticFeedback.mediumImpact;
 
   final BiteRepository _repository;
+  final Duration _tickInterval;
+  final Future<void> Function() _onReachedClear;
+
+  // v1 starting thresholds (§3b), used only as a fallback before a config has
+  // been read from the store — the default seed makes this unreachable in
+  // practice, but it keeps the pacing view sane if no config exists.
+  static const Duration _fallbackB1 = Duration(seconds: 15);
+  static const Duration _fallbackB2 = Duration(seconds: 30);
 
   int _todayCount = 0;
 
@@ -21,21 +50,71 @@ class BiteManager extends ChangeNotifier {
   /// (§3c). Zero until [initialize] (or a [logBite]) has run.
   int get todayCount => _todayCount;
 
-  /// Loads today's count from the store so the screen opens with the right
-  /// number even after an app restart.
+  // The pacing reference point, held in memory. The live view derives every
+  // zone from `now − _lastBiteAt`; the store is not re-read per tick (§3b).
+  DateTime? _lastBiteAt;
+
+  // The thresholds in effect for the live view, read once from the store.
+  PacingConfig? _pacingConfig;
+
+  PacingZone _pacingZone = PacingZone.inTheClear;
+
+  Timer? _ticker;
+
+  /// The current pacing zone, derived from `now − lastBite` against the
+  /// effective thresholds (§3b). Sits at [PacingZone.inTheClear] on open with no
+  /// recent bite; a tap restarts the countdown from [PacingZone.tooSoon].
+  PacingZone get pacingZone => _pacingZone;
+
+  /// Time elapsed since the last bite, or null if none has been logged this
+  /// session. Recomputed against the wall clock on each read so a build during
+  /// an active countdown shows a fresh value.
+  Duration? get sinceLastBite {
+    final ref = _lastBiteAt;
+    if (ref == null) return null;
+    return clock.now().difference(ref);
+  }
+
+  /// Whether a countdown ticker is currently running — i.e. we are mid-pace and
+  /// have not yet reached the clear zone. False in the static clear state.
+  bool get isPacing => _ticker != null;
+
+  Duration get _b1 => Duration(seconds: _pacingConfig?.b1S ?? _fallbackB1.inSeconds);
+  Duration get _b2 => Duration(seconds: _pacingConfig?.b2S ?? _fallbackB2.inSeconds);
+
+  /// Loads today's count and the effective pacing config, and seeds the pacing
+  /// reference from the last stored bite so the screen opens with the right
+  /// number and state even after an app restart. If that last bite is still
+  /// within the countdown window the ticker resumes; otherwise it opens on the
+  /// static clear state (§3b).
   Future<void> initialize() async {
+    final now = clock.now();
+    _pacingConfig = await _repository.pacingConfigAt(now);
     await _refreshTodayCount();
+
+    final last = await _repository.lastBite();
+    if (last != null) {
+      _lastBiteAt = DateTime.fromMillisecondsSinceEpoch(last.atMs);
+      _startCountdown();
+    }
   }
 
   /// Records one bite at the current instant — one tap = one bite, persisted
-  /// immediately and never blocked (§3a) — then refreshes today's count.
+  /// immediately and never blocked (§3a) — then refreshes today's count and
+  /// restarts the pacing countdown from the fresh reference.
   Future<void> logBite() async {
-    await _repository.logBite(DateTime.now());
+    final now = clock.now();
+    await _repository.logBite(now);
+    _lastBiteAt = now;
     await _refreshTodayCount();
+    // Lazily seed the thresholds if [initialize] was skipped (e.g. the very
+    // first bite of a fresh install before a config read landed).
+    _pacingConfig ??= await _repository.pacingConfigAt(now);
+    _startCountdown();
   }
 
   Future<void> _refreshTodayCount() async {
-    final now = DateTime.now();
+    final now = clock.now();
     // Local-day bounds as a half-open window `[startOfDay, startOfNextDay)`.
     // Building the next day via the DateTime constructor (day + 1) normalizes
     // month/year rollovers and lands on local midnight — DST-correct, unlike
@@ -44,5 +123,50 @@ class BiteManager extends ChangeNotifier {
     final startOfNextDay = DateTime(now.year, now.month, now.day + 1);
     _todayCount = await _repository.biteCount(startOfDay, startOfNextDay);
     notifyListeners();
+  }
+
+  /// (Re)starts the pacing countdown from the current [_lastBiteAt]. Sets the
+  /// zone to whatever the reference implies now and, only while the countdown
+  /// still matters (not yet clear), spins up the ticker. If the reference is
+  /// already past `b2` — a stale bite on open — it lands on the static clear
+  /// state with no ticker running (§3b).
+  void _startCountdown() {
+    _stopTicker();
+    _pacingZone = _currentZone();
+    notifyListeners();
+    if (_pacingZone != PacingZone.inTheClear) {
+      _ticker = Timer.periodic(_tickInterval, _tick);
+    }
+  }
+
+  void _tick(Timer timer) {
+    final zone = _currentZone();
+    if (zone == _pacingZone) return;
+    _pacingZone = zone;
+    if (zone == PacingZone.inTheClear) {
+      // Reaching `b2`: haptic, freeze on the static clear state, cancel the
+      // ticker so no periodic work runs until the next tap (§3b). Logging is
+      // untouched — only the display/compute stops here.
+      _stopTicker();
+      _onReachedClear();
+    }
+    notifyListeners();
+  }
+
+  PacingZone _currentZone() {
+    final ref = _lastBiteAt;
+    if (ref == null) return PacingZone.inTheClear;
+    return PacingZone.forElapsed(clock.now().difference(ref), b1: _b1, b2: _b2);
+  }
+
+  void _stopTicker() {
+    _ticker?.cancel();
+    _ticker = null;
+  }
+
+  @override
+  void dispose() {
+    _stopTicker();
+    super.dispose();
   }
 }

--- a/lib/features/bite/data/pacing_zone.dart
+++ b/lib/features/bite/data/pacing_zone.dart
@@ -1,0 +1,36 @@
+/// The three pacing zones a bite can fall into (§3b of the pacing plan).
+///
+/// A zone is a *derived* view, never stored: it is always computed at read time
+/// from `now − lastBite` against the two boundaries of the effective
+/// `PacingConfig`. The zones are the ranges those two boundaries cut —
+/// `[0, b1)` too soon, `[b1, b2)` ok — hold on, `[b2, ∞)` in the clear.
+///
+/// The zone expresses *how costly it is to bite right now*, decreasing to zero
+/// once you're clear — so the colour never falsely green-lights an early bite.
+enum PacingZone {
+  /// `[0, b1)` — too soon to take the next bite; keep chewing.
+  tooSoon,
+
+  /// `[b1, b2)` — almost there; hold on a moment.
+  holdOn,
+
+  /// `[b2, ∞)` — in the clear; it's ok to take the next bite. Reaching this is
+  /// the only readiness signal.
+  inTheClear;
+
+  /// The zone for [sinceLastBite] against the boundaries [b1] and [b2].
+  ///
+  /// The boundaries are half-open, matching the storage windows: a gap exactly
+  /// at a boundary belongs to the later (less costly) zone, so `b1` reads as
+  /// [holdOn] and `b2` reads as [inTheClear]. `b2` is the point at which biting
+  /// is recommended and the haptic fires.
+  static PacingZone forElapsed(
+    Duration sinceLastBite, {
+    required Duration b1,
+    required Duration b2,
+  }) {
+    if (sinceLastBite < b1) return PacingZone.tooSoon;
+    if (sinceLastBite < b2) return PacingZone.holdOn;
+    return PacingZone.inTheClear;
+  }
+}

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/ui/widgets/pacing_indicator.dart';
 import 'package:provider/provider.dart';
 
-/// The main bite-logging screen (Phase 4).
+/// The main bite-logging screen (Phases 4–5).
 ///
 /// One big tap = one bite, recorded immediately and never blocked (§3a); the
 /// day's running count — the headline metric — sits above the button and
-/// re-queries after every tap. Pacing visualization (Phase 5) lands on this
-/// same screen.
+/// re-queries after every tap. The pacing feedback banner (§3b) sits between
+/// the count and the button, colouring the current zone derived from the time
+/// since the last bite.
 class BitePage extends StatelessWidget {
   const BitePage({super.key});
 
@@ -40,6 +42,8 @@ class BitePage extends StatelessWidget {
                 ),
               ),
               const Spacer(),
+              PacingIndicator(zone: biteManager.pacingZone),
+              const SizedBox(height: 24),
               _BiteButton(onTap: biteManager.logBite),
               const Spacer(),
               Text(

--- a/lib/ui/widgets/pacing_indicator.dart
+++ b/lib/ui/widgets/pacing_indicator.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/features/bite/data/pacing_zone.dart';
+
+/// The pacing feedback banner (§3b, Phase 5).
+///
+/// A feedback metronome, not a gate: it renders the current [PacingZone] as a
+/// colour and a message that say *how costly it is to bite right now*, easing to
+/// green once you're in the clear. It never green-lights an early bite and never
+/// blocks logging — the tap button below stays live in every zone.
+///
+/// The colours and messages are fixed app constants (not theme-derived) so the
+/// red / amber / green semantics read the same regardless of the app's teal
+/// palette or platform.
+class PacingIndicator extends StatelessWidget {
+  const PacingIndicator({super.key, required this.zone});
+
+  final PacingZone zone;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final style = _PacingZoneStyle.of(zone);
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      decoration: BoxDecoration(
+        color: style.color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(28),
+        border: Border.all(color: style.color.withValues(alpha: 0.5)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(style.icon, color: style.color, size: 22),
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text(
+              style.message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: style.color,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The colour, icon, and message for each pacing zone — the app constants the
+/// visualization is built from (§3b). Messages are about *chewing* while you
+/// wait; reaching the clear zone is the only readiness cue.
+class _PacingZoneStyle {
+  const _PacingZoneStyle({
+    required this.color,
+    required this.icon,
+    required this.message,
+  });
+
+  final Color color;
+  final IconData icon;
+  final String message;
+
+  static _PacingZoneStyle of(PacingZone zone) {
+    switch (zone) {
+      case PacingZone.tooSoon:
+        return const _PacingZoneStyle(
+          color: Color(0xFFD32F2F), // red
+          icon: Icons.hourglass_top_rounded,
+          message: 'Too soon — keep chewing',
+        );
+      case PacingZone.holdOn:
+        return const _PacingZoneStyle(
+          color: Color(0xFFF9A825), // amber
+          icon: Icons.hourglass_bottom_rounded,
+          message: 'Almost — hold on a moment',
+        );
+      case PacingZone.inTheClear:
+        return const _PacingZoneStyle(
+          color: Color(0xFF2E7D32), // green
+          icon: Icons.check_circle_rounded,
+          message: "You're in the clear",
+        );
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   archive: ^4.0.7
+  clock: ^1.1.2
   csv: ^6.0.0
   drift: ^2.28.2
   drift_flutter: ^0.3.1
@@ -23,6 +24,7 @@ dependencies:
   shared_preferences: ^2.5.4
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/test/features/bite/data/bite_manager_pacing_test.dart
+++ b/test/features/bite/data/bite_manager_pacing_test.dart
@@ -1,0 +1,200 @@
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/pacing_zone.dart';
+
+/// Phase 5: the pacing ticker lifecycle. Driven with [fakeAsync] so the clock
+/// (via `package:clock`) and the periodic ticker advance together and
+/// deterministically — no real waiting, no drift database under fake time.
+void main() {
+  // The default seeded thresholds: b1 = 15 s, b2 = 30 s.
+  const config = PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30);
+
+  test('logBite starts the countdown in the too-soon zone', () {
+    fakeAsync((async) {
+      final repo = _FakeBiteRepository(config: config);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.logBite();
+      async.flushMicrotasks();
+
+      expect(manager.pacingZone, PacingZone.tooSoon);
+      expect(manager.isPacing, isTrue);
+
+      manager.dispose();
+    });
+  });
+
+  test('the zone advances through amber to green as time passes', () {
+    fakeAsync((async) {
+      final repo = _FakeBiteRepository(config: config);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.logBite();
+      async.flushMicrotasks();
+      expect(manager.pacingZone, PacingZone.tooSoon);
+
+      // Elapse just past each boundary so a tick is guaranteed to have fired
+      // after the crossing (the ticker is granular, not continuous).
+      async.elapse(const Duration(seconds: 16));
+      expect(manager.pacingZone, PacingZone.holdOn);
+
+      async.elapse(const Duration(seconds: 15));
+      expect(manager.pacingZone, PacingZone.inTheClear);
+
+      manager.dispose();
+    });
+  });
+
+  test('reaching b2 fires the haptic exactly once and stops the ticker', () {
+    fakeAsync((async) {
+      var haptics = 0;
+      final repo = _FakeBiteRepository(config: config);
+      final manager =
+          BiteManager(repo, onReachedClear: () async => haptics++);
+
+      manager.logBite();
+      async.flushMicrotasks();
+
+      async.elapse(const Duration(seconds: 31));
+      expect(manager.pacingZone, PacingZone.inTheClear);
+      expect(manager.isPacing, isFalse, reason: 'ticker frozen at clear');
+      expect(haptics, 1);
+
+      // No periodic work runs after clear, so no further haptics fire.
+      async.elapse(const Duration(seconds: 120));
+      expect(haptics, 1);
+
+      manager.dispose();
+    });
+  });
+
+  test('a fresh tap resets the reference and restarts the countdown', () {
+    fakeAsync((async) {
+      var haptics = 0;
+      final repo = _FakeBiteRepository(config: config);
+      final manager =
+          BiteManager(repo, onReachedClear: () async => haptics++);
+
+      manager.logBite();
+      async.flushMicrotasks();
+      async.elapse(const Duration(seconds: 31));
+      expect(manager.pacingZone, PacingZone.inTheClear);
+      expect(haptics, 1);
+
+      // Tapping again from the clear state re-arms the countdown.
+      manager.logBite();
+      async.flushMicrotasks();
+      expect(manager.pacingZone, PacingZone.tooSoon);
+      expect(manager.isPacing, isTrue);
+
+      async.elapse(const Duration(seconds: 31));
+      expect(manager.pacingZone, PacingZone.inTheClear);
+      expect(haptics, 2);
+
+      manager.dispose();
+    });
+  });
+
+  test('initialize resumes the countdown when the last bite is still recent',
+      () {
+    fakeAsync((async) {
+      final now = clock.now();
+      final repo = _FakeBiteRepository(
+        config: config,
+        bites: [now.subtract(const Duration(seconds: 5))],
+      );
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+
+      // 5 s in → still too soon, and the ticker is running.
+      expect(manager.pacingZone, PacingZone.tooSoon);
+      expect(manager.isPacing, isTrue);
+
+      // Elapse past b2 (5 s already gone, so >25 s more) to reach the clear
+      // state — a little extra so a tick lands after the crossing.
+      async.elapse(const Duration(seconds: 26));
+      expect(manager.pacingZone, PacingZone.inTheClear);
+
+      manager.dispose();
+    });
+  });
+
+  test('initialize opens on the static clear state for a stale last bite', () {
+    fakeAsync((async) {
+      final now = clock.now();
+      final repo = _FakeBiteRepository(
+        config: config,
+        bites: [now.subtract(const Duration(minutes: 10))],
+      );
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+
+      expect(manager.pacingZone, PacingZone.inTheClear);
+      expect(manager.isPacing, isFalse, reason: 'no ticker for a stale bite');
+
+      manager.dispose();
+    });
+  });
+
+  test('initialize with no bites shows the static clear state', () {
+    fakeAsync((async) {
+      final repo = _FakeBiteRepository(config: config);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+
+      expect(manager.pacingZone, PacingZone.inTheClear);
+      expect(manager.isPacing, isFalse);
+
+      manager.dispose();
+    });
+  });
+}
+
+/// An in-memory [BiteRepository] with synchronous-ish futures so the pacing
+/// ticker can be exercised under [fakeAsync] without a real drift database.
+class _FakeBiteRepository implements BiteRepository {
+  _FakeBiteRepository({this.config, List<DateTime>? bites})
+      : _bites = [...?bites];
+
+  final PacingConfig? config;
+  final List<DateTime> _bites;
+
+  @override
+  Future<void> logBite(DateTime at) async => _bites.add(at);
+
+  @override
+  Future<Bite?> lastBite() async => _bites.isEmpty
+      ? null
+      : Bite(id: _bites.length, atMs: _bites.last.millisecondsSinceEpoch);
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) async {
+    var id = 0;
+    return [
+      for (final at in _bites)
+        if (!at.isBefore(from) && at.isBefore(to))
+          Bite(id: ++id, atMs: at.millisecondsSinceEpoch),
+    ];
+  }
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) async => _bites
+      .where((at) => !at.isBefore(from) && at.isBefore(to))
+      .length;
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async {}
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
+}

--- a/test/features/bite/data/pacing_zone_test.dart
+++ b/test/features/bite/data/pacing_zone_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/pacing_zone.dart';
+
+/// Phase 5: the pure zone computation. Boundaries are half-open `[b1, b2)`, so a
+/// gap exactly on a boundary reads as the later (less costly) zone — matching
+/// the storage windows and the plan's zone table (§3b).
+void main() {
+  const b1 = Duration(seconds: 15);
+  const b2 = Duration(seconds: 30);
+
+  PacingZone zoneAt(Duration elapsed) =>
+      PacingZone.forElapsed(elapsed, b1: b1, b2: b2);
+
+  test('zero elapsed is too soon', () {
+    expect(zoneAt(Duration.zero), PacingZone.tooSoon);
+  });
+
+  test('just under b1 is too soon', () {
+    expect(zoneAt(const Duration(seconds: 14, milliseconds: 999)),
+        PacingZone.tooSoon);
+  });
+
+  test('exactly b1 crosses into hold on', () {
+    expect(zoneAt(b1), PacingZone.holdOn);
+  });
+
+  test('between b1 and b2 is hold on', () {
+    expect(zoneAt(const Duration(seconds: 22)), PacingZone.holdOn);
+  });
+
+  test('just under b2 is still hold on', () {
+    expect(zoneAt(const Duration(seconds: 29, milliseconds: 999)),
+        PacingZone.holdOn);
+  });
+
+  test('exactly b2 crosses into the clear', () {
+    expect(zoneAt(b2), PacingZone.inTheClear);
+  });
+
+  test('well past b2 is in the clear', () {
+    expect(zoneAt(const Duration(minutes: 5)), PacingZone.inTheClear);
+  });
+}


### PR DESCRIPTION
Implements **Phase 5 — Pacing visualization** from `docs/bite_pacing_plan.md`: a clock-driven pacing metronome on the bite-logging screen. The current zone is derived from `now − lastBite` against the effective pacing thresholds and is never stored (§3b).

## Changes

- **`pacing_zone.dart` (new)** — `PacingZone` enum (`tooSoon`/`holdOn`/`inTheClear`) with a pure `forElapsed(...)`. Boundaries are half-open `[b1, b2)`, matching the storage windows, so a gap exactly on a boundary reads as the later (less costly) zone.
- **`BiteManager`** — holds the last-bite reference in memory and reads the effective `PacingConfig` once (fallback 15 s / 30 s). A local `Timer.periodic` (~300 ms) starts on tap and recomputes the zone each tick. On reaching `b2` it fires an injectable haptic **exactly once**, freezes on the static "in the clear" state, and cancels the ticker; the next tap re-arms it. `initialize` resumes a still-recent countdown or opens on the static clear state. Uses `package:clock` so the lifecycle is testable under `fakeAsync`. Logging is never blocked or stopped — only the display/compute freezes.
- **`PacingIndicator` (new)** — renders the zone as fixed red/amber/green colours and messages (app constants, not theme-derived), placed between today's count and the tap button.
- **`docs/bite_pacing_plan.md`** — checked off the Phase 5 tasks.
- **`pubspec.yaml`** — `clock` promoted to a direct dependency; `fake_async` added as a dev dependency.

## Tests

- `pacing_zone_test.dart` — boundary behaviour of the pure zone computation.
- `bite_manager_pacing_test.dart` — ticker lifecycle under `fakeAsync`: enters `tooSoon` on tap, advances amber→green, fires the haptic once and freezes at `b2`, re-arms on a fresh tap, and `initialize` resumes / opens on the static clear state.

`flutter analyze` is clean and the full suite (91 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAdMMK4fhUHqKbx9b68zG9)_