### PR TITLE
Phase 2: BiteAnalytics — counts, averages, max (bite analytics plan)

### DIFF
--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -222,12 +222,12 @@ The one new persistence query; a SQL `GROUP BY`, no schema change.
 **Phase 2 — `BiteAnalytics`: counts, averages, max**
 
 Pure computation over the repository — no meals yet.
-- [ ] Add the `BiteAnalytics` class (constructed from a `BiteRepository`) to the
+- [x] Add the `BiteAnalytics` class (constructed from a `BiteRepository`) to the
       `bite_analytics.dart` created in Phase 1
-- [ ] `minBitesForAverage = 40` constant
-- [ ] `dailyCounts(from, to)`, `averagePerDay(from, to)` (mean over only the days
+- [x] `minBitesForAverage = 40` constant
+- [x] `dailyCounts(from, to)`, `averagePerDay(from, to)` (mean over only the days
       with ≥ 40 bites — §5.2), `maxDay(from, to)` returning the peak `DailyBiteCount`
-- [ ] **Verify:** unit-test that sub-40 and zero days are excluded from the
+- [x] **Verify:** unit-test that sub-40 and zero days are excluded from the
       average, a window with no qualifying day (average null/0), max with ties, and
       empty data (max null)
 

--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -1,3 +1,5 @@
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+
 /// Total bites on a single local calendar day.
 ///
 /// A read-time projection of the append-only bite log: [day] is normalised to
@@ -21,4 +23,53 @@ class DailyBiteCount {
 
   @override
   String toString() => 'DailyBiteCount(day: $day, count: $count)';
+}
+
+/// Read-time analytics over the append-only bite log.
+///
+/// Mirrors `WeightAnalytics`' shape — a pure projection over the repository,
+/// persisting nothing. Every method is a view of the stored `at_ms`
+/// timestamps: the class holds no state and can be reconstructed freely.
+class BiteAnalytics {
+  BiteAnalytics(this._repository);
+
+  final BiteRepository _repository;
+
+  /// Days below this bite count don't count toward [averagePerDay]: a day you
+  /// forgot to log — or only logged a few bites on — never dilutes the mean.
+  static const int minBitesForAverage = 40;
+
+  /// Bites per local calendar day in the half-open window `[from, to)`, one
+  /// entry per day that has at least one bite, in chronological day order.
+  ///
+  /// Days with no bites are absent, not zero-filled — the chart fills the gaps
+  /// against its own window.
+  Future<List<DailyBiteCount>> dailyCounts(DateTime from, DateTime to) {
+    return _repository.dailyBiteCounts(from, to);
+  }
+
+  /// Mean daily bites over `[from, to)`, counting only days with at least
+  /// [minBitesForAverage] bites (§5.2). Zero and lightly-logged days are
+  /// excluded from both numerator and denominator, so partial-logging noise
+  /// never drags the mean down. Returns 0 when no day qualifies.
+  Future<double> averagePerDay(DateTime from, DateTime to) async {
+    final counts = await _repository.dailyBiteCounts(from, to);
+    final qualifying = counts.where((c) => c.count >= minBitesForAverage);
+    if (qualifying.isEmpty) return 0;
+    final total = qualifying.fold<int>(0, (sum, c) => sum + c.count);
+    return total / qualifying.length;
+  }
+
+  /// The single highest-bite day in `[from, to)`, or null when the window holds
+  /// no bites. On a tie the earliest day wins (chronological order, first max
+  /// kept).
+  Future<DailyBiteCount?> maxDay(DateTime from, DateTime to) async {
+    final counts = await _repository.dailyBiteCounts(from, to);
+    if (counts.isEmpty) return null;
+    var peak = counts.first;
+    for (final c in counts.skip(1)) {
+      if (c.count > peak.count) peak = c;
+    }
+    return peak;
+  }
 }

--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -41,17 +41,15 @@ class BiteAnalytics {
 
   /// Bites per local calendar day in the half-open window `[from, to)`, one
   /// entry per day that has at least one bite, in chronological day order.
-  ///
-  /// Days with no bites are absent, not zero-filled — the chart fills the gaps
-  /// against its own window.
+  /// Days with no bites are absent, not zero-filled.
   Future<List<DailyBiteCount>> dailyCounts(DateTime from, DateTime to) {
     return _repository.dailyBiteCounts(from, to);
   }
 
   /// Mean daily bites over `[from, to)`, counting only days with at least
-  /// [minBitesForAverage] bites (§5.2). Zero and lightly-logged days are
-  /// excluded from both numerator and denominator, so partial-logging noise
-  /// never drags the mean down. Returns 0 when no day qualifies.
+  /// [minBitesForAverage] bites. Zero and lightly-logged days are excluded
+  /// from both numerator and denominator, so partial-logging noise never
+  /// drags the mean down. Returns 0 when no day qualifies.
   Future<double> averagePerDay(DateTime from, DateTime to) async {
     final counts = await _repository.dailyBiteCounts(from, to);
     final qualifying = counts.where((c) => c.count >= minBitesForAverage);
@@ -61,8 +59,7 @@ class BiteAnalytics {
   }
 
   /// The single highest-bite day in `[from, to)`, or null when the window holds
-  /// no bites. On a tie the earliest day wins (chronological order, first max
-  /// kept).
+  /// no bites. On a tie the earliest day wins.
   Future<DailyBiteCount?> maxDay(DateTime from, DateTime to) async {
     final counts = await _repository.dailyBiteCounts(from, to);
     if (counts.isEmpty) return null;

--- a/test/features/bite/data/bite_analytics_test.dart
+++ b/test/features/bite/data/bite_analytics_test.dart
@@ -1,0 +1,133 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+
+/// [BiteAnalytics] over an in-memory Drift store, so the real day-grouping
+/// query backs the pure computation rather than a hand-rolled fake.
+void main() {
+  late BiteDatabase db;
+  late BiteRepository repo;
+  late BiteAnalytics analytics;
+
+  setUp(() {
+    db = BiteDatabase.forTesting(NativeDatabase.memory());
+    repo = DriftBiteRepository(db);
+    analytics = BiteAnalytics(repo);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  /// Logs [count] bites spread through [day], one per minute from 08:00.
+  Future<void> logBites(DateTime day, int count) async {
+    for (var i = 0; i < count; i++) {
+      await repo.logBite(DateTime(day.year, day.month, day.day, 8, i));
+    }
+  }
+
+  group('dailyCounts', () {
+    test('surfaces one entry per day with bites, in day order', () async {
+      await logBites(DateTime(2026, 7, 13), 3);
+      await logBites(DateTime(2026, 7, 15), 1); // 14th has none
+
+      final counts = await analytics.dailyCounts(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(counts, [
+        DailyBiteCount(day: DateTime(2026, 7, 13), count: 3),
+        DailyBiteCount(day: DateTime(2026, 7, 15), count: 1),
+      ]);
+    });
+  });
+
+  group('averagePerDay', () {
+    test('averages only days at or above the 40-bite threshold', () async {
+      await logBites(DateTime(2026, 7, 13), 40); // qualifies (== threshold)
+      await logBites(DateTime(2026, 7, 14), 60); // qualifies
+      await logBites(DateTime(2026, 7, 15), 39); // below — excluded
+
+      final avg = await analytics.averagePerDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      // (40 + 60) / 2 — the 39-bite day is out of both sum and count.
+      expect(avg, 50);
+    });
+
+    test('excludes zero days by construction (they carry no entry)', () async {
+      await logBites(DateTime(2026, 7, 13), 40);
+      // 14th and 15th logged nothing at all.
+
+      final avg = await analytics.averagePerDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(avg, 40);
+    });
+
+    test('is 0 when no day reaches the threshold', () async {
+      await logBites(DateTime(2026, 7, 13), 39);
+      await logBites(DateTime(2026, 7, 14), 10);
+
+      final avg = await analytics.averagePerDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 15),
+      );
+
+      expect(avg, 0);
+    });
+
+    test('is 0 for an empty window', () async {
+      final avg = await analytics.averagePerDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 14),
+      );
+
+      expect(avg, 0);
+    });
+  });
+
+  group('maxDay', () {
+    test('returns the single highest-bite day', () async {
+      await logBites(DateTime(2026, 7, 13), 20);
+      await logBites(DateTime(2026, 7, 14), 55);
+      await logBites(DateTime(2026, 7, 15), 30);
+
+      final max = await analytics.maxDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(max, DailyBiteCount(day: DateTime(2026, 7, 14), count: 55));
+    });
+
+    test('breaks ties toward the earliest day', () async {
+      await logBites(DateTime(2026, 7, 13), 42);
+      await logBites(DateTime(2026, 7, 14), 42);
+
+      final max = await analytics.maxDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 15),
+      );
+
+      expect(max, DailyBiteCount(day: DateTime(2026, 7, 13), count: 42));
+    });
+
+    test('is null when the window holds no bites', () async {
+      final max = await analytics.maxDay(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 14),
+      );
+
+      expect(max, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Implements **Phase 2** of `docs/bite_analytics_plan.md` — the pure, read-time `BiteAnalytics` computation over `BiteRepository` (no meals yet; that's Phase 3).

## What was implemented (keyed to the phase checklist)

- **`BiteAnalytics` class** added to `lib/features/bite/data/bite_analytics.dart`, constructed from a `BiteRepository`, mirroring `WeightAnalytics`' pure-projection shape — holds no state, persists nothing.
- **`minBitesForAverage = 40`** constant.
- **`dailyCounts(from, to)`** — delegates to the repository's day-grouped query (Phase 1).
- **`averagePerDay(from, to)`** — mean over only days with ≥ 40 bites (§5.2); zero and lightly-logged days are excluded from both numerator and denominator. Returns `0` when no day qualifies (per the `Future<double>` signature in §3a).
- **`maxDay(from, to)`** — the peak `DailyBiteCount`, `null` on an empty window; ties broken toward the earliest day (chronological order, first max kept).

## Verification

- Tests added in `test/features/bite/data/bite_analytics_test.dart`, exercised against a real in-memory Drift store: sub-40 and zero days excluded from the average, a window with no qualifying day (average `0`), max with ties (earliest wins), and empty data (max `null`), plus a `dailyCounts` ordering/gap case.
- Flutter is not installed in this web session (per `CLAUDE.md`, the toolchain is not installed here), so `flutter analyze` / `flutter test` were **not** run locally — verification is deferred to the `flutter_ci.yml` checks on this PR.

## Plan doc

Phase 2's checklist (including its Verify bullet) is flipped to `- [x]` in `docs/bite_analytics_plan.md`; nothing else in the doc changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S47DJBm9u17Pba9947JLyL

---
_Generated by [Claude Code](https://claude.ai/code/session_01S47DJBm9u17Pba9947JLyL)_