### PR TITLE
feat: daily meal breakdown card (Phase 8)

### DIFF
--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -275,9 +275,9 @@ Get an (empty) screen reachable before filling it in.
 - [x] **Verify:** matches a hand-counted fixture
 
 **Phase 8 — Daily meal breakdown card**
-- [ ] For today (§5.5): a list of each meal's bite count plus the snack total,
+- [x] For today (§5.5): a list of each meal's bite count plus the snack total,
       with an empty state when today has no bites yet
-- [ ] **Verify:** meals, snacks, and the empty state each render
+- [x] **Verify:** meals, snacks, and the empty state each render
 
 **Phase 9 — Polish**
 - [ ] Accessibility labels on the chart and tiles, consistent theming/spacing,

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -71,6 +71,16 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// days that had at least one bite. 0 when the window holds no bites.
   double get averageMealsLast30 => _averageMealsLast30;
 
+  DayMealBreakdown _breakdownToday = DayMealBreakdown(
+    day: DateTime.fromMillisecondsSinceEpoch(0),
+    meals: const [],
+    snackBites: 0,
+  );
+
+  /// Today split into its meals and its snack total — the meal-breakdown card's
+  /// data. Empty (no meals, no snack bites) until today has a bite.
+  DayMealBreakdown get breakdownToday => _breakdownToday;
+
   /// Loads the analytics for the screen, notifying at the start and end so the
   /// spinner shows while the store is read.
   Future<void> load() async {
@@ -90,7 +100,8 @@ class BiteAnalyticsController extends ChangeNotifier {
     _averageLast30 = await _analytics.averagePerDay(from30, to);
     _maxLast30 = await _analytics.maxDay(from30, to);
     _averageLastYear = await _analytics.averagePerDay(fromYear, to);
-    _mealsToday = (await _analytics.mealsForDay(today)).length;
+    _breakdownToday = await _analytics.breakdownForDay(today);
+    _mealsToday = _breakdownToday.meals.length;
     _averageMealsLast30 = await _analytics.averageMealsPerDay(from30, to);
     _isLoading = false;
     notifyListeners();

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -3,6 +3,7 @@ import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_analytics_controller.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/ui/widgets/daily_bites_chart.dart';
+import 'package:food_locker/ui/widgets/meal_breakdown_list.dart';
 import 'package:food_locker/ui/widgets/stat_tile.dart';
 import 'package:provider/provider.dart';
 
@@ -61,6 +62,7 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
                 mealsToday: _controller.mealsToday,
                 averageMealsLast30: _controller.averageMealsLast30,
               ),
+              _MealBreakdownCard(breakdown: _controller.breakdownToday),
             ],
           );
         },
@@ -207,6 +209,37 @@ class _MealsSummaryRow extends StatelessWidget {
   /// Meals per day to one decimal, with `—` for a window that held no meals.
   static String _formatMealAverage(double average) =>
       average == 0 ? '—' : average.toStringAsFixed(1);
+}
+
+/// Today's meal breakdown, framed in a titled card matching the daily-bites
+/// card. The [MealBreakdownList] carries its own empty state for a day with no
+/// bites yet, so the card is always shown once the log holds any bite at all.
+class _MealBreakdownCard extends StatelessWidget {
+  const _MealBreakdownCard({required this.breakdown});
+
+  final DayMealBreakdown breakdown;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 16.0),
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Today\'s meals', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            MealBreakdownList(breakdown: breakdown),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 /// Shown when the bite log is empty: there is nothing to analyse until bites

