### PR TITLE
feat: export/import pacing_config in backup archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-FoodLocker is a Flutter (mobile, primarily Android) app for tracking daily weight and derived health stats. Data is stored locally with Hive CE; state is exposed to the UI via Provider. Despite the name and README, the shipped feature set is weight tracking and analytics (a `food`/`days` feature described in the README no longer exists in `lib/`).
+FoodLocker is a Flutter (mobile, primarily Android) app with two shipped features: daily **weight** tracking + analytics, and in-meal **bite** counting + pacing. State is exposed to the UI via Provider. The two features use different local stores: weight is on Hive CE, bite is on Drift/SQLite (see Architecture). Despite the name and README, those are the whole feature set (a `food`/`days` feature described in the README no longer exists in `lib/`).
 
 ## Commands
 
@@ -14,18 +14,18 @@ FoodLocker is a Flutter (mobile, primarily Android) app for tracking daily weigh
 - `flutter test test/features/weight/weight_manager_test.dart` — run a single test file
 - `flutter test --name "substring"` — run tests whose description matches
 - `flutter run` — run on a connected device/emulator (see `.agents/skills/flutter-emulator-run/SKILL.md` for the emulator workflow)
-- `dart run build_runner build --delete-conflicting-outputs` — regenerate Hive adapters after changing any `@HiveType`/`@HiveField` model
+- `dart run build_runner build --delete-conflicting-outputs` — regenerate generated code: Hive adapters after changing a `@HiveType`/`@HiveField` model, and the Drift database (`bite_database.g.dart`) after changing a bite table
 - `./setup.sh` — one-time local setup; points `core.hooksPath` at `.githooks`
 
 `flutter analyze` and `flutter test` both gate pushes locally (`.githooks/pre-push`) and PRs to `main` (`.github/workflows/flutter_ci.yml`). Run them before pushing.
 
 ## Code Generation
 
-`*.g.dart` files (e.g. `lib/features/weight/data/weight.g.dart`) and `lib/hive_registrar.g.dart` are generated and checked in — do not edit them by hand. After adding or changing a Hive model, or adding a new `@HiveType`, rerun `build_runner`. Hive `typeId`s must be unique and stable across the app's history (weight uses 3 and 4); reusing an old id breaks existing users' stored boxes, so pick a fresh id rather than renumbering.
+`*.g.dart` files (e.g. `lib/features/weight/data/weight.g.dart`, `lib/features/bite/data/bite_database.g.dart`) and `lib/hive_registrar.g.dart` are generated and checked in — do not edit them by hand. After adding or changing a Hive model, or adding a new `@HiveType`, rerun `build_runner`. Hive `typeId`s must be unique and stable across the app's history (weight uses 3 and 4); reusing an old id breaks existing users' stored boxes, so pick a fresh id rather than renumbering. The bite store is Drift: rerun `build_runner` after changing a `@DriftDatabase` table, and bump `BiteDatabase.schemaVersion` with a matching migration so existing users' SQLite files upgrade.
 
 ## Architecture
 
-Code is organized as `lib/features/<feature>/data` (domain + persistence) and `lib/ui` (`pages/`, `widgets/`, shell, theme). The dependency wiring lives in `lib/main.dart`: Hive is initialized, the `weights` box is opened, and everything is provided through a `MultiProvider` before `runApp`. `AppShell` is a three-tab `BottomNavigationBar` (Home / Weight / Settings) over an `IndexedStack`.
+Code is organized as `lib/features/<feature>/data` (domain + persistence) and `lib/ui` (`pages/`, `widgets/`, shell, theme). The dependency wiring lives in `lib/main.dart`: Hive is initialized and the `weights` box opened, the Drift `BiteDatabase` is opened, and both features' repositories/managers are provided through a `MultiProvider` before `runApp`. `AppShell` is a four-tab `BottomNavigationBar` (Home / Weight / Bite / Settings) over an `IndexedStack`.
 
 Key layering for the weight feature:
 
@@ -36,13 +36,19 @@ Key layering for the weight feature:
 
 Dates are treated as day-granular throughout: repository keys and equality normalize to `(year, month, day)`, so "one entry per day" is the invariant. When adding mutation paths, follow the existing pattern (write through the repository, then refresh `_weights` from it).
 
+The bite feature mirrors this shape (interface + manager) on Drift instead of Hive:
+
+- **`BiteDatabase`** (`bite_database.dart`) — two tables: `bites` (append-only `at_ms` epoch-millis log; only the raw timestamp is stored) and `pacing_config` (versioned `b1_s`/`b2_s` thresholds, a slowly-changing dimension seeded with a default on first run).
+- **`BiteRepository`** — persistence interface; `DriftBiteRepository` is the production impl, injected as a `Provider<BiteRepository>`.
+- **`BiteManager extends ChangeNotifier`** — UI state for the Bite tab: owns today's count and drives the pacing ticker/zone in memory. Counts, inter-bite deltas, and pacing zones (`PacingZone`) are all **derived at read time** from the stored timestamps, never persisted.
+
 ### Backup / restore
 
