### PR TITLE
docs: add bite analytics screen plan

### DIFF
--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -74,8 +74,9 @@ Not every cluster is a "meal" — item 5 explicitly separates *meals* from *bite
 outside meals (snacks)*. So a cluster is promoted to a **meal** only if it has at
 least `minMealBites` bites; smaller clusters count as **snacks**.
 
-- **`minMealBites = 5`** (§6.1, settled). A cluster of fewer than 5 bites is
-  treated as snacking, and its bites roll into the day's snack total.
+- **`minMealBites = 10`** (§6.1, settled). A cluster of fewer than 10 bites is
+  treated as snacking, and its bites roll into the day's snack total — so a small
+  snack never gets promoted to a full meal.
 - "Bites outside meals (snacks)" = every bite in the day that is not part of a
   qualifying meal cluster: `todayCount − Σ(bites in meal clusters)`.
 
@@ -194,8 +195,9 @@ Parked, not in v1 — listed so v1 doesn't accidentally foreclose them:
 
 All confirmed — these fix the numbers on screen:
 
-1. **Snack threshold `minMealBites = 5`.** A cluster qualifies as a *meal* only
-   with 5+ bites; smaller clusters are snacks and roll into the day's snack total.
+1. **Snack threshold `minMealBites = 10`.** A cluster qualifies as a *meal* only
+   with 10+ bites; smaller clusters are snacks and roll into the day's snack
+   total, so a snack-sized cluster is never promoted to a meal.
 2. **Averages count only days with ≥ `minBitesForAverage` (40) bites.** Zero and
    lightly-logged days are excluded from both the numerator and the denominator,
    so a day you forgot to log — or only logged a few bites — never dilutes the
@@ -245,13 +247,13 @@ Pure computation over the repository — no meals yet.
 **Phase 3 — `BiteAnalytics`: meal clustering**
 
 The meal/snack model (§2), the one genuinely new logic.
-- [ ] `mealGapThreshold = 5 min` and `minMealBites = 5` constants
+- [ ] `mealGapThreshold = 5 min` and `minMealBites = 10` constants
 - [ ] `mealsForDay(day)` — cluster a day's `bitesInRange` by ≤-5-min gaps, keep
-      clusters with ≥ 5 bites as meals; split at the local-day boundary (§2c)
+      clusters with ≥ 10 bites as meals; split at the local-day boundary (§2c)
 - [ ] `breakdownForDay(day)` → `DayMealBreakdown` (per-meal counts + snack total)
       and `averageMealsPerDay(from, to)`
 - [ ] **Verify:** unit-test empty day, single bite, a gap of *exactly* 5 min,
-      back-to-back clusters, a sub-5-bite cluster → snacks, all-snack day, and a
+      back-to-back clusters, a sub-10-bite cluster → snacks, all-snack day, and a
       meal straddling midnight splitting into two days
 
 **Phase 4 — Screen scaffold + navigation**

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -199,7 +199,8 @@ All confirmed — these fix the numbers on screen:
 2. **Averages count only days with ≥ `minBitesForAverage` (40) bites.** Zero and
    lightly-logged days are excluded from both the numerator and the denominator,
    so a day you forgot to log — or only logged a few bites — never dilutes the
-   mean. A fixed code constant, like the meal thresholds.
+   mean. A fixed code constant, like the meal thresholds. The chart flags these
+   excluded days visually (Phase 5) so the average stays legible against it.
 3. **`mealGapThreshold = 5 min` is a fixed code constant** in v1 — not
    user-configurable.
 4. **Midnight-straddling meals split at the day boundary**, consistent with every
@@ -267,7 +268,11 @@ Get an (empty) screen reachable before filling it in.
 **Phase 5 — Daily bites chart card**
 - [ ] `daily_bites_chart.dart` — an `fl_chart` `BarChart` over `dailyCounts`
       (last 30 days), one bar per day, themed like `weight_chart.dart`
-- [ ] **Verify:** renders with sparse data and with a zero-bite gap day
+- [ ] Flag days that don't count toward the average (§6.2): a faint horizontal
+      reference line at `minBitesForAverage` (40), and muted/desaturated fill on
+      bars below it — so the chart visibly explains why those days are excluded
+- [ ] **Verify:** renders with sparse data and a zero-bite gap day; a sub-40 bar
+      shows muted below the 40 line and a ≥40 bar shows full-colour above it
 
 **Phase 6 — Averages + max stat tiles**
 - [ ] A stat-tile widget and a row of three: 30-day average, 1-year average,

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -172,9 +172,6 @@ button is added there, shown only for the Bite tab.
 - **Why a pushed route, not a fifth tab:** analytics is a drill-down off the Bite
   tab, not a peer of Home/Weight/Bite/Settings. A route keeps the bottom nav at
   four items and gives a natural back affordance.