--- a/lib/ui/widgets/meal_breakdown_list.dart
+++ b/lib/ui/widgets/meal_breakdown_list.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+
+/// The meal-by-meal breakdown of a single day: one row per meal with its bite
+/// count and time span, plus a trailing row for the day's snack total (every
+/// bite outside a qualifying meal).
+///
+/// A read-only projection of [DayMealBreakdown]. When the day has no bites yet
+/// — no meals and no snacks — it shows an empty state instead of blank rows.
+class MealBreakdownList extends StatelessWidget {
+  const MealBreakdownList({super.key, required this.breakdown});
+
+  /// The day split into its meals and snack total.
+  final DayMealBreakdown breakdown;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final meals = breakdown.meals;
+    if (meals.isEmpty && breakdown.snackBites == 0) {
+      return _empty(theme);
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (var i = 0; i < meals.length; i++)
+          _MealRow(index: i + 1, meal: meals[i]),
+        _SnackRow(bites: breakdown.snackBites),
+      ],
+    );
+  }
+
+  Widget _empty(ThemeData theme) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 24.0),
+    child: Text(
+      'No bites logged today yet.',
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      textAlign: TextAlign.center,
+    ),
+  );
+}
+
+/// A single meal: its ordinal, the span it ran over, and its bite count.
+class _MealRow extends StatelessWidget {
+  const _MealRow({required this.index, required this.meal});
+
+  final int index;
+  final Meal meal;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: 'Meal $index, ${meal.count} bites',
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Meal $index', style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${_formatTime(meal.start)} – ${_formatTime(meal.end)}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Text('${meal.count} bites', style: theme.textTheme.titleMedium),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The day's snack total: every bite that fell outside a qualifying meal.
+class _SnackRow extends StatelessWidget {
+  const _SnackRow({required this.bites});
+
+  final int bites;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: 'Snacks, $bites bites',
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Snacks',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            Text(
+              '$bites bites',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A local time as `h:mm AM/PM`, 12-hour with no leading zero on the hour.
+String _formatTime(DateTime at) {
+  final hour12 = at.hour % 12 == 0 ? 12 : at.hour % 12;
+  final minute = at.minute.toString().padLeft(2, '0');
+  final period = at.hour < 12 ? 'AM' : 'PM';
+  return '$hour12:$minute $period';
+}

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -160,4 +160,41 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('meal breakdown card lists today\'s meals and snack total', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    // Today: two meals (12 @ 08, 15 @ 09) plus a 5-bite snack @ 10.
+    await logCluster(today, 8, 12);
+    await logCluster(today, 9, 15);
+    await logCluster(today, 10, 5);
+
+    await pumpPage(tester);
+
+    expect(find.text('Today\'s meals'), findsOneWidget);
+    expect(find.text('Meal 1'), findsOneWidget);
+    expect(find.text('Meal 2'), findsOneWidget);
+    expect(find.text('12 bites'), findsOneWidget);
+    expect(find.text('15 bites'), findsOneWidget);
+    expect(find.text('Snacks'), findsOneWidget);
+    expect(find.text('5 bites'), findsOneWidget);
+  });
+
+  testWidgets('meal breakdown card shows its empty state when today is empty '
+      'but earlier days have bites', (tester) async {
+    final now = DateTime.now();
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+
+    // Bites only on yesterday: the page has data, but today is empty.
+    await logCluster(yesterday, 8, 20);
+
+    await pumpPage(tester);
+
+    expect(find.text('Today\'s meals'), findsOneWidget);
+    expect(find.text('No bites logged today yet.'), findsOneWidget);
+    expect(find.text('Snacks'), findsNothing);
+  });
 }

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -173,6 +173,8 @@ void main() {
     await logCluster(today, 10, 5);
 
     await pumpPage(tester);
+    // The breakdown card is the bottom card in the scroll view; build it.
+    await tester.scrollUntilVisible(find.text('Today\'s meals'), 200);
 
     expect(find.text('Today\'s meals'), findsOneWidget);
     expect(find.text('Meal 1'), findsOneWidget);
@@ -192,6 +194,7 @@ void main() {
     await logCluster(yesterday, 8, 20);
 
     await pumpPage(tester);
+    await tester.scrollUntilVisible(find.text('Today\'s meals'), 200);
 
     expect(find.text('Today\'s meals'), findsOneWidget);
     expect(find.text('No bites logged today yet.'), findsOneWidget);

--- a/test/ui/widgets/meal_breakdown_list_test.dart
+++ b/test/ui/widgets/meal_breakdown_list_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/ui/theme.dart';
+import 'package:food_locker/ui/widgets/meal_breakdown_list.dart';
+
+void main() {
+  Future<void> pumpList(WidgetTester tester, DayMealBreakdown breakdown) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme,
+        home: Scaffold(body: MealBreakdownList(breakdown: breakdown)),
+      ),
+    );
+  }
+
+  final day = DateTime(2026, 7, 16);
+
+  testWidgets('renders a row per meal with its count and the snack total', (
+    tester,
+  ) async {
+    await pumpList(
+      tester,
+      DayMealBreakdown(
+        day: day,
+        meals: [
+          Meal(
+            start: DateTime(2026, 7, 16, 8, 0),
+            end: DateTime(2026, 7, 16, 8, 11),
+            count: 12,
+          ),
+          Meal(
+            start: DateTime(2026, 7, 16, 13, 30),
+            end: DateTime(2026, 7, 16, 13, 44),
+            count: 15,
+          ),
+        ],
+        snackBites: 5,
+      ),
+    );
+
+    expect(find.text('Meal 1'), findsOneWidget);
+    expect(find.text('Meal 2'), findsOneWidget);
+    expect(find.text('12 bites'), findsOneWidget);
+    expect(find.text('15 bites'), findsOneWidget);
+    expect(find.text('Snacks'), findsOneWidget);
+    expect(find.text('5 bites'), findsOneWidget);
+    // A morning and an afternoon meal read as 12-hour times.
+    expect(find.text('8:00 AM – 8:11 AM'), findsOneWidget);
+    expect(find.text('1:30 PM – 1:44 PM'), findsOneWidget);
+  });
+
+  testWidgets('renders the snack total on an all-snack day with no meals', (
+    tester,
+  ) async {
+    await pumpList(
+      tester,
+      DayMealBreakdown(day: day, meals: const [], snackBites: 8),
+    );
+
+    expect(find.text('Meal 1'), findsNothing);
+    expect(find.text('Snacks'), findsOneWidget);
+    expect(find.text('8 bites'), findsOneWidget);
+  });
+
+  testWidgets('shows the empty state when the day has no bites', (tester) async {
+    await pumpList(
+      tester,
+      DayMealBreakdown(day: day, meals: const [], snackBites: 0),
+    );
+
+    expect(find.text('No bites logged today yet.'), findsOneWidget);
+    expect(find.text('Snacks'), findsNothing);
+  });
+}


