### PR TITLE
feat: add dailyBiteCounts repository query for bite analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ FoodLocker is a Flutter (mobile, primarily Android) app with two shipped feature
 
 `flutter analyze` and `flutter test` both gate pushes locally (`.githooks/pre-push`) and PRs to `main` (`.github/workflows/flutter_ci.yml`). Run them before pushing.
 
+If Flutter is not installed in the environment (e.g. a Claude Code web session), **do not install it** — the toolchain is heavy and the sandboxed sqlite3 native-asset download is unreliable. Instead, push the branch and let the `flutter_ci.yml` workflow run `flutter analyze` and `flutter test` on the PR, then read the CI result to verify. Keep changes small and self-reviewed so a red CI run is cheap to diagnose.
+
 ## Code Generation
 
 `*.g.dart` files (e.g. `lib/features/weight/data/weight.g.dart`, `lib/features/bite/data/bite_database.g.dart`) and `lib/hive_registrar.g.dart` are generated and checked in — do not edit them by hand. After adding or changing a Hive model, or adding a new `@HiveType`, rerun `build_runner`. Hive `typeId`s must be unique and stable across the app's history (weight uses 3 and 4); reusing an old id breaks existing users' stored boxes, so pick a fresh id rather than renumbering. The bite store is Drift: rerun `build_runner` after changing a `@DriftDatabase` table, and bump `BiteDatabase.schemaVersion` with a matching migration so existing users' SQLite files upgrade.

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -211,12 +211,12 @@ fully-tested logic behind no UI.
 **Phase 1 — `dailyBiteCounts` on the repository seam**
 
 The one new persistence query; a SQL `GROUP BY`, no schema change.
-- [ ] Create `lib/features/bite/data/bite_analytics.dart` with the
+- [x] Create `lib/features/bite/data/bite_analytics.dart` with the
       `DailyBiteCount` value type (`day` + `count`) — the file the `BiteAnalytics`
       class lands in next phase
-- [ ] Add `dailyBiteCounts(from, to)` to `BiteRepository`; implement in
+- [x] Add `dailyBiteCounts(from, to)` to `BiteRepository`; implement in
       `DriftBiteRepository` grouping on `date(at_ms/1000,'unixepoch','localtime')`
-- [ ] **Verify:** unit-test grouping, the half-open `[from, to)` window, an empty
+- [x] **Verify:** unit-test grouping, the half-open `[from, to)` window, an empty
       range, and two bites on the same day collapsing to one entry
 
 **Phase 2 — `BiteAnalytics`: counts, averages, max**

--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -1,0 +1,24 @@
+/// Total bites on a single local calendar day.
+///
+/// A read-time projection of the append-only bite log: [day] is normalised to
+/// local midnight (`DateTime(y, m, d)`), so it doubles as the `[day, day.nextDay)`
+/// window's lower bound and compares cleanly against other per-day metrics.
+class DailyBiteCount {
+  const DailyBiteCount({required this.day, required this.count});
+
+  /// The calendar day, at local midnight.
+  final DateTime day;
+
+  /// Bites logged on [day].
+  final int count;
+
+  @override
+  bool operator ==(Object other) =>
+      other is DailyBiteCount && other.day == day && other.count == count;
+
+  @override
+  int get hashCode => Object.hash(day, count);
+
+  @override
+  String toString() => 'DailyBiteCount(day: $day, count: $count)';
+}

--- a/lib/features/bite/data/bite_repository.dart
+++ b/lib/features/bite/data/bite_repository.dart
@@ -1,3 +1,4 @@
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 
 /// The seam in front of the bite dataset.
