### PR TITLE
feat: two-store CSV backup for the bite log (bite-pacing Phases 6 & 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Dates are treated as day-granular throughout: repository keys and equality norma
 
 ### Backup / restore
 
-`SerializationService` (Settings tab) exports/imports a zip. `WeightBackupCodec` handles CSV-in-zip encode/decode; `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable. Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
+`SerializationService` (Settings tab) exports/imports one zip spanning **both** stores. Each dataset owns a per-store codec — `WeightBackupCodec` (`weight.csv`) and `BiteBackupCodec` (`bites.csv`, storing only the raw `at_ms`) — and `SerializationService` coordinates them into a single archive. `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable; it always replaces weights, and replaces bites only when the archive actually carries a bite entry (an older weight-only backup leaves bites untouched), deduping repeated instants on import. Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
 
 ## Testing
 

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -233,5 +233,5 @@ tooling swap, not a data migration.
 - [x] Route it through the repository seam so one call spans both stores
 
 **Phase 7 — CSV import**
-- [ ] Parse the bite CSV back into the SQLite (Drift) store
-- [ ] Route through the repository seam; validate / dedupe on import
+- [x] Parse the bite CSV back into the SQLite (Drift) store
+- [x] Route through the repository seam; validate / dedupe on import

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -229,8 +229,8 @@ tooling swap, not a data migration.
 - [x] Next tap resets the reference and restarts the ticker; on open with no recent bite, show the static clear state (no ticker)
 
 **Phase 6 — CSV export**
-- [ ] Extend the existing CSV export to include the bite data
-- [ ] Route it through the repository seam so one call spans both stores
+- [x] Extend the existing CSV export to include the bite data
+- [x] Route it through the repository seam so one call spans both stores
 
 **Phase 7 — CSV import**
 - [ ] Parse the bite CSV back into the SQLite (Drift) store

--- a/lib/features/bite/data/bite_repository.dart
+++ b/lib/features/bite/data/bite_repository.dart
@@ -42,4 +42,13 @@ abstract interface class BiteRepository {
   /// The pacing config in effect at [instant]: the newest version whose
   /// effective instant is at or before it, or null if none precedes it.
   Future<PacingConfig?> pacingConfigAt(DateTime instant);
+
+  /// Deletes every logged bite.
+  ///
+  /// The clear half of the clear-then-restore import path (§1c): a backup is a
+  /// full snapshot of the bite log, so restoring replaces it. The pacing-config
+  /// history is deliberately left intact — it is a separate slowly-changing
+  /// dimension the CSV backup doesn't carry, and wiping it would drop the
+  /// seeded default and any retuned thresholds.
+  Future<void> clearBites();
 }

--- a/lib/features/bite/data/drift_bite_repository.dart
+++ b/lib/features/bite/data/drift_bite_repository.dart
@@ -76,4 +76,9 @@ class DriftBiteRepository implements BiteRepository {
   Future<PacingConfig?> pacingConfigAt(DateTime instant) {
     return _db.pacingConfigAt(instant);
   }
+
+  @override
+  Future<void> clearBites() async {
+    await _db.delete(_db.bites).go();
+  }
 }

--- a/lib/features/settings/data/bite_backup_codec.dart
+++ b/lib/features/settings/data/bite_backup_codec.dart
@@ -1,0 +1,33 @@
+import 'package:archive/archive.dart';
+import 'package:food_locker/core/csv_serializer.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+
+/// CSV backup logic for the bite log (§1c of the pacing plan).
+///
+/// The two stores each own their own codec; this one turns the bite dataset
+/// into a `bites.csv` entry that `SerializationService` packs into the same zip
+/// as the weight CSV. Only the raw fact is exported — the epoch-millis
+/// timestamp of each bite — following the plan's "store facts, derive views"
+/// rule: counts, deltas, and pacing zones are all reconstructable from the
+/// timestamps, so exporting them verbatim keeps the backup lossless.
+class BiteBackupCodec {
+  /// The bite dataset's entry inside a backup zip.
+  static const String biteFileName = 'bites.csv';
+
+  const BiteBackupCodec();
+
+  /// The bite CSV packaged as a single [ArchiveFile], so it can be added to a
+  /// shared archive that also carries the weight CSV.
+  ArchiveFile toArchiveFile(List<Bite> bites) {
+    final csvContent = generateBiteCsv(bites);
+    return ArchiveFile(biteFileName, csvContent.length, csvContent.codeUnits);
+  }
+
+  /// One `at_ms` (epoch millis) per bite, in chronological order. The id is an
+  /// insertion-order artifact of the current store, not a fact worth exporting,
+  /// so only the timestamp — the atomic fact — is written.
+  String generateBiteCsv(List<Bite> bites) {
+    final items = bites.map((b) => {'at_ms': b.atMs}).toList();
+    return CsvSerializer.toCSV(items);
+  }
+}

--- a/lib/features/settings/data/bite_backup_codec.dart
+++ b/lib/features/settings/data/bite_backup_codec.dart
@@ -30,4 +30,37 @@ class BiteBackupCodec {
     final items = bites.map((b) => {'at_ms': b.atMs}).toList();
     return CsvSerializer.toCSV(items);
   }
+
+  /// The bite timestamps carried by a decoded [archive], or null when the
+  /// archive has no bite entry at all.
+  ///
+  /// The null vs. empty distinction is load-bearing on import: a pre-bite
+  /// backup (weight-only, no `bites.csv`) simply doesn't describe the bite
+  /// log, so its absence must leave existing bites untouched — whereas a
+  /// present-but-empty `bites.csv` is a real snapshot of "no bites" and does
+  /// clear them.
+  List<DateTime>? fromArchive(Archive archive) {
+    for (final file in archive) {
+      if (file.isFile && file.name == biteFileName) {
+        final content = String.fromCharCodes(file.content as List<int>);
+        return parseBiteCsv(content);
+      }
+    }
+    return null;
+  }
+
+  /// Parses the bite CSV back into instants, one per valid `at_ms` row, in file
+  /// order. Rows whose `at_ms` is missing or not an integer are dropped —
+  /// the validation half of "validate / dedupe on import". Deduplication of
+  /// repeated instants is left to the import coordinator.
+  List<DateTime> parseBiteCsv(String csv) {
+    final result = <DateTime>[];
+    for (final item in CsvSerializer.fromCSV(csv)) {
+      final raw = item['at_ms'];
+      final ms = raw is int ? raw : int.tryParse(raw?.toString() ?? '');
+      if (ms == null) continue;
+      result.add(DateTime.fromMillisecondsSinceEpoch(ms));
+    }
+    return result;
+  }
 }

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -1,7 +1,12 @@
 import 'dart:io';
