### PR TITLE
fix: center bite screen content on full screen width

### DIFF
--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -259,6 +259,12 @@ The Bite screen content is currently left-justified; it should be horizontally c
 - [x] Center the Bite screen's content horizontally (explicit `CrossAxisAlignment.center` on the
       column plus `TextAlign.center` on the loose labels), matching the layout intent of the
       other tabs
+- [x] Constrain the column to full width (`SizedBox(width: double.infinity)`). This was the
+      missing piece: `CrossAxisAlignment.center` only centers *within the column's own width*, and
+      inside `AppShell`'s `IndexedStack` (loose sizing, `topStart` alignment) the bare column shrank
+      to the button's width and pinned left — so the content sat left of the centered app-bar title
+      until it was forced to full width. The other tabs avoid this because their scroll views
+      (`CustomScrollView`/`ListView`) already fill the width.
 - [x] Verify the tap button, count, and pacing message all read as centered
 
 **Phase 10 — Elapsed-time timer up to the clear threshold**

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -292,3 +292,36 @@ historical bite's zone can no longer be reconstructed (§2b). Extend the backup 
       preserve the null-vs-empty semantics for older archives that lack the entry (leave existing
       config untouched when absent)
 - [ ] Ensure a default config still seeds correctly when restoring a pre-config backup
+
+**Phase 12 — Fold the pacing feedback into the button**
+
+Today the pacing zone shows as a separate banner (`PacingIndicator`, Phase 5) sitting above the
+tap button, while the button itself is a static teal circle labelled "Bite". Merge the two: the
+**button** becomes the pacing surface — its fill takes the current zone colour (red / amber /
+green) and a short one-or-two-word label inside it names the zone — and the standalone banner is
+removed. Fewer things on screen, and the feedback lives right where your thumb already is.
+
+This restyles the Phase 5 visualization surface; it does **not** change the pacing behaviour,
+timing, or `§0` principles. In particular: logging stays **feedback, not lockout** — the button
+is fully tappable in every zone, including red, and a tap always logs a bite immediately. The
+colour still never green-lights an early bite (red/amber mean "still costly"), and reaching `b2`
+remains the only readiness cue.
+
+- [ ] Add a short `label` to the per-zone constants (e.g. `Too soon` / `Hold on` / `Clear`),
+      alongside the existing colour/icon/message, keeping them fixed app constants (not theme
+      teal) so the red/amber/green semantics stay stable — reuse the zone styling that currently
+      lives in `PacingIndicator` rather than duplicating the colour values
+- [ ] Drive `_BiteButton`'s fill from the current `PacingZone` colour instead of
+      `colorScheme.primary`, animating the colour change (the existing ~250 ms ease already used
+      by the banner) so zone transitions don't snap
+- [ ] Replace the button's static "Bite" text with the zone label, keeping the icon and ensuring
+      the on-colour text/icon stay legible against all three fills (contrast check on amber in
+      particular); the button keeps its `Semantics(button: true, label: 'Log a bite')` so the
+      action is still announced independently of the visual zone label
+- [ ] Remove the standalone `PacingIndicator` from the Bite screen (and delete the widget if it
+      has no other use), reflowing the column now that the banner is gone
+- [ ] Confirm the static clear state on open (no recent bite) shows a green "Clear" button with no
+      ticker running, and that a tap immediately flips it to the red "Too soon" state
+- [ ] Keep this consistent with Phase 10 if implemented — the elapsed-time readout still hides at
+      `b2`; decide whether it sits under the button or inside it now that the button carries the
+      zone label

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -111,41 +111,49 @@ class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(24.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const Spacer(),
-              Text(
-                "Today's Bites",
-                textAlign: TextAlign.center,
-                style: theme.textTheme.titleMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w500,
-                  letterSpacing: 0.5,
+          // Force full width so the centered column spans the whole screen.
+          // Unlike the other tabs (scroll views that fill width), this page is
+          // a bare Column; inside the app shell's IndexedStack (loose sizing,
+          // topStart alignment) it would otherwise shrink to the button's width
+          // and pin left, leaving the content off-centre from the app-bar title.
+          child: SizedBox(
+            width: double.infinity,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Spacer(),
+                Text(
+                  "Today's Bites",
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w500,
+                    letterSpacing: 0.5,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '${biteManager.todayCount}',
-                style: theme.textTheme.displayLarge?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: theme.colorScheme.primary,
+                const SizedBox(height: 8),
+                Text(
+                  '${biteManager.todayCount}',
+                  style: theme.textTheme.displayLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
                 ),
-              ),
-              const Spacer(),
-              PacingIndicator(zone: biteManager.pacingZone),
-              const SizedBox(height: 24),
-              _BiteButton(onTap: _handleBite),
-              const Spacer(),
-              Text(
-                'Tap for each bite',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
+                const Spacer(),
+                PacingIndicator(zone: biteManager.pacingZone),
+                const SizedBox(height: 24),
+                _BiteButton(onTap: _handleBite),
+                const Spacer(),
+                Text(
+                  'Tap for each bite',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 16),
-            ],
+                const SizedBox(height: 16),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

Phase 9 of the bite pacing plan ("center the Bite screen content") added `CrossAxisAlignment.center` + `TextAlign.center`, but the content still rendered left of the centered app-bar title.

**Root cause:** the pages live in `AppShell`'s `IndexedStack`, which uses loose sizing and `topStart` alignment and sizes to its widest child. The other tabs use scroll views that fill full width, so they stretch the stack across the screen. The Bite page was a bare `Column`, which shrank to its widest child (the 220px button) and got pinned to the left. `CrossAxisAlignment.center` only centers within the column's own width, so it looked internally centered but sat off to the left.

**Fix:** wrap the column in a full-width `SizedBox` so the centered content spans the whole screen and lines up under the "Bite" title.

## Testing

- `flutter analyze` — clean
- `flutter test` — 111 passing (via pre-push hook)
- Verified visually on a local emulator: content now centered under the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)