### PR TITLE
feat: keep screen awake for 15s after each bite

### DIFF
--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -82,6 +82,11 @@ class BiteManager extends ChangeNotifier {
   Duration get _b1 => Duration(seconds: _pacingConfig?.b1S ?? _fallbackB1.inSeconds);
   Duration get _b2 => Duration(seconds: _pacingConfig?.b2S ?? _fallbackB2.inSeconds);
 
+  /// The effective `b2` boundary — the gap since the last bite at which the
+  /// next bite is recommended (the [PacingZone.inTheClear] point). Exposed so
+  /// the screen can hold the display awake across the whole pacing interval.
+  Duration get b2 => _b2;
+
   /// Loads today's count and the effective pacing config, and seeds the pacing
   /// reference from the last stored bite so the screen opens with the right
   /// number and state even after an app restart. If that last bite is still

--- a/lib/ui/app_shell.dart
+++ b/lib/ui/app_shell.dart
@@ -14,13 +14,6 @@ class AppShell extends StatefulWidget {
 class _AppShellState extends State<AppShell> {
   int _currentIndex = 0;
 
-  static const List<Widget> _pages = [
-    BitePage(),
-    HomePage(),
-    WeightPage(),
-    SettingsPage(),
-  ];
-
   static const List<String> _titles = ['Bite', 'Home', 'Weight', 'Settings'];
 
   void _onTabTapped(int index) {
@@ -33,7 +26,17 @@ class _AppShellState extends State<AppShell> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(_titles[_currentIndex])),
-      body: IndexedStack(index: _currentIndex, children: _pages),
+      body: IndexedStack(
+        index: _currentIndex,
+        children: [
+          // The Bite tab keeps the screen awake while logging; tell it whether
+          // it is the visible tab so it can release the wake-lock when hidden.
+          BitePage(isActive: _currentIndex == 0),
+          const HomePage(),
+          const WeightPage(),
+          const SettingsPage(),
+        ],
+      ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         currentIndex: _currentIndex,

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/ui/widgets/pacing_indicator.dart';
 import 'package:provider/provider.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 /// The main bite-logging screen (Phases 4–5).
 ///
@@ -10,8 +13,88 @@ import 'package:provider/provider.dart';
 /// re-queries after every tap. The pacing feedback banner (§3b) sits between
 /// the count and the button, colouring the current zone derived from the time
 /// since the last bite.
-class BitePage extends StatelessWidget {
-  const BitePage({super.key});
+///
+/// Logging a meal is a stop-start affair — you eat a bite, tap, wait, eat
+/// again — and those gaps can be longer than the system screen timeout, which
+/// would blank the screen mid-meal. So each tap keeps the screen awake for a
+/// rolling [_keepAwakeWindow]; once that window lapses with no new bite the
+/// wake-lock is released and the OS's normal sleep behaviour resumes. The lock
+/// is also released whenever the tab is hidden, the app is backgrounded, or
+/// this page is disposed, so it never leaks beyond this screen.
+class BitePage extends StatefulWidget {
+  const BitePage({super.key, this.isActive = true});
+
+  /// Whether this page is the visible tab. When `false` the wake-lock is
+  /// released so it does not hold the screen on from behind another tab.
+  final bool isActive;
+
+  @override
+  State<BitePage> createState() => _BitePageState();
+}
+
+class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
+  /// How long after the last bite the screen is kept awake.
+  static const Duration _keepAwakeWindow = Duration(seconds: 15);
+
+  Timer? _releaseTimer;
+  bool _wakeEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didUpdateWidget(BitePage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Left the Bite tab: drop the lock immediately rather than waiting out the
+    // remainder of the window on some other screen.
+    if (!widget.isActive) {
+      _releaseWakelock();
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Nothing to keep awake once the app is no longer in the foreground.
+    if (state != AppLifecycleState.resumed) {
+      _releaseWakelock();
+    }
+  }
+
+  Future<void> _handleBite() async {
+    await context.read<BiteManager>().logBite();
+    _keepAwakeForWindow();
+  }
+
+  /// Enables the wake-lock (if not already held) and (re)arms the release
+  /// timer so the screen stays on for [_keepAwakeWindow] from now.
+  void _keepAwakeForWindow() {
+    if (!widget.isActive) return;
+    _releaseTimer?.cancel();
+    _releaseTimer = Timer(_keepAwakeWindow, _releaseWakelock);
+    if (!_wakeEnabled) {
+      _wakeEnabled = true;
+      WakelockPlus.enable();
+    }
+  }
+
+  void _releaseWakelock() {
+    _releaseTimer?.cancel();
+    _releaseTimer = null;
+    if (_wakeEnabled) {
+      _wakeEnabled = false;
+      WakelockPlus.disable();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _releaseWakelock();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +127,7 @@ class BitePage extends StatelessWidget {
               const Spacer(),
               PacingIndicator(zone: biteManager.pacingZone),
               const SizedBox(height: 24),
-              _BiteButton(onTap: biteManager.logBite),
+              _BiteButton(onTap: _handleBite),
               const Spacer(),
               Text(
                 'Tap for each bite',

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -16,11 +16,13 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 ///
 /// Logging a meal is a stop-start affair — you eat a bite, tap, wait, eat
 /// again — and those gaps can be longer than the system screen timeout, which
-/// would blank the screen mid-meal. So each tap keeps the screen awake for a
-/// rolling [_keepAwakeWindow]; once that window lapses with no new bite the
-/// wake-lock is released and the OS's normal sleep behaviour resumes. The lock
-/// is also released whenever the tab is hidden, the app is backgrounded, or
-/// this page is disposed, so it never leaks beyond this screen.
+/// would blank the screen mid-meal. So each tap keeps the screen awake across
+/// the whole pacing interval — until the `b2` boundary (when the next bite is
+/// recommended) plus a [_clearGrace] cushion — resetting that window on every
+/// bite. Once it lapses with no new bite the wake-lock is released and the
+/// OS's normal sleep behaviour resumes. The lock is also released whenever the
+/// tab is hidden, the app is backgrounded, or this page is disposed, so it
+/// never leaks beyond this screen.
 class BitePage extends StatefulWidget {
   const BitePage({super.key, this.isActive = true});
 
@@ -33,8 +35,9 @@ class BitePage extends StatefulWidget {
 }
 
 class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
-  /// How long after the last bite the screen is kept awake.
-  static const Duration _keepAwakeWindow = Duration(seconds: 15);
+  /// Extra time the screen is held awake past the `b2` boundary, so it does not
+  /// blank the instant the next bite becomes due.
+  static const Duration _clearGrace = Duration(seconds: 15);
 
   Timer? _releaseTimer;
   bool _wakeEnabled = false;
@@ -64,16 +67,19 @@ class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
   }
 
   Future<void> _handleBite() async {
-    await context.read<BiteManager>().logBite();
-    _keepAwakeForWindow();
+    final biteManager = context.read<BiteManager>();
+    await biteManager.logBite();
+    // Hold the screen on for the whole pacing interval (b2) plus a grace
+    // cushion, measured from this bite; the next bite re-arms it.
+    _keepAwakeForWindow(biteManager.b2 + _clearGrace);
   }
 
   /// Enables the wake-lock (if not already held) and (re)arms the release
-  /// timer so the screen stays on for [_keepAwakeWindow] from now.
-  void _keepAwakeForWindow() {
+  /// timer so the screen stays on for [window] from now.
+  void _keepAwakeForWindow(Duration window) {
     if (!widget.isActive) return;
     _releaseTimer?.cancel();
-    _releaseTimer = Timer(_keepAwakeWindow, _releaseWakelock);
+    _releaseTimer = Timer(window, _releaseWakelock);
     if (!_wakeEnabled) {
       _wakeEnabled = true;
       WakelockPlus.enable();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   provider: ^6.1.5+1
   share_plus: ^12.0.1
   shared_preferences: ^2.5.4
+  wakelock_plus: ^1.2.8
 
 dev_dependencies:
   fake_async: ^1.3.3


### PR DESCRIPTION
Logging a meal is stop-start, and the gaps between bites can outlast the
system screen timeout, blanking the screen mid-meal. The Bite screen now
holds a wake-lock for a rolling 15s after each tap (via wakelock_plus),
releasing it once the window lapses, when the tab is hidden, when the app
is backgrounded, or on dispose.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xey64aePr35JSHb2zBeaJM