-`SerializationService` (Settings tab) exports/imports one zip spanning **both** stores. Each dataset owns a per-store codec — `WeightBackupCodec` (`weight.csv`) and `BiteBackupCodec` (`bites.csv`, storing only the raw `at_ms`) — and `SerializationService` coordinates them into a single archive. `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable; it always replaces weights, and replaces bites only when the archive actually carries a bite entry (an older weight-only backup leaves bites untouched), deduping repeated instants on import. Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
+`SerializationService` (Settings tab) exports/imports one zip spanning **both** stores. Each dataset owns a per-store codec — `WeightBackupCodec` (`weight.csv`), `BiteBackupCodec` (`bites.csv`, raw `at_ms`), and `PacingConfigBackupCodec` (`pacing_config.csv`, the threshold versions) — and `SerializationService` coordinates them into a single archive. `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable; it always replaces weights, and replaces bites / pacing config only when the archive actually carries that entry (an older backup missing an entry leaves that store untouched), deduping on import (repeated instants for bites, repeated `effective_ms` for config). Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
 
 ## Testing
 
-Tests mirror `lib/` under `test/`. Prefer `InMemoryWeightRepository` over Hive in unit tests. `test/features/weight/hive_ce_migration_test.dart` guards persistence/migration behavior — treat it as a compatibility contract when touching models or `typeId`s.
+Tests mirror `lib/` under `test/`. Prefer `InMemoryWeightRepository` over Hive in unit tests; for bite tests use `BiteDatabase.forTesting(NativeDatabase.memory())` or a fake `BiteRepository`. `test/features/weight/hive_ce_migration_test.dart` guards persistence/migration behavior — treat it as a compatibility contract when touching models or `typeId`s.
 
 ## Commit Messages & Releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-FoodLocker is a Flutter (mobile, primarily Android) app with two shipped features: daily **weight** tracking + analytics, and in-meal **bite** counting + pacing. State is exposed to the UI via Provider. The two features use different local stores: weight is on Hive CE, bite is on Drift/SQLite (see Architecture). Despite the name and README, those are the whole feature set (a `food`/`days` feature described in the README no longer exists in `lib/`).
+FoodLocker is a Flutter (mobile, primarily Android) app with two shipped features: daily **weight** tracking + analytics, and in-meal **bite** counting + pacing. State is exposed to the UI via Provider. The two features use different local stores: weight is on Hive CE, bite is on Drift/SQLite (see Architecture). Despite the app's name, there is no food-logging feature; a former `food`/`days` feature no longer exists in `lib/`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # FoodLocker
 
-A Flutter application for tracking your daily weight and understanding your progress over time. FoodLocker stores everything locally using `Hive CE` and uses `Provider` for state management.
+A Flutter application for tracking your daily weight and pacing your eating, one bite at a time. FoodLocker stores everything locally and uses `Provider` for state management.
 
 ## Features
 
 - **Daily Weight Tracking**: Log one weight entry per day, in kilograms or pounds.
 - **Analytics & Insights**: See your lowest weight all-time and over the last 7 / 30 days, plus "clean" vs. "overeating" streaks derived from day-over-day changes.
 - **Weight History & Chart**: Browse past entries and visualize trends with a chart (`fl_chart`).