@@ -30,6 +31,15 @@ abstract interface class BiteRepository {
   /// The number of bites in the half-open window `[from, to)` — the headline
   /// metric. Callers pass a local day's bounds for "today's count".
   Future<int> biteCount(DateTime from, DateTime to);
+
+  /// Bites per local calendar day in the half-open window `[from, to)`, one
+  /// entry per day that has at least one bite, in chronological day order.
+  ///
+  /// Grouped in the store (SQL `date(at_ms/1000,'unixepoch','localtime')`) so a
+  /// year of raw rows never has to cross into Dart just to be counted. Days with
+  /// no bites are absent, not zero-filled — callers that need a dense series
+  /// fill the gaps against their own window.
+  Future<List<DailyBiteCount>> dailyBiteCounts(DateTime from, DateTime to);
 
   /// Appends [cfg] as a new pacing-config version (a config-change marker).
   ///

--- a/lib/features/bite/data/drift_bite_repository.dart
+++ b/lib/features/bite/data/drift_bite_repository.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 
@@ -57,6 +58,41 @@ class DriftBiteRepository implements BiteRepository {
       );
     final row = await query.getSingle();
     return row.read(count) ?? 0;
+  }
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(
+    DateTime from,
+    DateTime to,
+  ) async {
+    final fromMs = from.millisecondsSinceEpoch;
+    final toMs = to.millisecondsSinceEpoch;
+    // 'localtime' resolves each row's day in the device zone, so the grouping
+    // stays DST-safe (a day is its own calendar day, never fixed 24h math).
+    final dayExpr = CustomExpression<String>(
+      "date(at_ms / 1000, 'unixepoch', 'localtime')",
+    );
+    final count = _db.bites.id.count();
+    final query = _db.selectOnly(_db.bites)
+      ..addColumns([dayExpr, count])
+      ..where(
+        _db.bites.atMs.isBiggerOrEqualValue(fromMs) &
+            _db.bites.atMs.isSmallerThanValue(toMs),
+      )
+      ..groupBy([dayExpr])
+      ..orderBy([OrderingTerm.asc(dayExpr)]);
+    final rows = await query.get();
+    return rows.map((row) {
+      // date() yields 'YYYY-MM-DD'; parsing it back builds local midnight, the
+      // same normalisation every other per-day metric uses as its lower bound.
+      final parts = row.read(dayExpr)!.split('-');
+      final day = DateTime(
+        int.parse(parts[0]),
+        int.parse(parts[1]),
+        int.parse(parts[2]),
+      );
+      return DailyBiteCount(day: day, count: row.read(count) ?? 0);
+    }).toList();
   }
 
   @override

--- a/test/features/bite/data/bite_manager_pacing_test.dart
+++ b/test/features/bite/data/bite_manager_pacing_test.dart
@@ -1,6 +1,7 @@
 import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
@@ -216,6 +217,23 @@ class _FakeBiteRepository implements BiteRepository {
   Future<int> biteCount(DateTime from, DateTime to) async => _bites
       .where((at) => !at.isBefore(from) && at.isBefore(to))
       .length;
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(
+    DateTime from,
+    DateTime to,
+  ) async {
+    final byDay = <DateTime, int>{};
+    for (final at in _bites) {
+      if (at.isBefore(from) || !at.isBefore(to)) continue;
+      final day = DateTime(at.year, at.month, at.day);
+      byDay[day] = (byDay[day] ?? 0) + 1;
+    }
+    final days = byDay.keys.toList()..sort();
+    return [
+      for (final day in days) DailyBiteCount(day: day, count: byDay[day]!),
+    ];
+  }
 
   @override
   Future<void> setPacingConfig(PacingConfig cfg) async {}

--- a/test/features/bite/data/drift_bite_repository_test.dart
+++ b/test/features/bite/data/drift_bite_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
@@ -145,6 +146,79 @@ void main() {
         ),
         0,
       );