+import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/widgets.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
@@ -24,12 +29,14 @@ class SerializationService {
 
   Future<void> exportData(BuildContext context) async {
     final weightRepo = context.read<WeightRepository>();
+    final biteRepo = context.read<BiteRepository>();
 
-    final zipData = const WeightBackupCodec().encode(
-      weightRepo.getAllWeights(),
-    );
+    final weights = weightRepo.getAllWeights();
+    final bites = await _allBites(biteRepo);
 
-    if (zipData.isEmpty) return;
+    if (weights.isEmpty && bites.isEmpty) return;
+
+    final zipData = encodeBackup(weights, bites);
 
     final tempDir = await getTemporaryDirectory();
     final zipFile = File('${tempDir.path}/${generateZipFileName()}');
@@ -37,6 +44,28 @@ class SerializationService {
 
     // ignore: deprecated_member_use
     await Share.shareXFiles([XFile(zipFile.path)], text: 'Food Locker Backup');
+  }
+
+  /// Packs both datasets into a single backup zip. Each store owns its own
+  /// codec (§1c two-store tax); the coordination — one archive, one file per
+  /// dataset — lives here so a single export call spans both stores.
+  @visibleForTesting
+  List<int> encodeBackup(List<Weight> weights, List<Bite> bites) {
+    final archive = Archive()
+      ..addFile(const WeightBackupCodec().toArchiveFile(weights))
+      ..addFile(const BiteBackupCodec().toArchiveFile(bites));
+    return ZipEncoder().encode(archive);
+  }
+
+  /// Every logged bite, read through the repository seam. The bite interface
+  /// exposes ranges rather than a bulk getter, so a full-history export is a
+  /// range from the epoch to a far-future bound (half-open, so the upper bound
+  /// stays safely past any real timestamp).
+  Future<List<Bite>> _allBites(BiteRepository biteRepo) {
+    return biteRepo.bitesInRange(
+      DateTime.fromMillisecondsSinceEpoch(0),
+      DateTime.utc(9999),
+    );
   }
 
   Future<void> importData(BuildContext context) async {

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -70,6 +70,7 @@ class SerializationService {
 
   Future<void> importData(BuildContext context) async {
     final weightRepo = context.read<WeightRepository>();
+    final biteRepo = context.read<BiteRepository>();
 
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -82,23 +83,42 @@ class SerializationService {
     final file = File(filePath);
     final bytes = await file.readAsBytes();
 
-    await restoreFromBackup(weightRepo, bytes);
+    await restoreFromBackup(weightRepo, biteRepo, bytes);
   }
 
-  /// Replaces every stored weight with the contents of a backup zip.
+  /// Replaces both stores' contents with a backup zip — the destructive core of
+  /// [importData], kept separate from the file-picker and file-I/O plumbing so
+  /// the clear-then-restore path stays unit-testable.
   ///
-  /// This is the destructive core of [importData], kept separate from the
-  /// file-picker and file-I/O plumbing so the clear-then-restore path is
-  /// unit-testable. It is also the natural coordination point for the upcoming
-  /// two-store import (bite data alongside weights).
+  /// The single decode is the coordination point for the two-store tax (§1c):
+  /// weights and bites are restored from the same archive. Weights are always
+  /// replaced; bites are replaced only when the archive actually carries a bite
+  /// entry, so restoring an older weight-only backup leaves existing bites
+  /// alone rather than wiping them.
   Future<void> restoreFromBackup(
     WeightRepository weightRepo,
+    BiteRepository biteRepo,
     List<int> zipBytes,
   ) async {
-    final weights = const WeightBackupCodec().decode(zipBytes);
+    final archive = ZipDecoder().decodeBytes(zipBytes);
+
+    final weights = const WeightBackupCodec().fromArchive(archive);
     await weightRepo.clear();
     for (final weight in weights) {
       await weightRepo.saveWeight(weight);
+    }
+
+    final bites = const BiteBackupCodec().fromArchive(archive);
+    if (bites != null) {
+      await biteRepo.clearBites();
+      final seen = <int>{};
+      for (final at in bites) {
+        // Dedupe by instant so a backup with repeated rows — or a re-import of
+        // the same file — never double-logs a bite.
+        if (seen.add(at.millisecondsSinceEpoch)) {
+          await biteRepo.logBite(at);
+        }
+      }
     }
   }
 }

--- a/lib/features/settings/data/weight_backup_codec.dart
+++ b/lib/features/settings/data/weight_backup_codec.dart
@@ -4,27 +4,34 @@ import 'package:food_locker/core/csv_serializer.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 
 class WeightBackupCodec {
-  static const String _weightFileName = 'weight.csv';
+  /// The weight dataset's entry inside a backup zip. Public so the two-store
+  /// coordinator (`SerializationService`) can pack it alongside the bite entry
+  /// in a single archive.
+  static const String weightFileName = 'weight.csv';
 
   const WeightBackupCodec();
 
   List<int> encode(List<Weight> weights) {
-    final csvContent = generateWeightCsv(weights);
-
-    final archive = Archive()
-      ..addFile(
-        ArchiveFile(_weightFileName, csvContent.length, csvContent.codeUnits),
-      );
-
-    return ZipEncoder().encode(archive);
+    return ZipEncoder().encode(Archive()..addFile(toArchiveFile(weights)));
   }
 
   List<Weight> decode(List<int> zipBytes) {
-    final archive = ZipDecoder().decodeBytes(zipBytes);
-    final List<Weight> weights = [];
+    return fromArchive(ZipDecoder().decodeBytes(zipBytes));
+  }
 
+  /// The weight CSV packaged as a single [ArchiveFile], so it can be added to a
+  /// shared archive that also carries other datasets (§1c two-store backup).
+  ArchiveFile toArchiveFile(List<Weight> weights) {
+    final csvContent = generateWeightCsv(weights);
+    return ArchiveFile(weightFileName, csvContent.length, csvContent.codeUnits);
+  }
+
+  /// Reads the weights out of a decoded [archive], ignoring any other datasets
+  /// packed alongside them (e.g. the bite CSV).
+  List<Weight> fromArchive(Archive archive) {
+    final List<Weight> weights = [];
     for (final file in archive) {
-      if (file.isFile && file.name == _weightFileName) {
+      if (file.isFile && file.name == weightFileName) {
         final content = String.fromCharCodes(file.content as List<int>);
         weights.addAll(parseWeightCsv(content));
       }

--- a/test/features/bite/data/bite_manager_pacing_test.dart
+++ b/test/features/bite/data/bite_manager_pacing_test.dart
@@ -197,4 +197,7 @@ class _FakeBiteRepository implements BiteRepository {
 
   @override
   Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
+
+  @override
+  Future<void> clearBites() async => _bites.clear();
 }

--- a/test/features/bite/data/drift_bite_repository_test.dart
+++ b/test/features/bite/data/drift_bite_repository_test.dart
@@ -185,4 +185,29 @@ void main() {
       expect(all, hasLength(2));
     });
   });
+
+  group('clearBites', () {
+    test('removes every logged bite', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 30));
+
+      await repo.clearBites();
+
+      expect(await db.select(db.bites).get(), isEmpty);
+      expect(await repo.lastBite(), isNull);
+    });
+
+    test('leaves the pacing-config history intact', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 12, 0, 0));
+
+      await repo.clearBites();
+
+      // The seeded default must survive a bite wipe — it is not part of the
+      // CSV backup and is a separate slowly-changing dimension.
+      final cfg = await repo.pacingConfigAt(DateTime(2026, 7, 13));
+      expect(cfg, isNotNull);
+      expect(cfg!.b1S, 15);
+      expect(cfg.b2S, 30);
+    });
+  });
 }