-- **Backup & Restore**: Export your data to a zip file and import it back later from the Settings tab.
-- **Persistent Storage**: Data is saved locally using [Hive CE](https://pub.dev/packages/hive_ce), so your records survive app restarts.
+- **Bite Counting & Pacing**: Tap once per bite to count your bites for the day, with a colour-coded timer that paces you between bites (too soon → hold on → clear) and a haptic buzz when it's a good time for the next one. Bites are never blocked — the pacing is feedback, not a lockout.
+- **Backup & Restore**: Export all your data — weight and bites — to a zip file and import it back later from the Settings tab.
+- **Persistent Storage**: Data is saved locally — weight in [Hive CE](https://pub.dev/packages/hive_ce) and bites in [Drift](https://pub.dev/packages/drift)/SQLite — so your records survive app restarts.
 - **State Management**: Uses the [Provider](https://pub.dev/packages/provider) package for state management across the app.
 
 ## Getting Started
@@ -47,7 +48,7 @@ A Flutter application for tracking your daily weight and understanding your prog
 
 ### Code Generation
 
-This project uses `build_runner` for code generation (e.g. for Hive CE adapters). If you change a model that requires code generation, regenerate the `*.g.dart` files:
+This project uses `build_runner` for code generation (Hive CE adapters and the Drift database). If you change a model or Drift table that requires code generation, regenerate the `*.g.dart` files:
 
 ```bash
 dart run build_runner build --delete-conflicting-outputs
@@ -55,7 +56,7 @@ dart run build_runner build --delete-conflicting-outputs
 
 ## Project Structure
 
-- `lib/features`: Feature-specific domain and persistence code (e.g. `weight`, `settings`).
+- `lib/features`: Feature-specific domain and persistence code (e.g. `weight`, `bite`, `settings`).
 - `lib/ui`: UI pages, widgets, the app shell, and theme.
 - `lib/core`: Shared helpers (CSV serialization, query utilities).
 - `lib/main.dart`: Application entry point and dependency wiring.

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -2,6 +2,10 @@
 
 A phased plan to add bite counting and timer-based pacing to Food Locker.
 
+> **Status: done.** Every phase below is shipped. This document is kept for
+> reference only — it records the design rationale (the `§`-sections that source
+> comments cite), not outstanding work.
+
 ---
 
 ## 0. Guiding principles

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -283,15 +283,17 @@ timer disappears.
 Backup currently exports only `bites.csv` (raw `at_ms` timestamps); the `pacing_config`
 table — the versioned thresholds — is left out, so a restore loses the config history and any
 historical bite's zone can no longer be reconstructed (§2b). Extend the backup to carry it too.
-- [ ] Add a per-store CSV entry for the pacing config (e.g. `pacing_config.csv` with
+- [x] Add a per-store CSV entry for the pacing config (`pacing_config.csv` with
       `effective_ms`, `b1_s`, `b2_s`, one row per version), following the `BiteBackupCodec` /
-      `bites.csv` pattern
-- [ ] Have `SerializationService` pack it into the same archive and route it through the
-      repository seam on both export and import
-- [ ] On import, replace/merge the config versions consistently with how bites are restored;
-      preserve the null-vs-empty semantics for older archives that lack the entry (leave existing
-      config untouched when absent)
-- [ ] Ensure a default config still seeds correctly when restoring a pre-config backup
+      `bites.csv` pattern (`PacingConfigBackupCodec`)
+- [x] Have `SerializationService` pack it into the same archive and route it through the
+      repository seam on both export (`allPacingConfigs`) and import (`clearPacingConfigs` +
+      `setPacingConfig`)
+- [x] On import, replace/merge the config versions consistently with how bites are restored
+      (clear then re-insert, deduped by `effective_ms`); preserve the null-vs-empty semantics for
+      older archives that lack the entry (leave existing config untouched when absent)
+- [x] Ensure a default config still seeds correctly when restoring a pre-config backup (the
+      absent-entry case leaves the seeded default in place)
 
 **Phase 12 — Fold the pacing feedback into the button**
 

--- a/docs/bite_pacing_plan.md
+++ b/docs/bite_pacing_plan.md
@@ -3,8 +3,9 @@
 A phased plan to add bite counting and timer-based pacing to Food Locker.
 
 > **Status: done.** Every phase below is shipped. This document is kept for
-> reference only — it records the design rationale (the `§`-sections that source
-> comments cite), not outstanding work.
+> reference only — it records the design rationale behind the bite feature (why
+> Drift for bites, why the versioned pacing config, and the §0 principles the
+> pacing behaviour rests on), not outstanding work.
 
 ---
 

--- a/lib/features/bite/data/bite_database.dart
+++ b/lib/features/bite/data/bite_database.dart
@@ -36,8 +36,8 @@ class Bites extends Table {
 /// no separate boundaries table is needed.
 @DataClassName('PacingConfig')
 class PacingConfigs extends Table {
-  /// The table name follows the plan's schema (`pacing_config`); the drift
-  /// accessor stays `pacingConfigs` (derived from the Dart class name).
+  /// The SQL table is `pacing_config`; the drift accessor stays `pacingConfigs`
+  /// (derived from the Dart class name).
   @override
   String get tableName => 'pacing_config';
 
@@ -74,7 +74,7 @@ class BiteDatabase extends _$BiteDatabase {
       await m.createAll();
     },
     onUpgrade: (m, from, to) async {
-      // v1 (Phase 1) shipped with only `bites`; v2 adds `pacing_config`.
+      // v1 shipped with only `bites`; v2 adds `pacing_config`.
       if (from < 2) {
         await m.createTable(pacingConfigs);
       }

--- a/lib/features/bite/data/bite_repository.dart
+++ b/lib/features/bite/data/bite_repository.dart
@@ -43,12 +43,26 @@ abstract interface class BiteRepository {
   /// effective instant is at or before it, or null if none precedes it.
   Future<PacingConfig?> pacingConfigAt(DateTime instant);
 
+  /// Every pacing-config version, in chronological (effective-instant) order.
+  ///
+  /// The backup exports the whole history, not just the current version, so a
+  /// restore can still reconstruct the zone of any historical bite.
+  Future<List<PacingConfig>> allPacingConfigs();
+
   /// Deletes every logged bite.
   ///
   /// The clear half of the clear-then-restore import path (§1c): a backup is a
   /// full snapshot of the bite log, so restoring replaces it. The pacing-config
-  /// history is deliberately left intact — it is a separate slowly-changing
-  /// dimension the CSV backup doesn't carry, and wiping it would drop the
-  /// seeded default and any retuned thresholds.
+  /// history is deliberately left intact — it is cleared separately via
+  /// [clearPacingConfigs] only when a backup actually carries replacement
+  /// versions, so a bite-only or weight-only restore keeps the thresholds.
   Future<void> clearBites();
+
+  /// Deletes every pacing-config version.
+  ///
+  /// The clear half of the config restore: a backup that carries pacing config
+  /// is a full snapshot of the threshold history, so restoring replaces it.
+  /// Kept distinct from [clearBites] so the bite log and the config history are
+  /// cleared independently — a bite restore never touches the thresholds.
+  Future<void> clearPacingConfigs();
 }

--- a/lib/features/bite/data/bite_repository.dart
+++ b/lib/features/bite/data/bite_repository.dart
@@ -1,10 +1,10 @@
 import 'package:food_locker/features/bite/data/bite_database.dart';
 
-/// The seam in front of the bite dataset (§1b of the pacing plan).
+/// The seam in front of the bite dataset.
 ///
 /// The rest of the app depends on this interface, never on the engine backing
 /// it — today Drift/SQLite, but that choice stays an implementation detail. It
-/// is the single place the two-store tax (§1c) gets coordinated, and it keeps
+/// is the single place the weight and bite stores get coordinated, and it keeps
 /// the bite store independently testable.
 ///
 /// The [Bite] and [PacingConfig] data classes it trades in are plain,
@@ -12,15 +12,15 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 /// greenfield feature carry no query machinery), so exposing them here doesn't
 /// leak the engine.
 abstract interface class BiteRepository {
-  /// Records a single bite at [at]. One tap = one bite; never blocked
-  /// (§3a) — the timestamp is persisted immediately.
+  /// Records a single bite at [at]. One tap = one bite; never blocked — the
+  /// timestamp is persisted immediately.
   Future<void> logBite(DateTime at);
 
   /// The most recent bite, or null if none has been logged.
   ///
   /// The reference point for the pacing ticker: the live view seeds itself from
-  /// this once per session and derives every zone from `now − lastBite` in
-  /// memory thereafter (§3b).
+  /// this once per session and derives every zone in memory thereafter from the
+  /// time since that bite.
   Future<Bite?> lastBite();
 
   /// Every bite whose timestamp falls in the half-open window `[from, to)`,
@@ -28,12 +28,12 @@ abstract interface class BiteRepository {
   Future<List<Bite>> bitesInRange(DateTime from, DateTime to);
 
   /// The number of bites in the half-open window `[from, to)` — the headline
-  /// metric (§3c). Callers pass a local day's bounds for "today's count".
+  /// metric. Callers pass a local day's bounds for "today's count".
   Future<int> biteCount(DateTime from, DateTime to);
 
   /// Appends [cfg] as a new pacing-config version (a config-change marker).
   ///
-  /// Thresholds are a slowly-changing dimension (§2b): retuning appends rather
+  /// Thresholds are a slowly-changing dimension: retuning appends rather
   /// than mutates, so every past bite stays gradable against the version
   /// effective at its own timestamp. The version takes effect from
   /// [PacingConfig.effectiveMs]; its [PacingConfig.id] is assigned by the store.
@@ -51,7 +51,7 @@ abstract interface class BiteRepository {
 
   /// Deletes every logged bite.
   ///
-  /// The clear half of the clear-then-restore import path (§1c): a backup is a
+  /// The clear half of the clear-then-restore import path: a backup is a
   /// full snapshot of the bite log, so restoring replaces it. The pacing-config
   /// history is deliberately left intact — it is cleared separately via
   /// [clearPacingConfigs] only when a backup actually carries replacement

--- a/lib/features/bite/data/drift_bite_repository.dart
+++ b/lib/features/bite/data/drift_bite_repository.dart
@@ -5,9 +5,9 @@ import 'package:food_locker/features/bite/data/bite_repository.dart';
 /// Drift/SQLite-backed [BiteRepository].
 ///
 /// Every range in this store is a half-open `[from, to)` window over `at_ms`
-/// (epoch millis), which is what the plan's day-granular counts expect: a
-/// local day is `[startOfDay, startOfNextDay)`, so consecutive days never
-/// double-count the boundary instant.
+/// (epoch millis), which is what the day-granular counts expect: a local day is
+/// `[startOfDay, startOfNextDay)`, so consecutive days never double-count the
+/// boundary instant.
 class DriftBiteRepository implements BiteRepository {
   DriftBiteRepository(this._db);
 

--- a/lib/features/bite/data/drift_bite_repository.dart
+++ b/lib/features/bite/data/drift_bite_repository.dart
@@ -78,7 +78,19 @@ class DriftBiteRepository implements BiteRepository {
   }
 
   @override
+  Future<List<PacingConfig>> allPacingConfigs() {
+    return (_db.select(_db.pacingConfigs)
+          ..orderBy([(c) => OrderingTerm.asc(c.effectiveMs)]))
+        .get();
+  }
+
+  @override
   Future<void> clearBites() async {
     await _db.delete(_db.bites).go();
+  }
+
+  @override
+  Future<void> clearPacingConfigs() async {
+    await _db.delete(_db.pacingConfigs).go();
   }
 }

--- a/lib/features/bite/data/pacing_zone.dart
+++ b/lib/features/bite/data/pacing_zone.dart
@@ -1,9 +1,9 @@
-/// The three pacing zones a bite can fall into (§3b of the pacing plan).
+/// The three pacing zones a bite can fall into.
 ///
 /// A zone is a *derived* view, never stored: it is always computed at read time
-/// from `now − lastBite` against the two boundaries of the effective
-/// `PacingConfig`. The zones are the ranges those two boundaries cut —
-/// `[0, b1)` too soon, `[b1, b2)` ok — hold on, `[b2, ∞)` in the clear.
+/// from the time since the last bite against the two boundaries of the
+/// effective `PacingConfig`. The zones are the ranges those two boundaries
+/// cut — `[0, b1)` too soon, `[b1, b2)` ok — hold on, `[b2, ∞)` in the clear.
 ///
 /// The zone expresses *how costly it is to bite right now*, decreasing to zero
 /// once you're clear — so the colour never falsely green-lights an early bite.

--- a/lib/features/settings/data/bite_backup_codec.dart
+++ b/lib/features/settings/data/bite_backup_codec.dart
@@ -2,14 +2,14 @@ import 'package:archive/archive.dart';
 import 'package:food_locker/core/csv_serializer.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 
-/// CSV backup logic for the bite log (§1c of the pacing plan).
+/// CSV backup logic for the bite log.
 ///
 /// The two stores each own their own codec; this one turns the bite dataset
 /// into a `bites.csv` entry that `SerializationService` packs into the same zip
 /// as the weight CSV. Only the raw fact is exported — the epoch-millis
-/// timestamp of each bite — following the plan's "store facts, derive views"
-/// rule: counts, deltas, and pacing zones are all reconstructable from the
-/// timestamps, so exporting them verbatim keeps the backup lossless.
+/// timestamp of each bite: counts, deltas, and pacing zones are all
+/// reconstructable from the timestamps, so exporting them verbatim keeps the
+/// backup lossless.
 class BiteBackupCodec {
   /// The bite dataset's entry inside a backup zip.
   static const String biteFileName = 'bites.csv';

--- a/lib/features/settings/data/pacing_config_backup_codec.dart
+++ b/lib/features/settings/data/pacing_config_backup_codec.dart
@@ -1,0 +1,89 @@
+import 'package:archive/archive.dart';
+import 'package:food_locker/core/csv_serializer.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+
+/// CSV backup logic for the versioned pacing thresholds.
+///
+/// The `pacing_config` table is a slowly-changing dimension: every historical
+/// bite's zone is only reconstructable from the threshold version effective at
+/// its timestamp, so leaving it out of the backup would lose that history on a
+/// restore. This codec turns the config versions into a `pacing_config.csv`
+/// entry that `SerializationService` packs into the same zip as the weight and
+/// bite CSVs.
+///
+/// Only the facts that define a version are exported — `effective_ms`, `b1_s`,
+/// `b2_s`. The autoincrement `id` is an insertion-order artifact of the current
+/// store, not a fact worth preserving, so it is dropped exactly as the bite
+/// codec drops its own id.
+class PacingConfigBackupCodec {
+  /// The pacing-config dataset's entry inside a backup zip.
+  static const String pacingConfigFileName = 'pacing_config.csv';
+
+  const PacingConfigBackupCodec();
+
+  /// The pacing-config CSV packaged as a single [ArchiveFile], so it can be
+  /// added to a shared archive that also carries the weight and bite CSVs.
+  ArchiveFile toArchiveFile(List<PacingConfig> configs) {
+    final csvContent = generatePacingConfigCsv(configs);
+    return ArchiveFile(
+      pacingConfigFileName,
+      csvContent.length,
+      csvContent.codeUnits,
+    );
+  }
+
+  /// One row per config version: its effective instant and the two boundaries,
+  /// in the store's chronological order.
+  String generatePacingConfigCsv(List<PacingConfig> configs) {
+    final items = configs
+        .map((c) => {
+              'effective_ms': c.effectiveMs,
+              'b1_s': c.b1S,
+              'b2_s': c.b2S,
+            })
+        .toList();
+    return CsvSerializer.toCSV(items);
+  }
+
+  /// The config versions carried by a decoded [archive], or null when the
+  /// archive has no pacing-config entry at all.
+  ///
+  /// The null vs. empty distinction is load-bearing on import (mirroring the
+  /// bite codec): a pre-config backup simply doesn't describe the thresholds,
+  /// so its absence must leave the existing config history untouched — whereas
+  /// a present-but-empty entry is a real snapshot and does replace it.
+  List<PacingConfig>? fromArchive(Archive archive) {
+    for (final file in archive) {
+      if (file.isFile && file.name == pacingConfigFileName) {
+        final content = String.fromCharCodes(file.content as List<int>);
+        return parsePacingConfigCsv(content);
+      }
+    }
+    return null;
+  }
+
+  /// Parses the pacing-config CSV back into versions, one per valid row, in
+  /// file order. Rows missing any of the three integer fields are dropped — the
+  /// validation half of "validate / dedupe on import". Deduplication of
+  /// repeated versions is left to the import coordinator.
+  ///
+  /// The reconstructed [PacingConfig] carries a placeholder `id` of 0: the id
+  /// is store-assigned on insert (`setPacingConfig` ignores it), so it is never
+  /// round-tripped through the backup.
+  List<PacingConfig> parsePacingConfigCsv(String csv) {
+    final result = <PacingConfig>[];
+    for (final item in CsvSerializer.fromCSV(csv)) {
+      final effectiveMs = _asInt(item['effective_ms']);
+      final b1S = _asInt(item['b1_s']);
+      final b2S = _asInt(item['b2_s']);
+      if (effectiveMs == null || b1S == null || b2S == null) continue;
+      result.add(
+        PacingConfig(id: 0, effectiveMs: effectiveMs, b1S: b1S, b2S: b2S),
+      );
+    }
+    return result;
+  }
+
+  int? _asInt(Object? raw) =>
+      raw is int ? raw : int.tryParse(raw?.toString() ?? '');
+}

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
+import 'package:food_locker/features/settings/data/pacing_config_backup_codec.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
@@ -36,7 +37,12 @@ class SerializationService {
 
     if (weights.isEmpty && bites.isEmpty) return;
 
-    final zipData = encodeBackup(weights, bites);
+    // Pacing config rides along with real data rather than gating the export:
+    // the default is always seeded, so it never on its own makes a backup
+    // "non-empty".
+    final configs = await biteRepo.allPacingConfigs();
+
+    final zipData = encodeBackup(weights, bites, configs);
 
     final tempDir = await getTemporaryDirectory();
     final zipFile = File('${tempDir.path}/${generateZipFileName()}');
@@ -46,14 +52,20 @@ class SerializationService {
     await Share.shareXFiles([XFile(zipFile.path)], text: 'Food Locker Backup');
   }
 
-  /// Packs both datasets into a single backup zip. Each store owns its own
-  /// codec (§1c two-store tax); the coordination — one archive, one file per
-  /// dataset — lives here so a single export call spans both stores.
+  /// Packs every dataset into a single backup zip — weights, bites, and the
+  /// pacing-config history. Each dataset owns its own codec; the coordination —
+  /// one archive, one file per dataset — lives here so a single export call
+  /// spans both stores.
   @visibleForTesting
-  List<int> encodeBackup(List<Weight> weights, List<Bite> bites) {
+  List<int> encodeBackup(
+    List<Weight> weights,
+    List<Bite> bites,
+    List<PacingConfig> configs,
+  ) {
     final archive = Archive()
       ..addFile(const WeightBackupCodec().toArchiveFile(weights))
-      ..addFile(const BiteBackupCodec().toArchiveFile(bites));
+      ..addFile(const BiteBackupCodec().toArchiveFile(bites))
+      ..addFile(const PacingConfigBackupCodec().toArchiveFile(configs));
     return ZipEncoder().encode(archive);
   }
 
@@ -117,6 +129,21 @@ class SerializationService {
         // the same file — never double-logs a bite.
         if (seen.add(at.millisecondsSinceEpoch)) {
           await biteRepo.logBite(at);
+        }
+      }
+    }
+
+    final configs = const PacingConfigBackupCodec().fromArchive(archive);
+    if (configs != null) {
+      // Same null-vs-empty contract as bites: a pre-config (older) backup has
+      // no entry and leaves the seeded thresholds alone; a present entry is a
+      // full snapshot and replaces the history. Dedupe by effective instant,
+      // which keys a version.
+      await biteRepo.clearPacingConfigs();
+      final seen = <int>{};
+      for (final cfg in configs) {
+        if (seen.add(cfg.effectiveMs)) {
+          await biteRepo.setPacingConfig(cfg);
         }
       }
     }

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -102,8 +102,8 @@ class SerializationService {
   /// [importData], kept separate from the file-picker and file-I/O plumbing so
   /// the clear-then-restore path stays unit-testable.
   ///
-  /// The single decode is the coordination point for the two-store tax (§1c):
-  /// weights and bites are restored from the same archive. Weights are always
+  /// The single decode is where the two stores are coordinated: weights and
+  /// bites are restored from the same archive. Weights are always
   /// replaced; bites are replaced only when the archive actually carries a bite
   /// entry, so restoring an older weight-only backup leaves existing bites
   /// alone rather than wiping them.

--- a/lib/features/settings/data/weight_backup_codec.dart
+++ b/lib/features/settings/data/weight_backup_codec.dart
@@ -20,7 +20,7 @@ class WeightBackupCodec {
   }
 
   /// The weight CSV packaged as a single [ArchiveFile], so it can be added to a
-  /// shared archive that also carries other datasets (§1c two-store backup).
+  /// shared archive that also carries the other datasets' CSVs.
   ArchiveFile toArchiveFile(List<Weight> weights) {
     final csvContent = generateWeightCsv(weights);
     return ArchiveFile(weightFileName, csvContent.length, csvContent.codeUnits);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: food_locker
-description: "A new Flutter project."
+description: "Track your daily weight and pace your eating one bite at a time — a local-first Flutter app."
 publish_to: 'none'
 version: 1.11.0
 

--- a/test/features/bite/data/bite_database_test.dart
+++ b/test/features/bite/data/bite_database_test.dart
@@ -2,8 +2,8 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 
-/// Phase 1 verification: the Drift database opens and a bite row round-trips.
-/// Phase 2 verification: `pacing_config` seeds a default and resolves by instant.
+/// The Drift database opens and a bite row round-trips, and `pacing_config`
+/// seeds a default and resolves the effective version by instant.
 void main() {
   late BiteDatabase db;
 

--- a/test/features/bite/data/bite_manager_pacing_test.dart
+++ b/test/features/bite/data/bite_manager_pacing_test.dart
@@ -224,5 +224,11 @@ class _FakeBiteRepository implements BiteRepository {
   Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
 
   @override
+  Future<List<PacingConfig>> allPacingConfigs() async => [?config];
+
+  @override
   Future<void> clearBites() async => _bites.clear();
+
+  @override
+  Future<void> clearPacingConfigs() async {}
 }

--- a/test/features/bite/data/bite_manager_test.dart
+++ b/test/features/bite/data/bite_manager_test.dart
@@ -4,9 +4,9 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
 
-/// Phase 4 verification: [BiteManager] logs bites through the repository and
-/// keeps today's count consistent with the store. An in-memory drift database
-/// stands in for the on-disk store, matching the repository tests.
+/// [BiteManager] logs bites through the repository and keeps today's count
+/// consistent with the store. An in-memory drift database stands in for the
+/// on-disk store, matching the repository tests.
 void main() {
   late BiteDatabase db;
   late DriftBiteRepository repo;

--- a/test/features/bite/data/drift_bite_repository_test.dart
+++ b/test/features/bite/data/drift_bite_repository_test.dart
@@ -4,9 +4,9 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
 
-/// Phase 3 verification: the [BiteRepository] seam over Drift. An in-memory
-/// drift database stands in for the on-disk store, so the seam is exercised
-/// without touching the filesystem.
+/// The [BiteRepository] seam over Drift. An in-memory drift database stands in
+/// for the on-disk store, so the seam is exercised without touching the
+/// filesystem.
 void main() {
   late BiteDatabase db;
   late BiteRepository repo;

--- a/test/features/bite/data/pacing_zone_test.dart
+++ b/test/features/bite/data/pacing_zone_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/pacing_zone.dart';
 
-/// Phase 5: the pure zone computation. Boundaries are half-open `[b1, b2)`, so a
-/// gap exactly on a boundary reads as the later (less costly) zone — matching
-/// the storage windows and the plan's zone table (§3b).
+/// The pure zone computation. Boundaries are half-open `[b1, b2)`, so a gap
+/// exactly on a boundary reads as the later (less costly) zone — matching the
+/// storage windows.
 void main() {
   const b1 = Duration(seconds: 15);
   const b2 = Duration(seconds: 30);

--- a/test/features/settings/data/pacing_config_backup_codec_test.dart
+++ b/test/features/settings/data/pacing_config_backup_codec_test.dart
@@ -1,0 +1,95 @@
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/settings/data/pacing_config_backup_codec.dart';
+
+void main() {
+  const codec = PacingConfigBackupCodec();
+
+  const v1 = PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30);
+  const v2 = PacingConfig(id: 2, effectiveMs: 5000, b1S: 10, b2S: 20);
+
+  group('PacingConfigBackupCodec CSV logic', () {
+    test('generatePacingConfigCsv writes one row per version', () {
+      final csv = codec.generatePacingConfigCsv([v1, v2]);
+
+      expect(csv, contains('effective_ms'));
+      expect(csv, contains('b1_s'));
+      expect(csv, contains('b2_s'));
+      expect(csv, contains('5000'));
+      expect(csv, contains('10'));
+      expect(csv, contains('20'));
+    });
+
+    test('generatePacingConfigCsv of no versions is empty', () {
+      expect(codec.generatePacingConfigCsv([]), isEmpty);
+    });
+  });
+
+  group('PacingConfigBackupCodec archive entry', () {
+    test('toArchiveFile names the entry pacing_config.csv', () {
+      final file = codec.toArchiveFile([v1]);
+      expect(file.name, PacingConfigBackupCodec.pacingConfigFileName);
+      expect(file.name, 'pacing_config.csv');
+    });
+
+    test('toArchiveFile content is the generated CSV', () {
+      final file = codec.toArchiveFile([v1, v2]);
+      final content = String.fromCharCodes(file.content as List<int>);
+      expect(content, codec.generatePacingConfigCsv([v1, v2]));
+    });
+  });
+
+  group('PacingConfigBackupCodec parsePacingConfigCsv', () {
+    test('round-trips generatePacingConfigCsv', () {
+      final parsed = codec.parsePacingConfigCsv(
+        codec.generatePacingConfigCsv([v1, v2]),
+      );
+
+      expect(parsed.map((c) => c.effectiveMs), [0, 5000]);
+      expect(parsed.map((c) => c.b1S), [15, 10]);
+      expect(parsed.map((c) => c.b2S), [30, 20]);
+    });
+
+    test('drops rows missing any of the three integer fields', () {
+      const csv = 'effective_ms,b1_s,b2_s\r\n'
+          '0,15,30\r\n' // valid
+          ',10,20\r\n' // missing effective_ms
+          '5000,,20\r\n' // missing b1_s
+          '6000,10,abc\r\n' // non-integer b2_s
+          '7000,10,20'; // valid
+      final parsed = codec.parsePacingConfigCsv(csv);
+
+      expect(parsed.map((c) => c.effectiveMs), [0, 7000]);
+    });
+
+    test('an empty CSV parses to no versions', () {
+      expect(codec.parsePacingConfigCsv(''), isEmpty);
+    });
+  });
+
+  group('PacingConfigBackupCodec fromArchive', () {
+    test('returns null when the archive has no pacing-config entry', () {
+      // A pre-config backup: absence must not be read as "no versions".
+      final archive = Archive()
+        ..addFile(ArchiveFile('weight.csv', 3, 'a,b'.codeUnits));
+
+      expect(codec.fromArchive(archive), isNull);
+    });
+
+    test('returns the parsed versions when the entry is present', () {
+      final archive = Archive()..addFile(codec.toArchiveFile([v1, v2]));
+
+      final parsed = codec.fromArchive(archive);
+      expect(parsed, isNotNull);
+      expect(parsed!.map((c) => c.effectiveMs), [0, 5000]);
+    });
+
+    test('returns an empty list for a present-but-empty entry', () {
+      // A real snapshot of "no versions", distinct from a missing entry.
+      final archive = Archive()..addFile(codec.toArchiveFile([]));
+
+      expect(codec.fromArchive(archive), isEmpty);
+    });
+  });
+}

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
+import 'package:food_locker/features/settings/data/pacing_config_backup_codec.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
@@ -32,6 +33,8 @@ class _RecordingWeightRepository extends InMemoryWeightRepository {
 class _RecordingBiteRepository implements BiteRepository {
   final List<String> operations = [];
   final List<int> loggedMs = [];
+  final List<String> configOperations = [];
+  final List<PacingConfig> savedConfigs = [];
 
   @override
   Future<void> clearBites() async {
@@ -46,6 +49,18 @@ class _RecordingBiteRepository implements BiteRepository {
   }
 
   @override
+  Future<void> clearPacingConfigs() async {
+    configOperations.add('clear');
+    savedConfigs.clear();
+  }
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async {
+    configOperations.add('set');
+    savedConfigs.add(cfg);
+  }
+
+  @override
   Future<Bite?> lastBite() => throw UnimplementedError();
 
   @override
@@ -57,11 +72,11 @@ class _RecordingBiteRepository implements BiteRepository {
       throw UnimplementedError();
 
   @override
-  Future<void> setPacingConfig(PacingConfig cfg) => throw UnimplementedError();
-
-  @override
   Future<PacingConfig?> pacingConfigAt(DateTime instant) =>
       throw UnimplementedError();
+
+  @override
+  Future<List<PacingConfig>> allPacingConfigs() => throw UnimplementedError();
 }
 
 void main() {
@@ -85,10 +100,11 @@ void main() {
     List<int> contentOf(Archive archive, String name) =>
         archive.files.firstWhere((f) => f.name == name).content as List<int>;
 
-    test('packs both datasets into one zip, one file each', () {
+    test('packs all three datasets into one zip, one file each', () {
       final zip = service.encodeBackup(
         [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
         [const Bite(id: 1, atMs: 1000)],
+        [const PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30)],
       );
 
       final archive = ZipDecoder().decodeBytes(zip);
@@ -96,6 +112,7 @@ void main() {
       expect(names, containsAll([
         WeightBackupCodec.weightFileName,
         BiteBackupCodec.biteFileName,
+        PacingConfigBackupCodec.pacingConfigFileName,
       ]));
     });
 
@@ -105,6 +122,7 @@ void main() {
       final zip = service.encodeBackup(
         [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
         [const Bite(id: 1, atMs: 1000)],
+        const [],
       );
 
       final weights = const WeightBackupCodec().decode(zip);
@@ -115,6 +133,7 @@ void main() {
       final zip = service.encodeBackup(
         const [],
         [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 31000)],
+        const [],
       );
 
       final archive = ZipDecoder().decodeBytes(zip);
@@ -123,6 +142,26 @@ void main() {
       );
       expect(csv, contains('1000'));
       expect(csv, contains('31000'));
+    });
+
+    test('the pacing-config entry holds the exported version values', () {
+      final zip = service.encodeBackup(
+        const [],
+        const [],
+        [
+          const PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30),
+          const PacingConfig(id: 2, effectiveMs: 5000, b1S: 10, b2S: 20),
+        ],
+      );
+
+      final archive = ZipDecoder().decodeBytes(zip);
+      final csv = String.fromCharCodes(
+        contentOf(archive, PacingConfigBackupCodec.pacingConfigFileName),
+      );
+      expect(csv, contains('effective_ms'));
+      expect(csv, contains('5000'));
+      expect(csv, contains('10'));
+      expect(csv, contains('20'));
     });
   });
 
@@ -182,6 +221,7 @@ void main() {
       final backup = service.encodeBackup(
         [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
         [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 31000)],
+        const [],
       );
 
       await service.restoreFromBackup(
@@ -201,6 +241,7 @@ void main() {
       final backup = service.encodeBackup(
         const [],
         [const Bite(id: 1, atMs: 1000), const Bite(id: 2, atMs: 1000)],
+        const [],
       );
 
       await service.restoreFromBackup(
@@ -216,6 +257,7 @@ void main() {
       final biteRepo = _RecordingBiteRepository();
       final backup = service.encodeBackup(
         [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+        const [],
         const [],
       );
 
@@ -243,6 +285,78 @@ void main() {
       );
 
       expect(biteRepo.operations, isEmpty);
+      // The config history rides on the bite backup's absence too: no entry.
+      expect(biteRepo.configOperations, isEmpty);
+    });
+
+    test('restores pacing config from a backup, clearing first', () async {
+      final biteRepo = _RecordingBiteRepository();
+      final backup = service.encodeBackup(
+        const [],
+        const [],
+        [
+          const PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30),
+          const PacingConfig(id: 2, effectiveMs: 5000, b1S: 10, b2S: 20),
+        ],
+      );
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      // clear must come first, then one set per restored version.
+      expect(biteRepo.configOperations, ['clear', 'set', 'set']);
+      expect(
+        biteRepo.savedConfigs.map((c) => c.effectiveMs),
+        [0, 5000],
+      );
+      expect(biteRepo.savedConfigs.map((c) => c.b2S), [30, 20]);
+    });
+
+    test('dedupes repeated config versions by effective instant', () async {
+      final biteRepo = _RecordingBiteRepository();
+      // Two rows share an effective_ms — only the first survives.
+      final backup = service.encodeBackup(
+        const [],
+        const [],
+        [
+          const PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30),
+          const PacingConfig(id: 2, effectiveMs: 0, b1S: 10, b2S: 20),
+        ],
+      );
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      expect(biteRepo.savedConfigs, hasLength(1));
+      expect(biteRepo.savedConfigs.single.b2S, 30);
+    });
+
+    test('leaves pacing config untouched for a pre-config backup', () async {
+      final biteRepo = _RecordingBiteRepository();
+      // A weight+bite backup with no pacing_config.csv must not wipe the
+      // seeded thresholds.
+      final archive = Archive()
+        ..addFile(
+          const WeightBackupCodec().toArchiveFile([
+            Weight(date: DateTime(2023, 10, 27), value: 75.5),
+          ]),
+        )
+        ..addFile(const BiteBackupCodec().toArchiveFile([]));
+      final backup = ZipEncoder().encode(archive);
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        biteRepo,
+        backup,
+      );
+
+      expect(biteRepo.configOperations, isEmpty);
     });
   });
 }


### PR DESCRIPTION
Extend the backup to carry the versioned pacing thresholds (Phase 11).
Previously the archive held only weights.csv and bites.csv, so a restore
dropped the pacing_config history and left historical bites' zones
unreconstructable (plan §2b).

- Add PacingConfigBackupCodec (pacing_config.csv: effective_ms, b1_s,
  b2_s, one row per version), mirroring BiteBackupCodec including its
  load-bearing null-vs-empty fromArchive contract.
- Add allPacingConfigs (export) and clearPacingConfigs (import) to
  BiteRepository and the Drift impl.
- SerializationService packs the config into the same archive and, on
  restore, clears then re-inserts (deduped by effective_ms) only when the
  entry is present; an absent entry leaves the seeded default untouched.