### PR DESCRIPTION
Implements **Phase 8 — Daily meal breakdown card** of the Bite Analytics plan (`docs/bite_analytics_plan.md`).

## What changed
- **`MealBreakdownList`** (`lib/ui/widgets/meal_breakdown_list.dart`, new) — renders today's breakdown as one row per meal (ordinal, `h:mm AM/PM` time span, bite count) plus a trailing **Snacks** total row (§2b: every bite outside a qualifying meal). Carries its own **empty state** — "No bites logged today yet." — for a day with no meals and no snack bites (§5.5).
- **`BiteAnalyticsController`** now loads today's `DayMealBreakdown` via `breakdownForDay(today)` and exposes it as `breakdownToday`. `mealsToday` is now derived from that same breakdown's `meals.length`, dropping a redundant `mealsForDay` repository read (both already return clusters that reached `minMealBites`, so the value is identical).
- **`BiteAnalyticsPage`** gains a titled **"Today's meals"** card (`_MealBreakdownCard`) below the meals-summary row, matching the daily-bites card's chrome.

## Checklist (Phase 8)
- [x] For today (§5.5): a list of each meal's bite count plus the snack total, with an empty state when today has no bites yet
- [x] **Verify:** meals, snacks, and the empty state each render

## Verification
Flutter isn't available in this web session (per `CLAUDE.md`, the toolchain isn't installed here), so `flutter analyze` / `flutter test` are deferred to the `flutter_ci.yml` PR checks. Tests added:
- `test/ui/widgets/meal_breakdown_list_test.dart` — meals-with-snack render (including 12-hour time formatting), an all-snack day with no meals, and the empty state.
- `test/ui/pages/bite_analytics_page_test.dart` — the breakdown card lists today's meals + snack total against a seeded Drift fixture, and shows its empty state when today is empty but earlier days have bites.

## Deviations
None. Scope is limited to Phase 8; the plan document's Phase 8 checklist is flipped to complete in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xm6B7YdWgpkviY4MTz7w6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xm6B7YdWgpkviY4MTz7w6e)_