--- a/test/features/settings/data/bite_backup_codec_test.dart
+++ b/test/features/settings/data/bite_backup_codec_test.dart
@@ -1,0 +1,42 @@
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
+
+void main() {
+  const codec = BiteBackupCodec();
+
+  group('BiteBackupCodec CSV Logic', () {
+    test('generateBiteCsv writes one at_ms per bite under an at_ms header', () {
+      final bites = [
+        const Bite(id: 1, atMs: 1000),
+        const Bite(id: 2, atMs: 31000),
+      ];
+
+      final csv = codec.generateBiteCsv(bites);
+
+      expect(csv, contains('at_ms'));
+      expect(csv, contains('1000'));
+      expect(csv, contains('31000'));
+    });
+
+    test('generateBiteCsv of no bites is empty', () {
+      expect(codec.generateBiteCsv([]), isEmpty);
+    });
+  });
+
+  group('BiteBackupCodec archive entry', () {
+    test('toArchiveFile names the entry bites.csv', () {
+      final file = codec.toArchiveFile([const Bite(id: 1, atMs: 1000)]);
+      expect(file.name, BiteBackupCodec.biteFileName);
+      expect(file.name, 'bites.csv');
+    });
+
+    test('toArchiveFile content is the generated CSV', () {
+      final bites = [const Bite(id: 1, atMs: 1234)];
+      final file = codec.toArchiveFile(bites);
+      final content = String.fromCharCodes(file.content as List<int>);
+      expect(content, codec.generateBiteCsv(bites));
+    });
+  });
+}