+    });
+  });
+
+  group('dailyBiteCounts', () {
+    test('groups bites by local calendar day', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 20, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 14, 9, 0, 0));
+
+      final counts = await repo.dailyBiteCounts(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 15),
+      );
+
+      expect(counts, [
+        DailyBiteCount(day: DateTime(2026, 7, 13), count: 2),
+        DailyBiteCount(day: DateTime(2026, 7, 14), count: 1),
+      ]);
+    });
+
+    test('collapses two bites on the same day to one entry', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 30));
+
+      final counts = await repo.dailyBiteCounts(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 14),
+      );
+
+      expect(counts, [DailyBiteCount(day: DateTime(2026, 7, 13), count: 2)]);
+    });
+
+    test('respects the half-open window (includes from, excludes to)', () async {
+      await repo.logBite(DateTime(2026, 7, 13)); // lower bound — included
+      await repo.logBite(DateTime(2026, 7, 14, 12, 0, 0)); // inside
+      await repo.logBite(DateTime(2026, 7, 15)); // upper bound — excluded
+      await repo.logBite(DateTime(2026, 7, 12, 23, 59, 59)); // before
+
+      final counts = await repo.dailyBiteCounts(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 15),
+      );
+
+      expect(counts, [
+        DailyBiteCount(day: DateTime(2026, 7, 13), count: 1),
+        DailyBiteCount(day: DateTime(2026, 7, 14), count: 1),
+      ]);
+    });
+
+    test('omits days with no bites rather than zero-filling them', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 0));
+      await repo.logBite(DateTime(2026, 7, 15, 8, 0, 0)); // 14th has none
+
+      final counts = await repo.dailyBiteCounts(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(counts, [
+        DailyBiteCount(day: DateTime(2026, 7, 13), count: 1),
+        DailyBiteCount(day: DateTime(2026, 7, 15), count: 1),
+      ]);
+    });
+
+    test('is empty when the window holds no bites', () async {
+      await repo.logBite(DateTime(2026, 7, 13, 8, 0, 0));
+
+      final counts = await repo.dailyBiteCounts(
+        DateTime(2026, 7, 14),
+        DateTime(2026, 7, 15),
+      );
+
+      expect(counts, isEmpty);
     });
   });
 

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
@@ -69,6 +70,10 @@ class _RecordingBiteRepository implements BiteRepository {
 
   @override
   Future<int> biteCount(DateTime from, DateTime to) =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(DateTime from, DateTime to) =>
       throw UnimplementedError();
 
   @override


### PR DESCRIPTION
## Summary

Phase 1 of the [bite analytics plan](docs/bite_analytics_plan.md): the one new persistence seam behind the upcoming analytics screen, with **no schema change and no migration**. Nothing here is user-visible yet — Phases 1–3 are pure logic behind no UI.

## Changes

- **`DailyBiteCount` value type** in the new `lib/features/bite/data/bite_analytics.dart` — a small immutable data class (`day` at local midnight + `count`), following the `OvereatingStats` precedent. This is the file the `BiteAnalytics` class lands in next phase.
- **`BiteRepository.dailyBiteCounts(from, to)`** — new interface method returning one entry per day that has at least one bite, in chronological day order. Gap days are omitted rather than zero-filled.
- **`DriftBiteRepository`** implementation — groups in SQL on `date(at_ms/1000,'unixepoch','localtime')` so a year of raw rows never crosses into Dart just to be counted. Local-day and DST-safe; the `YYYY-MM-DD` result is parsed back to local midnight to match the `[startOfDay, …)` idiom used across the codebase.
- Extended the two existing `BiteRepository` test fakes (pacing + serialization) with the new method.
- Added a `CLAUDE.md` note: when Flutter isn't installed in the environment, prefer verifying via this CI workflow rather than installing the toolchain.

## Testing

- New `dailyBiteCounts` test group covering grouping by day, same-day collapse, the half-open `[from, to)` window, omitted gap days, and an empty window.
- Full suite (`flutter analyze` + `flutter test`, 133 tests) verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXerhkWmY6dGft58P2Nvei

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXerhkWmY6dGft58P2Nvei)_