-- **Alternative considered:** give `BitePage` its own `AppBar` with the action.
-  Rejected — it would double the app bar inside the shell's existing one. The
-  conditional-action approach reuses the shell's single app bar cleanly.
 
 New files: `lib/ui/pages/bite_analytics_page.dart`, plus widgets under
 `lib/ui/widgets/` (e.g. `daily_bites_chart.dart`, a stat-tile widget for the

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -6,7 +6,7 @@ daily-bite trends, averages, and a meal/snack breakdown derived from the stored
 timestamps.
 
 > **Status: ready to build.** Nothing here is built yet, but every design
-> decision is settled (§6) — implementation can start at Phase 1.
+> decision is settled (§5) — implementation can start at Phase 1.
 
 ---
 
@@ -37,7 +37,7 @@ every decision below.
 2. **Averages** — mean daily bites over the **last 30 days** and the **last
    year**, counting only days with at least `minBitesForAverage` (**40**) bites;
    zero and lightly-logged days are excluded so partial-logging noise doesn't drag
-   the mean down (§6.2).
+   the mean down (§5.2).
 3. **Max daily bites — last 30 days** — the single highest day's count in the
    window, and the day it fell on.
 4. **Meals per day** — count of *meals* per day, where a **meal** is a cluster of
@@ -46,8 +46,6 @@ every decision below.
 5. **Daily meal breakdown** — for a selected day (default: today), the bite count
    in each meal, plus a total of bites that fell **outside** any meal (**snacks**,
    §2).
-
-"…and maybe more" — candidates parked for later in §5.
 
 ---
 
@@ -66,7 +64,7 @@ keep adding bites while the gap from the **previous bite** is `≤ 5 min`; a gap
 - The threshold is between **consecutive** bites, not from the cluster's start —
   a long, slow meal stays one cluster as long as no single gap exceeds 5 min.
 - `5 min` is a fixed named constant (`mealGapThreshold`), defined once so it is
-  easy to retune in code — **not** user-configurable in v1 (§6.3, settled).
+  easy to retune in code — **not** user-configurable in v1 (§5.3, settled).
 
 ### 2b. Meal vs. snack
 
@@ -74,7 +72,7 @@ Not every cluster is a "meal" — item 5 explicitly separates *meals* from *bite
 outside meals (snacks)*. So a cluster is promoted to a **meal** only if it has at
 least `minMealBites` bites; smaller clusters count as **snacks**.
 
-- **`minMealBites = 10`** (§6.1, settled). A cluster of fewer than 10 bites is
+- **`minMealBites = 10`** (§5.1, settled). A cluster of fewer than 10 bites is
   treated as snacking, and its bites roll into the day's snack total — so a small
   snack never gets promoted to a full meal.
 - "Bites outside meals (snacks)" = every bite in the day that is not part of a
@@ -82,7 +80,7 @@ least `minMealBites` bites; smaller clusters count as **snacks**.
 
 ### 2c. Day boundaries
 
-Clustering runs **within a single local day** (§6.4, settled). A meal that
+Clustering runs **within a single local day** (§5.4, settled). A meal that
 straddles midnight is split at the day boundary — the bites before midnight
 belong to one day, those after to the next. This keeps "meals per day" consistent
 with every other per-day metric and avoids a single late-night meal being
@@ -178,21 +176,7 @@ the existing chart's theming.
 
 ---
 
-## 5. Follow-up candidates ("…and maybe more")
-
-Parked, not in v1 — listed so v1 doesn't accidentally foreclose them:
-
-- **Window selector** (7 / 30 / 365 days) driving the chart and averages.
-- **Day picker** for the meal breakdown (browse past days, not just today).
-- **Meals-per-day trend** as its own small chart.
-- **Time-of-day distribution** (bites/meals by hour) — a snacking-pattern view.
-- **Pacing overlay** — average inter-bite gap or share of well-paced bites,
-  joining the analytics with the pacing thresholds (`pacingConfigAt`).
-- **Best/worst day, current low-bite streak** — echoing the weight streak banners.
-
----
-
-## 6. Settled decisions
+## 5. Settled decisions
 
 All confirmed — these fix the numbers on screen:
 
@@ -213,7 +197,7 @@ All confirmed — these fix the numbers on screen:
 
 ---
 
-## 7. Phases
+## 6. Phases
 
 Each phase is one sitting on a single subject, ends **green** (`flutter analyze`
 + `flutter test` pass), and is independently committable. Phases are ordered so
@@ -240,7 +224,7 @@ Pure computation over the repository — no meals yet.
       `BiteRepository`
 - [ ] `minBitesForAverage = 40` constant
 - [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (mean over only the days
-      with ≥ 40 bites — §6.2), `maxDay(from, to)` returning the peak `DailyBiteCount`
+      with ≥ 40 bites — §5.2), `maxDay(from, to)` returning the peak `DailyBiteCount`
 - [ ] **Verify:** unit-test that sub-40 and zero days are excluded from the
       average, a window with no qualifying day (average null/0), max with ties, and
       empty data (max null)
@@ -273,7 +257,7 @@ Get an (empty) screen reachable before filling it in.
 **Phase 5 — Daily bites chart card**
 - [ ] `daily_bites_chart.dart` — an `fl_chart` `BarChart` over `dailyCounts`
       (last 30 days), one bar per day, themed like `weight_chart.dart`
-- [ ] Flag days that don't count toward the average (§6.2): a faint horizontal
+- [ ] Flag days that don't count toward the average (§5.2): a faint horizontal
       reference line at `minBitesForAverage` (40), and muted/desaturated fill on
       bars below it — so the chart visibly explains why those days are excluded
 - [ ] **Verify:** renders with sparse data and a zero-bite gap day; a sub-40 bar
@@ -289,7 +273,7 @@ Get an (empty) screen reachable before filling it in.
 - [ ] **Verify:** matches a hand-counted fixture
 
 **Phase 8 — Daily meal breakdown card**
-- [ ] For today (§6.5): a list of each meal's bite count plus the snack total,
+- [ ] For today (§5.5): a list of each meal's bite count plus the snack total,
       with an empty state when today has no bites yet
 - [ ] **Verify:** meals, snacks, and the empty state each render
 

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -5,9 +5,8 @@ dashboard reached from a small chart button in the top-right corner, surfacing
 daily-bite trends, averages, and a meal/snack breakdown derived from the stored
 timestamps.
 
-> **Status: draft.** Nothing here is built yet. This document scopes the feature
-> and records the design decisions before any code lands. Open questions that
-> need a call before implementation are collected in §6.
+> **Status: ready to build.** Nothing here is built yet, but every design
+> decision is settled (§6) — implementation can start at Phase 1.
 
 ---
 
@@ -36,8 +35,8 @@ every decision below.
 1. **Daily bites chart** — a bar chart of total bites per calendar day over a
    window (default: last 30 days). One bar per day, gaps for zero days.
 2. **Averages** — mean daily bites over the **last 30 days** and the **last
-   year**. (Mean over calendar days in the window, including or excluding
-   zero-bite days — see §6.)
+   year**, dividing by *every* calendar day in the window (zero-bite days
+   included, so skipped days pull the mean down — §6.2).
 3. **Max daily bites — last 30 days** — the single highest day's count in the
    window, and the day it fell on.
 4. **Meals per day** — count of *meals* per day, where a **meal** is a cluster of
@@ -65,8 +64,8 @@ keep adding bites while the gap from the **previous bite** is `≤ 5 min`; a gap
 
 - The threshold is between **consecutive** bites, not from the cluster's start —
   a long, slow meal stays one cluster as long as no single gap exceeds 5 min.
-- `5 min` is a named constant (`mealGapThreshold`), defined once so it is easy to
-  retune. See §6 for whether it should be user-configurable.
+- `5 min` is a fixed named constant (`mealGapThreshold`), defined once so it is
+  easy to retune in code — **not** user-configurable in v1 (§6.3, settled).
 
 ### 2b. Meal vs. snack
 
@@ -74,24 +73,18 @@ Not every cluster is a "meal" — item 5 explicitly separates *meals* from *bite
 outside meals (snacks)*. So a cluster is promoted to a **meal** only if it has at
 least `minMealBites` bites; smaller clusters count as **snacks**.
 
-- **Proposed default: `minMealBites = 5`.** A cluster of fewer than 5 bites is
+- **`minMealBites = 5`** (§6.1, settled). A cluster of fewer than 5 bites is
   treated as snacking, and its bites roll into the day's snack total.
 - "Bites outside meals (snacks)" = every bite in the day that is not part of a
   qualifying meal cluster: `todayCount − Σ(bites in meal clusters)`.
 
-This threshold is a **decision, not a fact** — flagged in §6. If we'd rather every
-cluster be a meal (so "snacks" only means truly isolated single bites), set
-`minMealBites = 1` and the snack total collapses to lone bites separated by
-`> 5 min` on both sides.
-
 ### 2c. Day boundaries
 
-Clustering runs **within a single local day**. A meal that straddles midnight is
-split at the day boundary (the bites before midnight belong to one day, those
-after to the next). This keeps "meals per day" consistent with every other
-per-day metric and avoids a single late-night meal being double-counted or
-attributed to the wrong day. Noted as a known edge in §6 in case we later prefer
-gap-based splitting that ignores midnight.
+Clustering runs **within a single local day** (§6.4, settled). A meal that
+straddles midnight is split at the day boundary — the bites before midnight
+belong to one day, those after to the next. This keeps "meals per day" consistent
+with every other per-day metric and avoids a single late-night meal being
+double-counted or attributed to the wrong day.
 
 ---
 
@@ -196,73 +189,99 @@ Parked, not in v1 — listed so v1 doesn't accidentally foreclose them:
 
 ---
 
-## 6. Open questions / decisions to confirm
+## 6. Settled decisions
 
-These change the numbers on screen, so they're worth settling before building:
+All confirmed — these fix the numbers on screen:
 
-1. **Snack threshold (`minMealBites`).** Proposed default **5**. Alternative:
-   `1` (every cluster is a meal; snacks = lone `>5 min`-isolated bites). Drives
-   items 4 and 5. *(Leaning: 5.)*
-2. **Averages over zero-bite days.** Does the daily average divide by *all*
-   calendar days in the window (zeros included, so a skipped day drags the mean
-   down) or only by days that have at least one bite? *(Leaning: include zero
-   days — it reflects real adherence, per §0's adherence framing.)*
-3. **Meal gap threshold configurability.** Ship `5 min` as a fixed constant for
-   v1, or expose it like the pacing thresholds? *(Leaning: fixed constant in v1;
-   revisit if requested.)*
-4. **Midnight-straddling meals** (§2c) — split at the day boundary (proposed) or
-   cluster purely by gaps, attributing the whole meal to its first bite's day?
-   *(Leaning: split at boundary, consistent with every other per-day metric.)*
-5. **Default breakdown day** — today, or the most recent day with any bites?
-   *(Leaning: today, with an empty state when today has none.)*
+1. **Snack threshold `minMealBites = 5`.** A cluster qualifies as a *meal* only
+   with 5+ bites; smaller clusters are snacks and roll into the day's snack total.
+2. **Averages include zero-bite days.** The daily mean divides by *every*
+   calendar day in the window, so skipped days pull it down — it reflects real
+   adherence (§0).
+3. **`mealGapThreshold = 5 min` is a fixed code constant** in v1 — not
+   user-configurable.
+4. **Midnight-straddling meals split at the day boundary**, consistent with every
+   other per-day metric.
+5. **Default meal-breakdown day is today**, with an empty state when today has no
+   bites yet.
 
 ---
 
-## 7. Tasks
+## 7. Phases
 
-Ordered so each phase assumes the earlier ones; beyond that they're independent.
-Each is one sitting on a single subject, following the pacing plan's cadence.
+Each phase is one sitting on a single subject, ends **green** (`flutter analyze`
++ `flutter test` pass), and is independently committable. Phases are ordered so
+each assumes the earlier ones. Every implementation phase ships with its tests —
+the "verify" bullet is the definition of done, not a separate phase.
 
-**Phase 0 — Settle the open questions (§6)**
-- [ ] Confirm `minMealBites`, the zero-day averaging rule, and the midnight
-      handling so the analytics have a single defined meaning before code lands
+Data first (1–3), then the screen shell (4), then one card per phase (5–8), then
+polish (9). Nothing before Phase 4 is user-visible, so 1–3 can land as pure,
+fully-tested logic behind no UI.
 
 **Phase 1 — `dailyBiteCounts` on the repository seam**
-- [ ] Add `dailyBiteCounts(from, to)` to `BiteRepository` (SQL `GROUP BY` on the
-      local day) and implement it in `DriftBiteRepository`; add the `DailyBiteCount`
-      value type
-- [ ] Add a fake/in-memory path for tests (existing `BiteDatabase.forTesting`)
-- [ ] Unit-test grouping, the half-open window, and the empty range
 
-**Phase 2 — `BiteAnalytics` computation**
-- [ ] New `bite_analytics.dart` over `BiteRepository`: `dailyCounts`,
-      `averagePerDay`, `maxDay`, per the confirmed averaging rule
-- [ ] Meal clustering (`mealsForDay`, `breakdownForDay`, `averageMealsPerDay`)
-      over `bitesInRange`, with the `mealGapThreshold` / `minMealBites` constants
-- [ ] Unit-test clustering edges: empty day, single bite, a gap of exactly the
-      threshold, back-to-back clusters, sub-`minMealBites` clusters → snacks,
-      and a day that straddles midnight
+The one new persistence query; a SQL `GROUP BY`, no schema change.
+- [ ] Add the `DailyBiteCount` value type (`day` + `count`) in `bite_analytics.dart`
+- [ ] Add `dailyBiteCounts(from, to)` to `BiteRepository`; implement in
+      `DriftBiteRepository` grouping on `date(at_ms/1000,'unixepoch','localtime')`
+- [ ] **Verify:** unit-test grouping, the half-open `[from, to)` window, an empty
+      range, and two bites on the same day collapsing to one entry
 
-**Phase 3 — Navigation + screen scaffold**
-- [ ] Add the conditional chart action to `AppShell`'s app bar (Bite tab only),
-      pushing `BiteAnalyticsPage`
-- [ ] `BiteAnalyticsPage` with its own `Scaffold`/`AppBar` and a
-      `BiteAnalyticsController` (or `FutureBuilder`) loading from the injected
-      `BiteRepository`; loading and empty states
+**Phase 2 — `BiteAnalytics`: counts, averages, max**
 
-**Phase 4 — Daily bites chart**
-- [ ] `daily_bites_chart.dart` — an `fl_chart` `BarChart` over `dailyCounts`,
-      themed like `weight_chart.dart`, with the last-30-days default window
+Pure computation over the repository — no meals yet.
+- [ ] New `lib/features/bite/data/bite_analytics.dart` constructed from a
+      `BiteRepository`
+- [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (divide by all calendar
+      days in the window — §6.2), `maxDay(from, to)` returning the peak
+      `DailyBiteCount`
+- [ ] **Verify:** unit-test the average incl. zero days, max with ties, and empty
+      data (average 0, max null)
 
-**Phase 5 — Averages + max stat tiles**
-- [ ] Stat row/tiles: 30-day average, 1-year average, 30-day max (with its date)
+**Phase 3 — `BiteAnalytics`: meal clustering**
 
-**Phase 6 — Meal breakdown**
-- [ ] Meals-per-day (today + window average) and the per-day meal breakdown list
-      with the snack total, for the default day from §6
+The meal/snack model (§2), the one genuinely new logic.
+- [ ] `mealGapThreshold = 5 min` and `minMealBites = 5` constants
+- [ ] `mealsForDay(day)` — cluster a day's `bitesInRange` by ≤-5-min gaps, keep
+      clusters with ≥ 5 bites as meals; split at the local-day boundary (§2c)
+- [ ] `breakdownForDay(day)` → `DayMealBreakdown` (per-meal counts + snack total)
+      and `averageMealsPerDay(from, to)`
+- [ ] **Verify:** unit-test empty day, single bite, a gap of *exactly* 5 min,
+      back-to-back clusters, a sub-5-bite cluster → snacks, all-snack day, and a
+      meal straddling midnight splitting into two days
 
-**Phase 7 — Polish**
-- [ ] Empty/first-run states throughout, accessibility labels on the chart and
-      tiles, and a `flutter analyze` / `flutter test` pass before pushing
+**Phase 4 — Screen scaffold + navigation**
+
+Get an (empty) screen reachable before filling it in.
+- [ ] Chart `IconButton` in `AppShell`'s app bar, rendered only when
+      `_currentIndex == 2`, pushing `BiteAnalyticsPage`
+- [ ] `bite_analytics_page.dart` with its own `Scaffold`/`AppBar` ("Bite
+      Analytics", back arrow) and a `BiteAnalyticsController extends ChangeNotifier`
+      loading from the injected `BiteRepository` in `initState`
+- [ ] Loading spinner and a global empty state (no bites logged ever)
+- [ ] **Verify:** the button shows only on the Bite tab and the route opens/pops
+
+**Phase 5 — Daily bites chart card**
+- [ ] `daily_bites_chart.dart` — an `fl_chart` `BarChart` over `dailyCounts`
+      (last 30 days), one bar per day, themed like `weight_chart.dart`
+- [ ] **Verify:** renders with sparse data and with a zero-bite gap day
+
+**Phase 6 — Averages + max stat tiles**
+- [ ] A stat-tile widget and a row of three: 30-day average, 1-year average,
+      30-day max (with its date)
+- [ ] **Verify:** tiles read correctly against a seeded fixture
+
+**Phase 7 — Meals-per-day summary**
+- [ ] Surface today's meal count and the window average (`averageMealsPerDay`)
+- [ ] **Verify:** matches a hand-counted fixture
+
+**Phase 8 — Daily meal breakdown card**
+- [ ] For today (§6.5): a list of each meal's bite count plus the snack total,
+      with an empty state when today has no bites yet
+- [ ] **Verify:** meals, snacks, and the empty state each render
+
+**Phase 9 — Polish**
+- [ ] Accessibility labels on the chart and tiles, consistent theming/spacing,
+      and a final `flutter analyze` / `flutter test` pass before pushing
 </content>
 </invoke>

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -155,11 +155,20 @@ app bar is owned by `AppShell` (one shared `AppBar` across all four tabs), so th
 button is added there, shown only for the Bite tab.
 
 - **Recommended:** in `AppShell`, add `actions:` to the shared `AppBar` that
-  render an `IconButton(Icons.bar_chart_rounded /* or insights */)` **only when
-  `_currentIndex == 2`** (the Bite tab), pushing a full-screen route to a new
-  `BiteAnalyticsPage`. That page owns its **own** `Scaffold` + `AppBar` (title
-  "Bite Analytics", automatic back arrow), so it is self-contained and does not
-  fight the shell's chrome.
+  render an `IconButton(Icons.bar_chart_rounded /* or insights */)` **only on the
+  Bite tab**, pushing a full-screen route to a new `BiteAnalyticsPage`. That page
+  owns its **own** `Scaffold` + `AppBar` (title "Bite Analytics", automatic back
+  arrow), so it is self-contained and does not fight the shell's chrome.
+- **Identify the tab by name, not by a bare index.** `AppShell` currently keys
+  everything off `_currentIndex` and already carries a magic `_currentIndex == 2`
+  in the `BitePage(isActive:)` line — and the tab order has been reshuffled once
+  before (pacing plan Phase 8), which is exactly what makes a hardcoded `2`
+  fragile. Introduce an `AppTab { home, weight, bite, settings }` enum so the tab
+  is named in one place; the action then shows when
+  `_currentIndex == AppTab.bite.index`, and the existing `isActive` check adopts
+  the same name so this plan *removes* a magic number rather than adding a third.
+  (The `_titles` list, `IndexedStack` children, and nav items stay index-ordered;
+  the enum just gives that order a single named source of truth.)
 - **Why a pushed route, not a fifth tab:** analytics is a drill-down off the Bite
   tab, not a peer of Home/Weight/Bite/Settings. A route keeps the bottom nav at
   four items and gives a natural back affordance.
@@ -257,8 +266,10 @@ The meal/snack model (§2), the one genuinely new logic.
 **Phase 4 — Screen scaffold + navigation**
 
 Get an (empty) screen reachable before filling it in.
+- [ ] Add an `AppTab { home, weight, bite, settings }` enum and repoint the
+      existing `_currentIndex == 2` (`BitePage isActive:`) at `AppTab.bite.index`
 - [ ] Chart `IconButton` in `AppShell`'s app bar, rendered only when
-      `_currentIndex == 2`, pushing `BiteAnalyticsPage`
+      `_currentIndex == AppTab.bite.index`, pushing `BiteAnalyticsPage`
 - [ ] `bite_analytics_page.dart` with its own `Scaffold`/`AppBar` ("Bite
       Analytics", back arrow) and the `BiteAnalyticsController` (§3c) loading from
       the injected `BiteRepository` in `initState`

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -35,8 +35,9 @@ every decision below.
 1. **Daily bites chart** — a bar chart of total bites per calendar day over a
    window (default: last 30 days). One bar per day, gaps for zero days.
 2. **Averages** — mean daily bites over the **last 30 days** and the **last
-   year**, dividing by *every* calendar day in the window (zero-bite days
-   included, so skipped days pull the mean down — §6.2).
+   year**, counting only days with at least `minBitesForAverage` (**40**) bites;
+   zero and lightly-logged days are excluded so partial-logging noise doesn't drag
+   the mean down (§6.2).
 3. **Max daily bites — last 30 days** — the single highest day's count in the
    window, and the day it fell on.
 4. **Meals per day** — count of *meals* per day, where a **meal** is a cluster of
@@ -195,9 +196,10 @@ All confirmed — these fix the numbers on screen:
 
 1. **Snack threshold `minMealBites = 5`.** A cluster qualifies as a *meal* only
    with 5+ bites; smaller clusters are snacks and roll into the day's snack total.
-2. **Averages include zero-bite days.** The daily mean divides by *every*
-   calendar day in the window, so skipped days pull it down — it reflects real
-   adherence (§0).
+2. **Averages count only days with ≥ `minBitesForAverage` (40) bites.** Zero and
+   lightly-logged days are excluded from both the numerator and the denominator,
+   so a day you forgot to log — or only logged a few bites — never dilutes the
+   mean. A fixed code constant, like the meal thresholds.
 3. **`mealGapThreshold = 5 min` is a fixed code constant** in v1 — not
    user-configurable.
 4. **Midnight-straddling meals split at the day boundary**, consistent with every
@@ -232,11 +234,12 @@ The one new persistence query; a SQL `GROUP BY`, no schema change.
 Pure computation over the repository — no meals yet.
 - [ ] New `lib/features/bite/data/bite_analytics.dart` constructed from a
       `BiteRepository`
-- [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (divide by all calendar
-      days in the window — §6.2), `maxDay(from, to)` returning the peak
-      `DailyBiteCount`
-- [ ] **Verify:** unit-test the average incl. zero days, max with ties, and empty
-      data (average 0, max null)
+- [ ] `minBitesForAverage = 40` constant
+- [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (mean over only the days
+      with ≥ 40 bites — §6.2), `maxDay(from, to)` returning the peak `DailyBiteCount`
+- [ ] **Verify:** unit-test that sub-40 and zero days are excluded from the
+      average, a window with no qualifying day (average null/0), max with ties, and
+      empty data (max null)
 
 **Phase 3 — `BiteAnalytics`: meal clustering**
 

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -139,14 +139,12 @@ window) of raw bites, which is small. No new table, no `schemaVersion` bump.
 The screen loads async, so give it a lightweight controller rather than reusing
 the pacing-oriented `BiteManager`:
 
-- **Recommended:** a `BiteAnalyticsController extends ChangeNotifier` that holds
-  the loaded results + a loading flag, created per-screen from the injected
-  `BiteRepository` (`context.read<BiteRepository>()`), loading in `initState`.
-  Keeps `BiteManager` focused on live logging/pacing and keeps analytics work off
-  the main screen's hot path.
-- **Alternative:** a bare `FutureBuilder` in the page if the state stays trivial.
-  Fine for a first cut; promote to a controller once there's a window selector or
-  a day picker driving re-loads.
+A `BiteAnalyticsController extends ChangeNotifier` holds the loaded results + a
+loading flag, created per-screen from the injected `BiteRepository`
+(`context.read<BiteRepository>()`), loading in `initState`. This keeps
+`BiteManager` focused on live logging/pacing and analytics work off the main
+screen's hot path, and leaves a clean seam for a later window selector or day
+picker to drive re-loads.
 
 ---
 
@@ -262,8 +260,8 @@ Get an (empty) screen reachable before filling it in.
 - [ ] Chart `IconButton` in `AppShell`'s app bar, rendered only when
       `_currentIndex == 2`, pushing `BiteAnalyticsPage`
 - [ ] `bite_analytics_page.dart` with its own `Scaffold`/`AppBar` ("Bite
-      Analytics", back arrow) and a `BiteAnalyticsController extends ChangeNotifier`
-      loading from the injected `BiteRepository` in `initState`
+      Analytics", back arrow) and the `BiteAnalyticsController` (§3c) loading from
+      the injected `BiteRepository` in `initState`
 - [ ] Loading spinner and a global empty state (no bites logged ever)
 - [ ] **Verify:** the button shows only on the Bite tab and the route opens/pops
 

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -211,7 +211,9 @@ fully-tested logic behind no UI.
 **Phase 1 — `dailyBiteCounts` on the repository seam**
 
 The one new persistence query; a SQL `GROUP BY`, no schema change.
-- [ ] Add the `DailyBiteCount` value type (`day` + `count`) in `bite_analytics.dart`
+- [ ] Create `lib/features/bite/data/bite_analytics.dart` with the
+      `DailyBiteCount` value type (`day` + `count`) — the file the `BiteAnalytics`
+      class lands in next phase
 - [ ] Add `dailyBiteCounts(from, to)` to `BiteRepository`; implement in
       `DriftBiteRepository` grouping on `date(at_ms/1000,'unixepoch','localtime')`
 - [ ] **Verify:** unit-test grouping, the half-open `[from, to)` window, an empty
@@ -220,8 +222,8 @@ The one new persistence query; a SQL `GROUP BY`, no schema change.
 **Phase 2 — `BiteAnalytics`: counts, averages, max**
 
 Pure computation over the repository — no meals yet.
-- [ ] New `lib/features/bite/data/bite_analytics.dart` constructed from a
-      `BiteRepository`
+- [ ] Add the `BiteAnalytics` class (constructed from a `BiteRepository`) to the
+      `bite_analytics.dart` created in Phase 1
 - [ ] `minBitesForAverage = 40` constant
 - [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (mean over only the days
       with ≥ 40 bites — §5.2), `maxDay(from, to)` returning the peak `DailyBiteCount`
@@ -280,5 +282,3 @@ Get an (empty) screen reachable before filling it in.
 **Phase 9 — Polish**
 - [ ] Accessibility labels on the chart and tiles, consistent theming/spacing,
       and a final `flutter analyze` / `flutter test` pass before pushing
-</content>
-</invoke>

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -154,7 +154,7 @@ The chart button lives at the **top-right of the Bite tab's app bar**, and the
 app bar is owned by `AppShell` (one shared `AppBar` across all four tabs), so the
 button is added there, shown only for the Bite tab.
 
-- **Recommended:** in `AppShell`, add `actions:` to the shared `AppBar` that
+- **The button.** In `AppShell`, add `actions:` to the shared `AppBar` that
   render an `IconButton(Icons.bar_chart_rounded /* or insights */)` **only on the
   Bite tab**, pushing a full-screen route to a new `BiteAnalyticsPage`. That page
   owns its **own** `Scaffold` + `AppBar` (title "Bite Analytics", automatic back
@@ -169,9 +169,6 @@ button is added there, shown only for the Bite tab.
   the same name so this plan *removes* a magic number rather than adding a third.
   (The `_titles` list, `IndexedStack` children, and nav items stay index-ordered;
   the enum just gives that order a single named source of truth.)
-- **Why a pushed route, not a fifth tab:** analytics is a drill-down off the Bite
-  tab, not a peer of Home/Weight/Bite/Settings. A route keeps the bottom nav at
-  four items and gives a natural back affordance.
 
 New files: `lib/ui/pages/bite_analytics_page.dart`, plus widgets under
 `lib/ui/widgets/` (e.g. `daily_bites_chart.dart`, a stat-tile widget for the

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -1,0 +1,268 @@
+# Food Locker — Bite Analytics Plan
+
+A phased plan to add a **Bite Analytics** screen to the Bite tab: a read-only
+dashboard reached from a small chart button in the top-right corner, surfacing
+daily-bite trends, averages, and a meal/snack breakdown derived from the stored
+timestamps.
+
+> **Status: draft.** Nothing here is built yet. This document scopes the feature
+> and records the design decisions before any code lands. Open questions that
+> need a call before implementation are collected in §6.
+
+---
+
+## 0. Guiding principles
+
+These carry over from the pacing plan (`bite_pacing_plan.md` §0) and constrain
+every decision below.
+
+- **Store facts, derive views.** The `bites` table stays exactly as it is — an
+  append-only log of raw `at_ms` timestamps. Every analytic (daily counts,
+  averages, meals, snacks) is a **read-time projection** of that log. Nothing new
+  is persisted; no schema change, no migration.
+- **Bite count is the headline metric.** The analytics screen elaborates on the
+  count the main screen already shows — it never introduces a competing number.
+- **Read-only.** This screen only reads. It logs nothing, mutates nothing, and
+  touches no pacing state. It can be opened and closed without side effects.
+- **Local-day granularity, DST-safe.** Days are calendar days in the device's
+  local zone, bounded by the half-open `[startOfDay, startOfNextDay)` window and
+  built with the `DateTime(y, m, d ± 1)` idiom already used in `BiteManager` and
+  `WeightAnalytics` — never fixed 24-hour arithmetic.
+
+---
+
+## 1. What the screen shows (v1 scope)
+
+1. **Daily bites chart** — a bar chart of total bites per calendar day over a
+   window (default: last 30 days). One bar per day, gaps for zero days.
+2. **Averages** — mean daily bites over the **last 30 days** and the **last
+   year**. (Mean over calendar days in the window, including or excluding
+   zero-bite days — see §6.)
+3. **Max daily bites — last 30 days** — the single highest day's count in the
+   window, and the day it fell on.
+4. **Meals per day** — count of *meals* per day, where a **meal** is a cluster of
+   bites no more than **5 minutes** apart (§2). Shown as today's number plus an
+   average over the window.
+5. **Daily meal breakdown** — for a selected day (default: today), the bite count
+   in each meal, plus a total of bites that fell **outside** any meal (**snacks**,
+   §2).
+
+"…and maybe more" — candidates parked for later in §5.
+
+---
+
+## 2. The meal model (the one genuinely new concept)
+
+Everything except the meal/snack split is a straight count or average. The meal
+model is the piece that needs a precise definition, because the rest of the
+screen (items 4 and 5) is built on it.
+
+### 2a. Clustering
+
+Walk a day's bites in chronological order. Start a cluster at the first bite;
+keep adding bites while the gap from the **previous bite** is `≤ 5 min`; a gap
+`> 5 min` closes the current cluster and starts a new one.
+
+- The threshold is between **consecutive** bites, not from the cluster's start —
+  a long, slow meal stays one cluster as long as no single gap exceeds 5 min.
+- `5 min` is a named constant (`mealGapThreshold`), defined once so it is easy to
+  retune. See §6 for whether it should be user-configurable.
+
+### 2b. Meal vs. snack
+
+Not every cluster is a "meal" — item 5 explicitly separates *meals* from *bites
+outside meals (snacks)*. So a cluster is promoted to a **meal** only if it has at
+least `minMealBites` bites; smaller clusters count as **snacks**.
+
+- **Proposed default: `minMealBites = 5`.** A cluster of fewer than 5 bites is
+  treated as snacking, and its bites roll into the day's snack total.
+- "Bites outside meals (snacks)" = every bite in the day that is not part of a
+  qualifying meal cluster: `todayCount − Σ(bites in meal clusters)`.
+
+This threshold is a **decision, not a fact** — flagged in §6. If we'd rather every
+cluster be a meal (so "snacks" only means truly isolated single bites), set
+`minMealBites = 1` and the snack total collapses to lone bites separated by
+`> 5 min` on both sides.
+
+### 2c. Day boundaries
+
+Clustering runs **within a single local day**. A meal that straddles midnight is
+split at the day boundary (the bites before midnight belong to one day, those
+after to the next). This keeps "meals per day" consistent with every other
+per-day metric and avoids a single late-night meal being double-counted or
+attributed to the wrong day. Noted as a known edge in §6 in case we later prefer
+gap-based splitting that ignores midnight.
+
+---
+
+## 3. Where the computation lives
+
+Mirror the weight feature's shape: a pure computation class over the repository,
+exactly as `WeightAnalytics` sits over `WeightRepository`.
+
+### 3a. `BiteAnalytics` — pure, read-time computation
+
+A new `lib/features/bite/data/bite_analytics.dart`, constructed from a
+`BiteRepository`. Async (the bite store is async, unlike Hive's cached weights),
+returning plain value objects:
+
+```dart
+class BiteAnalytics {
+  BiteAnalytics(this._repository);
+  final BiteRepository _repository;
+
+  Future<List<DailyBiteCount>> dailyCounts(DateTime from, DateTime to);
+  Future<double> averagePerDay(DateTime from, DateTime to);
+  Future<DailyBiteCount?> maxDay(DateTime from, DateTime to);   // last-30 max
+  Future<List<Meal>> mealsForDay(DateTime day);                 // clusters ≥ minMealBites
+  Future<DayMealBreakdown> breakdownForDay(DateTime day);       // meals + snack total
+  Future<double> averageMealsPerDay(DateTime from, DateTime to);
+}
+```
+
+Value types (`DailyBiteCount`, `Meal`, `DayMealBreakdown`) are small immutable
+data classes in the same file, following the `OvereatingStats` precedent.
+
+### 3b. Repository seam — one aggregate query added
+
+Per the pacing plan §1a, day-grouped counts are a SQL sweet spot, so add **one**
+aggregate method to `BiteRepository` rather than pulling a year of raw rows into
+Dart just to count them:
+
+```dart
+/// Bites per local calendar day in [from, to), one entry per day that has
+/// at least one bite. Grouped in SQL via date(at_ms/1000,'unixepoch','localtime').
+Future<List<DailyBiteCount>> dailyBiteCounts(DateTime from, DateTime to);
+```
+
+Meal clustering needs the actual inter-bite gaps, so it keeps using the existing
+`bitesInRange(from, to)` and clusters in Dart — the volume there is one day (or a
+window) of raw bites, which is small. No new table, no `schemaVersion` bump.
+
+### 3c. UI wiring
+
+The screen loads async, so give it a lightweight controller rather than reusing
+the pacing-oriented `BiteManager`:
+
+- **Recommended:** a `BiteAnalyticsController extends ChangeNotifier` that holds
+  the loaded results + a loading flag, created per-screen from the injected
+  `BiteRepository` (`context.read<BiteRepository>()`), loading in `initState`.
+  Keeps `BiteManager` focused on live logging/pacing and keeps analytics work off
+  the main screen's hot path.
+- **Alternative:** a bare `FutureBuilder` in the page if the state stays trivial.
+  Fine for a first cut; promote to a controller once there's a window selector or
+  a day picker driving re-loads.
+
+---
+
+## 4. Navigation — the chart button
+
+The chart button lives at the **top-right of the Bite tab's app bar**, and the
+app bar is owned by `AppShell` (one shared `AppBar` across all four tabs), so the
+button is added there, shown only for the Bite tab.
+
+- **Recommended:** in `AppShell`, add `actions:` to the shared `AppBar` that
+  render an `IconButton(Icons.bar_chart_rounded /* or insights */)` **only when
+  `_currentIndex == 2`** (the Bite tab), pushing a full-screen route to a new
+  `BiteAnalyticsPage`. That page owns its **own** `Scaffold` + `AppBar` (title
+  "Bite Analytics", automatic back arrow), so it is self-contained and does not
+  fight the shell's chrome.
+- **Why a pushed route, not a fifth tab:** analytics is a drill-down off the Bite
+  tab, not a peer of Home/Weight/Bite/Settings. A route keeps the bottom nav at
+  four items and gives a natural back affordance.
+- **Alternative considered:** give `BitePage` its own `AppBar` with the action.
+  Rejected — it would double the app bar inside the shell's existing one. The
+  conditional-action approach reuses the shell's single app bar cleanly.
+
+New files: `lib/ui/pages/bite_analytics_page.dart`, plus widgets under
+`lib/ui/widgets/` (e.g. `daily_bites_chart.dart`, a stat-tile widget for the
+averages/max, a meal-breakdown list). Charts use **`fl_chart`**, already a
+dependency (used by `weight_chart.dart`) — a `BarChart` for daily bites, matching
+the existing chart's theming.
+
+---
+
+## 5. Follow-up candidates ("…and maybe more")
+
+Parked, not in v1 — listed so v1 doesn't accidentally foreclose them:
+
+- **Window selector** (7 / 30 / 365 days) driving the chart and averages.
+- **Day picker** for the meal breakdown (browse past days, not just today).
+- **Meals-per-day trend** as its own small chart.
+- **Time-of-day distribution** (bites/meals by hour) — a snacking-pattern view.
+- **Pacing overlay** — average inter-bite gap or share of well-paced bites,
+  joining the analytics with the pacing thresholds (`pacingConfigAt`).
+- **Best/worst day, current low-bite streak** — echoing the weight streak banners.
+
+---
+
+## 6. Open questions / decisions to confirm
+
+These change the numbers on screen, so they're worth settling before building:
+
+1. **Snack threshold (`minMealBites`).** Proposed default **5**. Alternative:
+   `1` (every cluster is a meal; snacks = lone `>5 min`-isolated bites). Drives
+   items 4 and 5. *(Leaning: 5.)*
+2. **Averages over zero-bite days.** Does the daily average divide by *all*
+   calendar days in the window (zeros included, so a skipped day drags the mean
+   down) or only by days that have at least one bite? *(Leaning: include zero
+   days — it reflects real adherence, per §0's adherence framing.)*
+3. **Meal gap threshold configurability.** Ship `5 min` as a fixed constant for
+   v1, or expose it like the pacing thresholds? *(Leaning: fixed constant in v1;
+   revisit if requested.)*
+4. **Midnight-straddling meals** (§2c) — split at the day boundary (proposed) or
+   cluster purely by gaps, attributing the whole meal to its first bite's day?
+   *(Leaning: split at boundary, consistent with every other per-day metric.)*
+5. **Default breakdown day** — today, or the most recent day with any bites?
+   *(Leaning: today, with an empty state when today has none.)*
+
+---
+
+## 7. Tasks
+
+Ordered so each phase assumes the earlier ones; beyond that they're independent.
+Each is one sitting on a single subject, following the pacing plan's cadence.
+
+**Phase 0 — Settle the open questions (§6)**
+- [ ] Confirm `minMealBites`, the zero-day averaging rule, and the midnight
+      handling so the analytics have a single defined meaning before code lands
+
+**Phase 1 — `dailyBiteCounts` on the repository seam**
+- [ ] Add `dailyBiteCounts(from, to)` to `BiteRepository` (SQL `GROUP BY` on the
+      local day) and implement it in `DriftBiteRepository`; add the `DailyBiteCount`
+      value type
+- [ ] Add a fake/in-memory path for tests (existing `BiteDatabase.forTesting`)
+- [ ] Unit-test grouping, the half-open window, and the empty range
+
+**Phase 2 — `BiteAnalytics` computation**
+- [ ] New `bite_analytics.dart` over `BiteRepository`: `dailyCounts`,
+      `averagePerDay`, `maxDay`, per the confirmed averaging rule
+- [ ] Meal clustering (`mealsForDay`, `breakdownForDay`, `averageMealsPerDay`)
+      over `bitesInRange`, with the `mealGapThreshold` / `minMealBites` constants
+- [ ] Unit-test clustering edges: empty day, single bite, a gap of exactly the
+      threshold, back-to-back clusters, sub-`minMealBites` clusters → snacks,
+      and a day that straddles midnight
+
+**Phase 3 — Navigation + screen scaffold**
+- [ ] Add the conditional chart action to `AppShell`'s app bar (Bite tab only),
+      pushing `BiteAnalyticsPage`
+- [ ] `BiteAnalyticsPage` with its own `Scaffold`/`AppBar` and a
+      `BiteAnalyticsController` (or `FutureBuilder`) loading from the injected
+      `BiteRepository`; loading and empty states
+
+**Phase 4 — Daily bites chart**
+- [ ] `daily_bites_chart.dart` — an `fl_chart` `BarChart` over `dailyCounts`,
+      themed like `weight_chart.dart`, with the last-30-days default window
+
+**Phase 5 — Averages + max stat tiles**
+- [ ] Stat row/tiles: 30-day average, 1-year average, 30-day max (with its date)
+
+**Phase 6 — Meal breakdown**
+- [ ] Meals-per-day (today + window average) and the per-day meal breakdown list
+      with the snack total, for the default day from §6
+
+**Phase 7 — Polish**
+- [ ] Empty/first-run states throughout, accessibility labels on the chart and
+      tiles, and a `flutter analyze` / `flutter test` pass before pushing
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

Adds `docs/bite_analytics_plan.md` — a design plan for a new **Bite Analytics** screen reached from a chart button in the Bite tab's app bar. This is a planning document only; no app code changes.

The plan mirrors the existing weight feature's shape (a pure computation class over the repository seam) and the style of `docs/bite_pacing_plan.md`. Every design decision is settled, so implementation can start at Phase 1.

## What the screen covers (v1)

- Daily bites bar chart (last 30 days)
- 30-day and 1-year averages
- 30-day max day
- Meals per day
- Per-day meal breakdown with a snack total

## Key decisions captured

- **Meal** = a cluster of bites ≤ 5 min apart with **≥ 10 bites** (`minMealBites`); smaller clusters are snacks.
- **Averages** count only days with **≥ 40 bites** (`minBitesForAverage`); lightly-logged/zero days are excluded and flagged in the chart (faint line at 40 + muted bars below it).
- `mealGapThreshold = 5 min` is a fixed constant (not user-configurable in v1).
- Meals straddling midnight split at the local-day boundary.
- Meal breakdown defaults to today.
- Navigation: a full-screen pushed route (`BiteAnalyticsPage`) with its own Scaffold/AppBar; the app-bar action shows only on the Bite tab, identified via a new `AppTab` enum rather than a magic index.
- UI state via a `BiteAnalyticsController extends ChangeNotifier`.

## Structure

Guiding principles → v1 scope → meal model → computation layer → navigation → settled decisions → a 9-phase task breakdown (data-first, each phase independently committable and ending green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D27J6sbgfVXPeSuRM7wafF

---
_Generated by [Claude Code](https://claude.ai/code/session_01D27J6sbgfVXPeSuRM7wafF)_