--- a/test/features/settings/data/bite_backup_codec_test.dart
+++ b/test/features/settings/data/bite_backup_codec_test.dart
@@ -39,4 +39,57 @@ void main() {
       expect(content, codec.generateBiteCsv(bites));
     });
   });
+
+  group('BiteBackupCodec parseBiteCsv', () {
+    test('reads one instant per at_ms row, preserving order', () {
+      const csv = 'at_ms\r\n1000\r\n31000';
+      final instants = codec.parseBiteCsv(csv);
+
+      expect(instants.map((d) => d.millisecondsSinceEpoch), [1000, 31000]);
+    });
+
+    test('round-trips generateBiteCsv', () {
+      final bites = [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 31000)];
+      final instants = codec.parseBiteCsv(codec.generateBiteCsv(bites));
+
+      expect(instants.map((d) => d.millisecondsSinceEpoch), [1000, 31000]);
+    });
+
+    test('drops rows whose at_ms is missing or non-integer', () {
+      const csv = 'at_ms\r\n1000\r\n\r\nabc\r\n31000';
+      final instants = codec.parseBiteCsv(csv);
+
+      expect(instants.map((d) => d.millisecondsSinceEpoch), [1000, 31000]);
+    });
+
+    test('an empty CSV parses to no bites', () {
+      expect(codec.parseBiteCsv(''), isEmpty);
+    });
+  });
+
+  group('BiteBackupCodec fromArchive', () {
+    test('returns null when the archive has no bite entry', () {
+      // A pre-bite, weight-only backup: absence must not be read as "no bites".
+      final archive = Archive()
+        ..addFile(ArchiveFile('weight.csv', 3, 'a,b'.codeUnits));
+
+      expect(codec.fromArchive(archive), isNull);
+    });
+
+    test('returns the parsed bites when the entry is present', () {
+      final archive = Archive()
+        ..addFile(codec.toArchiveFile([const Bite(id: 1, atMs: 1000)]));
+
+      final instants = codec.fromArchive(archive);
+      expect(instants, isNotNull);
+      expect(instants!.single.millisecondsSinceEpoch, 1000);
+    });
+
+    test('returns an empty list for a present-but-empty bite entry', () {
+      // A real snapshot of "no bites", distinct from a missing entry.
+      final archive = Archive()..addFile(codec.toArchiveFile([]));
+
+      expect(codec.fromArchive(archive), isEmpty);
+    });
+  });
 }

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -1,4 +1,7 @@
+import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
@@ -34,6 +37,53 @@ void main() {
       final timestamp = DateTime(2026, 1, 5, 3, 2, 1);
       final fileName = SerializationService.generateZipFileName(timestamp);
       expect(fileName, 'food_locker_20260105030201.zip');
+    });
+  });
+
+  group('SerializationService encodeBackup', () {
+    final service = SerializationService();
+
+    List<int> contentOf(Archive archive, String name) =>
+        archive.files.firstWhere((f) => f.name == name).content as List<int>;
+
+    test('packs both datasets into one zip, one file each', () {
+      final zip = service.encodeBackup(
+        [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+        [const Bite(id: 1, atMs: 1000)],
+      );
+
+      final archive = ZipDecoder().decodeBytes(zip);
+      final names = archive.files.map((f) => f.name).toSet();
+      expect(names, containsAll([
+        WeightBackupCodec.weightFileName,
+        BiteBackupCodec.biteFileName,
+      ]));
+    });
+
+    test('the weight entry stays decodable by WeightBackupCodec', () {
+      // Backward compatibility: adding the bite CSV must not disturb the
+      // weight restore path, which reads weight.csv out of the same zip.
+      final zip = service.encodeBackup(
+        [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+        [const Bite(id: 1, atMs: 1000)],
+      );
+
+      final weights = const WeightBackupCodec().decode(zip);
+      expect(weights.single.value, 75.5);
+    });
+
+    test('the bite entry holds the exported at_ms values', () {
+      final zip = service.encodeBackup(
+        const [],
+        [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 31000)],
+      );
+
+      final archive = ZipDecoder().decodeBytes(zip);
+      final csv = String.fromCharCodes(
+        contentOf(archive, BiteBackupCodec.biteFileName),
+      );
+      expect(csv, contains('1000'));
+      expect(csv, contains('31000'));
     });
   });
 

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
@@ -23,6 +24,44 @@ class _RecordingWeightRepository extends InMemoryWeightRepository {
     operations.add('save');
     await super.saveWeight(weight);
   }
+}
+
+/// Records the bite mutations a restore performs, so the clear-then-restore
+/// sequence and dedup behaviour are assertable without a real Drift store. Only
+/// the restore path's methods do anything; the rest aren't exercised here.
+class _RecordingBiteRepository implements BiteRepository {
+  final List<String> operations = [];
+  final List<int> loggedMs = [];
+
+  @override
+  Future<void> clearBites() async {
+    operations.add('clear');
+    loggedMs.clear();
+  }
+
+  @override
+  Future<void> logBite(DateTime at) async {
+    operations.add('log');
+    loggedMs.add(at.millisecondsSinceEpoch);
+  }
+
+  @override
+  Future<Bite?> lastBite() => throw UnimplementedError();
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) =>
+      throw UnimplementedError();
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) => throw UnimplementedError();
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) =>
+      throw UnimplementedError();
 }
 
 void main() {
@@ -100,7 +139,7 @@ void main() {
         Weight(date: DateTime(2023, 10, 28), value: 75.0),
       ]);
 
