### PR TITLE
feat: meals-per-day summary (Phase 7)

### DIFF
--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -271,8 +271,8 @@ Get an (empty) screen reachable before filling it in.
 - [x] **Verify:** tiles read correctly against a seeded fixture
 
 **Phase 7 — Meals-per-day summary**
-- [ ] Surface today's meal count and the window average (`averageMealsPerDay`)
-- [ ] **Verify:** matches a hand-counted fixture
+- [x] Surface today's meal count and the window average (`averageMealsPerDay`)
+- [x] **Verify:** matches a hand-counted fixture
 
 **Phase 8 — Daily meal breakdown card**
 - [ ] For today (§5.5): a list of each meal's bite count plus the snack total,

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -59,6 +59,18 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// window holds no bites — the max stat tile's value and its date.
   DailyBiteCount? get maxLast30 => _maxLast30;
 
+  int _mealsToday = 0;
+
+  /// The number of meals logged today — clusters that reached
+  /// [BiteAnalytics.minMealBites]. 0 when today has no qualifying meal.
+  int get mealsToday => _mealsToday;
+
+  double _averageMealsLast30 = 0;
+
+  /// Mean meals per day over the last [dailyBitesWindow] days, across only the
+  /// days that had at least one bite. 0 when the window holds no bites.
+  double get averageMealsLast30 => _averageMealsLast30;
+
   /// Loads the analytics for the screen, notifying at the start and end so the
   /// spinner shows while the store is read.
   Future<void> load() async {
@@ -66,6 +78,7 @@ class BiteAnalyticsController extends ChangeNotifier {
     notifyListeners();
     _hasAnyBites = await _repository.lastBite() != null;
     final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
     final to = DateTime(now.year, now.month, now.day + 1);
     final from30 = DateTime(
       now.year,
@@ -77,6 +90,8 @@ class BiteAnalyticsController extends ChangeNotifier {
     _averageLast30 = await _analytics.averagePerDay(from30, to);
     _maxLast30 = await _analytics.maxDay(from30, to);
     _averageLastYear = await _analytics.averagePerDay(fromYear, to);
+    _mealsToday = (await _analytics.mealsForDay(today)).length;
+    _averageMealsLast30 = await _analytics.averageMealsPerDay(from30, to);
     _isLoading = false;
     notifyListeners();
   }

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -57,6 +57,10 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
                 averageLastYear: _controller.averageLastYear,
                 maxLast30: _controller.maxLast30,
               ),
+              _MealsSummaryRow(
+                mealsToday: _controller.mealsToday,
+                averageMealsLast30: _controller.averageMealsLast30,
+              ),
             ],
           );
         },
@@ -158,6 +162,51 @@ class _StatTilesRow extends StatelessWidget {
 
   /// A day as `month/day`, matching the daily-bites chart's axis labels.
   static String _formatDay(DateTime day) => '${day.month}/${day.day}';
+}
+
+/// A meals summary: today's meal count and the 30-day average meals per day. A
+/// meal is a cluster of at least [BiteAnalytics.minMealBites] bites no more than
+/// [BiteAnalytics.mealGapThreshold] apart; the average spans only days that had
+/// bites, so `—` marks a window with no meals rather than zero.
+class _MealsSummaryRow extends StatelessWidget {
+  const _MealsSummaryRow({
+    required this.mealsToday,
+    required this.averageMealsLast30,
+  });
+
+  final int mealsToday;
+  final double averageMealsLast30;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 16.0),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: StatTile(
+                label: 'Meals today',
+                value: mealsToday.toString(),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: StatTile(
+                label: '30-day avg meals',
+                value: _formatMealAverage(averageMealsLast30),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Meals per day to one decimal, with `—` for a window that held no meals.
+  static String _formatMealAverage(double average) =>
+      average == 0 ? '—' : average.toStringAsFixed(1);
 }
 
 /// Shown when the bite log is empty: there is nothing to analyse until bites

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -31,6 +31,14 @@ void main() {
     }
   }
 
+  /// Logs [count] bites one per minute from [hour]:00 on [day] — a single
+  /// cluster (consecutive-minute gaps stay under the meal-gap threshold).
+  Future<void> logCluster(DateTime day, int hour, int count) async {
+    for (var i = 0; i < count; i++) {
+      await repo.logBite(DateTime(day.year, day.month, day.day, hour, i));
+    }
+  }
+
   Future<void> pumpPage(WidgetTester tester) async {
     await tester.pumpWidget(
       Provider<BiteRepository>.value(
@@ -112,6 +120,42 @@ void main() {
       find.descendant(
         of: find.widgetWithText(StatTile, '30-day max'),
         matching: find.text('5'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('meal tiles read today\'s meals and the window average from a '
+      'hand-counted fixture', (tester) async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+    final earlier = DateTime(now.year, now.month, now.day - 3);
+
+    // Today: two meals (12 bites @ 08, 15 @ 09) plus a 5-bite snack @ 10 that
+    // stays below minMealBites → 2 meals.
+    await logCluster(today, 8, 12);
+    await logCluster(today, 9, 15);
+    await logCluster(today, 10, 5);
+    // Yesterday: a single 20-bite meal.
+    await logCluster(yesterday, 8, 20);
+    // Three days ago: 8 bites — a snack, so a logged day with 0 meals.
+    await logCluster(earlier, 8, 8);
+    // Days with bites in the window: 3; meals 2 + 1 + 0 = 3 → average 1.0.
+
+    await pumpPage(tester);
+
+    expect(
+      find.descendant(
+        of: find.widgetWithText(StatTile, 'Meals today'),
+        matching: find.text('2'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.widgetWithText(StatTile, '30-day avg meals'),
+        matching: find.text('1.0'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Implements **Phase 7 — Meals-per-day summary** of the Bite Analytics plan (`docs/bite_analytics_plan.md`).

## What changed

Surfaces two new meal metrics on the Bite Analytics screen, both derived at read time from the stored bite log (nothing new persisted, no schema change):

- **`BiteAnalyticsController`** now loads:
  - `mealsToday` — today's meal count (`mealsForDay(today).length`, i.e. clusters that reached `minMealBites`).
  - `averageMealsLast30` — mean meals per day over the 30-day window (`averageMealsPerDay`, across only days that had bites).
- **`bite_analytics_page.dart`** gains a `_MealsSummaryRow`: a two-tile band reusing the existing `StatTile`, showing "Meals today" and "30-day avg meals". The average renders to one decimal, with `—` for a window that held no meals (consistent with the sibling averages tiles' dash-on-empty treatment).

Both `mealsForDay` and `averageMealsPerDay` already existed and were unit-tested in Phase 3 — this phase only surfaces them.

## Checklist (Phase 7)

- [x] Surface today's meal count and the window average (`averageMealsPerDay`)
- [x] Verify: matches a hand-counted fixture

## Verification

Added a widget test in `test/ui/pages/bite_analytics_page_test.dart` driving a real in-memory Drift store with a hand-counted fixture: today has two meals (12 + 15 bites) plus a 5-bite snack, yesterday one 20-bite meal, and a 3-days-ago 8-bite snack day — 3 logged days, 3 meals total → the tiles read **2** meals today and a **1.0** window average.

Flutter is not installed in this Claude Code web session, so `flutter analyze` / `flutter test` were not run locally (per the repo's CLAUDE.md guidance) — relying on the `flutter_ci.yml` PR checks to verify.

No deviations from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZaZqRtNajdCdShY7P2z2t)_