### PR TITLE
docs: add implement-next-phase skill

### DIFF
--- a/.agents/skills/implement-next-phase/SKILL.md
+++ b/.agents/skills/implement-next-phase/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: implement-next-phase
+description: Implement the next phase of a phased design-document plan in the current repo and open a PR for it. Use this whenever the user names a plan document and asks to continue, implement, or work on it — e.g. "bite analytics plan", "do the next phase of the pacing plan", "continue the analytics plan" — even if they don't say the words "phase" or "PR". The plan is a markdown file in the repo whose final section is a numbered list of phases with `- [ ]` checklists.
+---
+# Implement Next Phase
+
+Given the name of a plan document, implement exactly one phase — the next incomplete one — mark it complete inside the plan document, open a PR, and iterate on it until the PR checks are green.
+
+## 1. Locate the plan document
+
+The user gives a loose, human name like "bite analytics plan". Find the file:
+
+- List tracked markdown files (`git ls-files '*.md'`) and match the name against filenames and, if needed, the documents' H1 titles. Normalize (case, spaces vs. `_`/`-`) before matching.
+- Never ask the user anything — resolve autonomously:
+  - Exactly one plausible match → proceed.
+  - Multiple plausible matches → prefer the ones that still have unimplemented phases (an unchecked `- [ ]` item); if more than one of those remains, pick the best match and proceed.
+  - No plausible match → do nothing: report that no plan document was found and stop.
+
+## 2. Identify the next phase
+
+Read the entire plan document, not just the phases. The sections before the phase list (guiding principles, scope, settled decisions, architecture) are binding constraints on how the phase must be implemented.
+
+- The next phase is the first phase whose checklist contains at least one unchecked `- [ ]` item.
+- If every phase is fully checked, report that the plan is complete and stop.
+- Do not look at open PRs, branches, or what other agents may be doing. The plan file on `main` is the single source of truth for what is done.
+
+## 3. Branch
+
+- Update `main` (`git fetch` + checkout/reset to `origin/main`).
+- Create a branch named `phase-<N>-<short-slug>` off it, e.g. `phase-2-bite-analytics-averages`.
+
+## 4. Implement the phase
+
+- Do every checklist item of the phase — no more, no less. Never start the next phase, even if it is small or convenient.
+- Follow the plan's stated file paths, names, constants, and design decisions exactly. If the plan and the code have drifted in a way that makes an item impossible as written, implement the closest faithful equivalent and note the deviation in the PR description.
+- Match the existing code style and the precedents the plan points to.
+
+## 5. Verify locally — without installing anything
+
+The phase's Verify bullet is the definition of done. Run the verification it describes (e.g. the repo's analyzer/tests) only if the required tools are already available in the environment.
+
+- Tools present → run them, fix failures, repeat until green.
+- Tools missing → do not install them. Skip local verification and rely on the PR checks in step 7 instead. Say so in the PR description.
+
+## 6. Mark the phase complete
+
+In the same branch, edit the plan document: flip every checklist item of the implemented phase from `- [ ]` to `- [x]`, including its Verify bullet. Touch nothing else in the document. (The PR is not finished until its checks are green, so the checked state is truthful by the time the PR is mergeable.)
+
+## 7. Open the PR and iterate until green
+
+- Commit with a concise message like `Phase <N>: <phase title>`. The commit includes both the implementation and the plan-document update.
+- Push and open a PR against `main` using whatever GitHub access is available (the `gh` CLI or a GitHub MCP tool — use whichever exists; do not install anything).
+  - Title: `Phase <N>: <phase title> (<plan name>)`
+  - Body: what was implemented, keyed to the phase's checklist; how it was verified (locally, or deferred to PR checks); any deviations from the plan.
+- Watch the PR checks (`gh pr checks --watch` or the MCP equivalent). While any check fails: read the failure logs, fix, commit, push, and watch again.
+- After 5 failed fix rounds, stop pushing and report: link the PR, summarize what still fails and why, and suggest next steps.
+
+## 8. Report
+
+End by giving the user the PR link, the phase implemented, and a one-paragraph summary of what changed and how it was verified. One phase, one PR — then stop.


### PR DESCRIPTION
## Summary

Adds a new repo skill, `implement-next-phase`, at `.agents/skills/implement-next-phase/SKILL.md`, following the same `SKILL.md` frontmatter convention as the existing `resolve-github-issue` and `flutter-emulator-run` skills.

## What the skill does

Given a loose, human name for a plan document (e.g. "bite analytics plan"), it implements exactly the next incomplete phase of a phased design-document plan, marks that phase complete in the plan file, opens a PR, and iterates until checks are green. Key rules baked into the skill:

- **Autonomous plan resolution** — matches the named document against tracked `*.md` filenames/H1 titles; never asks the user; stops if there's no plausible match.
- **`main` is the source of truth** — the next phase is the first one with an unchecked `- [ ]` item; open PRs/branches are ignored.
- **One phase, one PR** — implements every checklist item of that phase and no more; never starts the next phase.
- **No installs** — runs the phase's Verify step only if the tooling is already present, otherwise defers to PR checks.
- Flips the phase's checkboxes to `- [x]` in the same branch, commits impl + plan update together, and watches PR checks, iterating up to 5 fix rounds before reporting a stuck state.

## Verification

Documentation-only change (a single new Markdown skill file); no code paths affected, so nothing to run locally. CI (`flutter analyze` / `flutter test`) will confirm nothing else is disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013pH1guwwxHwJrYnaVb1i9V)_