-      await service.restoreFromBackup(repo, backup);
+      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup);
 
       final restored = repo.getAllWeights();
       expect(restored.map((w) => w.value), containsAll([75.5, 75.0]));
@@ -119,7 +158,7 @@ void main() {
         Weight(date: DateTime(2023, 10, 28), value: 75.0),
       ]);
 
-      await service.restoreFromBackup(repo, backup);
+      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup);
 
       // clear must come first, then one save per restored weight.
       expect(repo.operations, ['clear', 'save', 'save']);
@@ -129,9 +168,81 @@ void main() {
       final repo = InMemoryWeightRepository();
       await repo.saveWeight(Weight(date: DateTime(2020, 1, 1), value: 99.9));
 
-      await service.restoreFromBackup(repo, codec.encode([]));
+      await service.restoreFromBackup(
+        repo,
+        _RecordingBiteRepository(),
+        codec.encode([]),
+      );
 
       expect(repo.getAllWeights(), isEmpty);
+    });
+
+    test('restores bites from a two-store backup, clearing first', () async {
+      final biteRepo = _RecordingBiteRepository();
+      final backup = service.encodeBackup(
+        [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+        [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 31000)],
+      );
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      // clear must come first, then one log per restored bite.
+      expect(biteRepo.operations, ['clear', 'log', 'log']);
+      expect(biteRepo.loggedMs, [1000, 31000]);
+    });
+
+    test('dedupes repeated bite instants on import', () async {
+      final biteRepo = _RecordingBiteRepository();
+      // Two rows share an at_ms — a re-import artifact; only one bite survives.
+      final backup = service.encodeBackup(
+        const [],
+        [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 1000)],
+      );
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      expect(biteRepo.loggedMs, [1000]);
+    });
+
+    test('a present-but-empty bite entry clears existing bites', () async {
+      final biteRepo = _RecordingBiteRepository();
+      final backup = service.encodeBackup(
+        [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+        const [],
+      );
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      // The bite log is a real (empty) snapshot: cleared, nothing logged.
+      expect(biteRepo.operations, ['clear']);
+    });
+
+    test('leaves bites untouched for a weight-only (pre-bite) backup', () async {
+      final biteRepo = _RecordingBiteRepository();
+      // A legacy zip with no bites.csv must not wipe the existing bite log.
+      final backup = codec.encode([
+        Weight(date: DateTime(2023, 10, 27), value: 75.5),
+      ]);
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      expect(biteRepo.operations, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

Extends backup/restore to span **both** stores (Hive weights + Drift bites), completing the last two phases of `docs/bite_pacing_plan.md`. A single backup zip now carries the bite log alongside weights, all coordinated through the repository seam (§1c "two-store tax").

### Phase 6 — CSV export
- Split `WeightBackupCodec`'s zip packaging into a reusable `toArchiveFile`/`fromArchive` pair (`encode`/`decode` now delegate to them), so both datasets share one archive; `weight.csv` stays byte-compatible.
- Added `BiteBackupCodec`, which exports the raw `at_ms` epoch-millis fact per bite ("store facts, derive views") as `bites.csv`.
- `SerializationService.exportData` reads all bites via `bitesInRange` over a full-history window and packs `weight.csv` + `bites.csv` into one zip. Export is skipped only when **both** stores are empty.

### Phase 7 — CSV import
- `BiteBackupCodec.parseBiteCsv` rebuilds instants from `at_ms` rows, dropping malformed rows (the "validate" half).
- `BiteBackupCodec.fromArchive` returns `null` when the zip has no `bites.csv`, so restoring an older weight-only backup **leaves existing bites untouched** rather than wiping them; a present-but-empty entry is a real "no bites" snapshot and does clear them.
- Added `BiteRepository.clearBites` — clears the bite log only; `pacing_config` (a separate slowly-changing dimension, not in the CSV) is left intact.
- `restoreFromBackup` decodes the archive once, replaces weights as before, and replaces bites when present, **deduping repeated instants** so a re-import is idempotent.

## Testing
- Added `bite_backup_codec_test.dart` (CSV gen/parse, round-trip, validation, `fromArchive` null/empty/present cases).
- Added `encodeBackup` and bite-restore tests to `serialization_service_test.dart` (one-zip packaging, weight backward-compat, clear-then-log ordering, dedup, empty-clears, weight-only-leaves-bites-alone).
- Added `clearBites` coverage to `drift_bite_repository_test.dart` (removes bites, preserves pacing config).

⚠️ `flutter analyze` / `flutter test` were **not** run locally — no Dart/Flutter toolchain in the execution environment. CI (`flutter_ci.yml`) runs both on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVEDUHpucYU1gE2fUmn7nQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVEDUHpucYU1gE2fUmn7nQ)_