### PR TITLE
docs: add analytics enhancements & floating window plans

### DIFF
--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -9,8 +9,8 @@ across the Bite tab and its analytics screen:
 3. **Current-meal bites on the main Bite page** — the in-progress meal's running
    count, alongside the day's headline total.
 
-> **Status: ready to build.** Nothing here is built yet; the design decisions
-> below (§4) are proposed defaults — confirm or adjust before Phase 1.
+> **Status: ready to build.** Nothing here is built yet, but every design
+> decision (§4) is settled — implementation can start at Phase 1.
 
 ---
 
@@ -140,6 +140,10 @@ trailing cluster of today's bites whose consecutive gaps are `≤ mealGapThresho
 (5 min), using the same rule as the analytics meal model. It answers "how much
 have I eaten *this* sitting?" next to the all-day total.
 
+Shown only while a meal is **actually in progress**: if the most recent bite is
+more than `mealGapThreshold` ago, the sitting has ended and the line is hidden —
+so opening the app hours after a meal shows nothing rather than a stale count.
+
 No `minMealBites` gate applies to the live count — it counts from the first bite
 of the sitting, before the cluster is big enough to have "qualified" as a meal in
 the analytics sense.
@@ -151,23 +155,29 @@ every mutation. The current-meal size follows the exact same pattern: it's
 **recomputed from today's stored bites**, not tracked with a running counter.
 
 ```dart
-/// Bites in the current meal: the size of the trailing run of today's bites no
-/// more than [BiteAnalytics.mealGapThreshold] apart. Recomputed from the store
-/// alongside [todayCount]; 0 when today has no bites.
+/// Bites in the current meal, or 0 when no meal is in progress. Recomputed from
+/// the store alongside [todayCount]: the size of the trailing run of today's
+/// bites no more than [BiteAnalytics.mealGapThreshold] apart — but only when the
+/// most recent bite is within that threshold of now. A last bite older than the
+/// threshold means the sitting has ended, so this reads 0.
 int get currentMealBites;
 ```
 
-- **On `logBite` and `initialize`:** cluster today's bites by the
-  `mealGapThreshold` rule and take the trailing cluster's size — folded into the
-  same refresh that already recomputes the day count, off one read of today's
-  bites. There is no increment/reset arithmetic and no `_currentMealCount` state
-  to keep in sync; the number is always a projection of the log.
+- **On `logBite` and `initialize`** (every refresh that recomputes the day
+  count): first gate on recency — if the most recent bite is more than
+  `mealGapThreshold` ago, `currentMealBites` is 0. Otherwise cluster today's bites
+  by the `mealGapThreshold` rule and take the trailing cluster's size. It's folded
+  into the same refresh, off one read of today's bites — there is no increment/
+  reset arithmetic and no `_currentMealCount` state to keep in sync; the number is
+  always a projection of the log.
 - Reuse the meal-clustering already in `BiteAnalytics` (extract its private
   `_clusterBites` / `mealGapThreshold` into a shared spot) so the live count and
   the analytics screen apply one identical rule.
 
-Because it's recomputed from the log, resetting is automatic: a tap after a
-`> mealGapThreshold` gap forms a fresh trailing cluster of size 1.
+Because it's recomputed from the log, resetting is automatic: a just-logged bite
+(`lastBite == now`) always shows and starts a fresh trailing cluster of size 1
+after a `> mealGapThreshold` gap, while opening the app long after the last bite
+shows nothing.
 
 ### 3c. UI
 
@@ -175,18 +185,18 @@ Because it's recomputed from the log, resetting is automatic: a tap after a
 (e.g. "This meal: N"), rendered only when `currentMealBites > 0` so an empty day
 stays clean. It reads `biteManager.currentMealBites`; no new provider.
 
-**Bite-driven caveat (settled, §4.4):** the number refreshes only when the manager
-recomputes — on a bite or on open — not on a timer. Between bites it does not
-auto-clear at the 5-min mark (the pacing ticker stops at `b2` (~30 s), so there's
-no periodic rebuild), and on open it reflects today's trailing cluster. It settles
-to the right value on the next bite. A timer to blank it exactly at the 5-min
-boundary is deliberately out of scope for v1.
+**Bite-driven caveat (settled, §4.4):** the recency gate is evaluated when the
+manager recomputes — on a bite or on open — not on a timer. So opening the app
+after a meal ended correctly shows nothing, but if you sit on the Bite page and
+the 5-min mark passes with no new bite, the line only clears on the next refresh
+(a bite, a tab switch, or reopening the tab), since no ticker runs past `b2`
+(~30 s). A timer to blank it at the exact 5-min boundary is out of scope for v1.
 
 ---
 
-## 4. Proposed decisions
+## 4. Settled decisions
 
-Defaults chosen to match the shipped screen; confirm or adjust before building.
+All confirmed — these fix the behaviour on screen:
 
 1. **Avg meal size counts only qualifying meals** (`≥ minMealBites`), excluding
    snacks, and is shown as a whole number of bites. `—` when the window has no
@@ -199,9 +209,11 @@ Defaults chosen to match the shipped screen; confirm or adjust before building.
    bites (trailing `mealGapThreshold` cluster) alongside the day count, with no
    running counter. It reuses `mealGapThreshold` (5 min) and ignores
    `minMealBites` for the live count (it counts from bite 1 of the sitting).
-4. **Current meal is bite-driven, not timer-driven** — it refreshes on a bite or
-   on open, not at the instant 5 min elapses (§3c).
-5. **Current-meal line is hidden when the day has no bites.**
+4. **Current meal is bite-driven, not timer-driven** — the recency check and
+   recompute run on a bite or on open, not at the instant 5 min elapses; the line
+   can linger past 5 min only until the next refresh (§3c).
+5. **Current-meal line is hidden when no meal is in progress** — the day has no
+   bites, or the most recent bite is more than `mealGapThreshold` (5 min) ago.
 
 ---
 
@@ -248,14 +260,16 @@ Chart tap drives the breakdown card; no new analytics.
       apply one identical rule
 - [ ] Add `currentMealBites` to `BiteManager`, **recomputed** from today's bites
       (trailing `mealGapThreshold` cluster) in the same refresh that recomputes the
-      day count — no running counter, no `initialize` special-casing beyond that
-      refresh
+      day count, gated on recency — 0 when the most recent bite is more than
+      `mealGapThreshold` ago; no running counter, no `initialize` special-casing
+      beyond that refresh
 - [ ] Show a quiet "This meal: N" line under the day total in `bite_page.dart`,
       hidden when `currentMealBites == 0`
-- [ ] **Verify:** unit-test the trailing cluster's size within the threshold, a
-      fresh trailing cluster of 1 after a `> mealGapThreshold` gap, a fresh manager
-      at 0, and that it recomputes after a logged bite; widget-test the line shows
-      with a current meal and hides on an empty day
+- [ ] **Verify:** unit-test the trailing cluster's size when the last bite is
+      recent, 0 when the last bite is older than `mealGapThreshold`, a fresh
+      cluster of 1 after a `> mealGapThreshold` gap, a fresh manager at 0, and that
+      it recomputes after a logged bite; widget-test the line shows with a current
+      meal and hides when no meal is in progress
 
 **Phase 4 — Polish**
 - [ ] Accessibility labels on the new tile, the selected-bar highlight, and the

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -1,0 +1,256 @@
+# Food Locker — Bite Analytics Enhancements Plan
+
+A follow-up to `bite_analytics_plan.md` (now shipped) adding three refinements
+across the Bite tab and its analytics screen:
+
+1. **Average meal size** over the last 30 days, as a new stat tile.
+2. **A pickable breakdown day** — tapping a bar in the daily-bites chart switches
+   the meal-breakdown card below it to that day.
+3. **Current-meal bites on the main Bite page** — the in-progress meal's running
+   count, alongside the day's headline total.
+
+> **Status: ready to build.** Nothing here is built yet; the design decisions
+> below (§4) are proposed defaults — confirm or adjust before Phase 1.
+
+---
+
+## 0. Guiding principles
+
+Unchanged from `bite_analytics_plan.md` §0 and `bite_pacing_plan.md` §0, and they
+still constrain every decision here:
+
+- **Store facts, derive views.** The `bites` table stays an append-only log of
+  raw `at_ms` timestamps. Average meal size, the current-meal count, and every
+  breakdown are **read-time projections** of that log. No schema change, no
+  migration, nothing new persisted.
+- **Bite count is the headline metric.** The new numbers elaborate on the count;
+  they never compete with it.
+- **Reuse the settled meal model.** "Meal", "snack", `mealGapThreshold` (5 min),
+  and `minMealBites` (10) already live on `BiteAnalytics` (§2 of the analytics
+  plan). Both feature 1 and feature 3 build on those exact definitions rather
+  than introducing a second clustering rule.
+- **Local-day granularity, DST-safe.** Days are calendar days in the device's
+  local zone, bounded by `[startOfDay, startOfNextDay)` and built with the
+  `DateTime(y, m, d ± 1)` idiom — never fixed 24-hour arithmetic.
+
+---
+
+## 1. Average meal size (last 30 days)
+
+### 1a. What it is
+
+The mean number of bites in a **meal** — a qualifying cluster of `≥ minMealBites`
+bites — across the last 30 days. Snacks (sub-`minMealBites` clusters) are excluded
+by definition, so this measures the size of actual meals, not of all eating.
+
+`averageMealSize = Σ(bites in meals over the window) / (number of meals)`
+
+Returns `0` when the window holds no meal, mirroring how `averagePerDay` and
+`averageMealsPerDay` treat an empty window (rendered as `—`).
+
+### 1b. Where it lives
+
+A new method on `BiteAnalytics` (`lib/features/bite/data/bite_analytics.dart`),
+built from the same per-day clustering the class already does for
+`averageMealsPerDay`:
+
+```dart
+/// Mean bites per meal over `[from, to)` — total bites in qualifying meal
+/// clusters divided by the number of those clusters. Snacks are excluded.
+/// Returns 0 when the window holds no meal.
+Future<double> averageMealSize(DateTime from, DateTime to);
+```
+
+`averageMealsPerDay` already clusters each day and counts the meals; this reuses
+that traversal, summing meal *bites* as well as counting meals. Factor the shared
+"meal clusters across a window" walk into one private helper so the two methods
+can't drift apart.
+
+### 1c. UI
+
+The meals summary row (`_MealsSummaryRow` in `bite_analytics_page.dart`) grows
+from two tiles to three — **Meals today**, **30-day avg meals**, **30-day avg
+meal size** — matching the three-across `_StatTilesRow` above it. The controller
+gains `averageMealSizeLast30`, loaded over the same `from30 … to` window the other
+30-day metrics already use.
+
+---
+
+## 2. Pickable breakdown day
+
+### 2a. What changes
+
+Today the breakdown card is pinned to today (`breakdownToday`). This makes the
+day **selectable**: tapping a bar in the daily-bites chart selects that calendar
+day, and the breakdown card re-queries and re-renders for it. Today stays the
+default selection on open, and a control returns to today after browsing.
+
+No new analytics: `BiteAnalytics.breakdownForDay(day)` already takes any day.
+This is a controller + chart-wiring change.
+
+### 2b. Controller
+
+`BiteAnalyticsController` replaces the fixed `breakdownToday` with a selected-day
+model:
+
+```dart
+DateTime get selectedDay;             // defaults to today
+bool get isSelectedDayToday;          // drives the "back to today" affordance
+DayMealBreakdown get selectedBreakdown;
+Future<void> selectDay(DateTime day); // re-queries breakdownForDay, notifies
+```
+
+`selectDay` normalises to local midnight, sets a per-card loading flag, awaits
+`breakdownForDay`, and notifies — so re-selection never blocks the rest of the
+screen. The initial `load()` seeds `selectedDay = today`. `mealsToday` and the
+30-day tiles are unaffected — they stay today/window metrics.
+
+### 2c. Chart
+
+`DailyBitesChart` gains two optional parameters, staying a stateless widget:
+
+```dart
+final DateTime? selectedDay;              // highlighted bar
+final ValueChanged<DateTime>? onDaySelected;
+```
+
+- **Selection** rides `BarTouchData.touchCallback`: on a tap-up event, map
+  `group.x` back to its calendar day (the same `firstDay + index` arithmetic the
+  tooltip and axis labels already use) and call `onDaySelected`.
+- **Highlight** the selected bar so the link to the card below is visible — e.g. a
+  border or a full-opacity rod even when it's below the 40 line — without losing
+  the existing muted/threshold treatment.
+- The existing tooltip stays; tapping both shows the tooltip and selects the day.
+
+### 2d. Card
+
+`_MealBreakdownCard`'s title becomes the selected date ("Meals — Jul 14", "Today's
+meals" when it's today), with a small "Back to today" action shown only when
+`!isSelectedDayToday`. The card keeps its own empty state for a selected day with
+no bites.
+
+---
+
+## 3. Current-meal bites on the main Bite page
+
+### 3a. What it is
+
+Under "Today's Bites", show the number of bites in the **current meal** — the
+trailing cluster of bites whose consecutive gaps are `≤ mealGapThreshold`
+(5 min), using the same rule as the analytics meal model. It answers "how much
+have I eaten *this* sitting?" next to the all-day total.
+
+A meal is "in progress" while the last bite is within `mealGapThreshold` of now;
+once that lapses the current-meal count clears (the next bite after the gap starts
+a fresh meal at 1). No `minMealBites` gate applies to the live count — it counts
+from the first bite of the sitting, before the cluster is big enough to have
+"qualified" as a meal in the analytics sense.
+
+### 3b. Where it lives
+
+`BiteManager` already holds `_lastBiteAt` in memory and drives the live screen, so
+the current-meal count lives there as derived state:
+
+```dart
+/// Bites in the current (in-progress) meal: the trailing run of bites no more
+/// than [BiteAnalytics.mealGapThreshold] apart, ending at the last bite. 0 when
+/// no meal is in progress (no bite within the threshold of now).
+int get currentMealBites;
+```
+
+- **On `logBite`:** if the previous bite is within `mealGapThreshold` of now,
+  increment; otherwise reset to 1 (this tap starts a new meal).
+- **On `initialize`:** seed by reading today's bites, clustering the tail, and
+  taking the trailing cluster's size — but only when the last bite is within
+  `mealGapThreshold` of now; otherwise seed 0, so opening the app hours later
+  shows no stale in-progress meal.
+- Reuse `BiteAnalytics.mealGapThreshold` as the single source of the 5-min rule
+  rather than redefining it on the manager.
+
+### 3c. UI
+
+`bite_page.dart` shows the count as a quiet secondary line under the big day total
+(e.g. "This meal: N"), rendered only when `currentMealBites > 0` so an empty day
+stays clean. It reads `biteManager.currentMealBites`; no new provider.
+
+**Live-clear caveat (settled, §4.4):** the number is bite-driven. Between bites it
+does not auto-clear at the 5-min mark — the pacing ticker stops at `b2` (~30 s), so
+there's no periodic rebuild to hide it on. It clears on the next bite after a gap
+(reset to 1) or when the tab/app is left and the page rebuilds. A timer to blank it
+exactly at the 5-min boundary is deliberately out of scope for v1.
+
+---
+
+## 4. Proposed decisions
+
+Defaults chosen to match the shipped screen; confirm or adjust before building.
+
+1. **Avg meal size counts only qualifying meals** (`≥ minMealBites`), excluding
+   snacks, and is shown as a whole number of bites. `—` when the window has no
+   meal.
+2. **Breakdown-day selection is tap-to-select on the chart**, defaulting to today,
+   with an explicit "Back to today" control. The top stat tiles and "Meals today"
+   stay today/window metrics — only the bottom breakdown card follows the
+   selection.
+3. **Current meal reuses `mealGapThreshold` (5 min)** and ignores `minMealBites`
+   for the live count (it counts from bite 1 of the sitting).
+4. **Current meal is bite-driven, not timer-driven** — it clears on the next
+   post-gap bite, not at the instant 5 min elapses (§3c).
+5. **Current-meal line is hidden when the day has no bites.**
+
+---
+
+## 5. Phases
+
+Each phase is one sitting on a single subject, ends **green** (`flutter analyze`
++ `flutter test` pass), and is independently committable. Ordered so each assumes
+the earlier ones; every phase ships with its tests — the "verify" bullet is the
+definition of done.
+
+**Phase 1 — `averageMealSize` on `BiteAnalytics` + the stat tile**
+
+Pure computation first, then wire it into the existing meals summary row.
+- [ ] Add `averageMealSize(from, to)` to `BiteAnalytics`, factoring the shared
+      "meal clusters across a window" walk out of `averageMealsPerDay` so the two
+      can't diverge
+- [ ] Add `averageMealSizeLast30` to `BiteAnalyticsController`, loaded over the
+      existing `from30 … to` window
+- [ ] Add the third tile ("30-day avg meal size") to `_MealsSummaryRow`
+- [ ] **Verify:** unit-test avg meal size with snacks excluded, a window with no
+      meal (0/`—`), a single meal, and multiple meals across several days; the
+      tile reads correctly against a seeded fixture
+
+**Phase 2 — Pickable breakdown day**
+
+Chart tap drives the breakdown card; no new analytics.
+- [ ] Replace `breakdownToday` with `selectedDay` / `selectedBreakdown` /
+      `isSelectedDayToday` on the controller, plus `selectDay(day)` re-querying
+      `breakdownForDay` behind a per-card loading flag; seed `selectedDay = today`
+      in `load()`
+- [ ] Add `selectedDay` + `onDaySelected` to `DailyBitesChart`: select via
+      `barTouchData.touchCallback` (tap-up → `firstDay + index`), and highlight the
+      selected bar
+- [ ] `_MealBreakdownCard` titles the selected date and shows a "Back to today"
+      control only when `!isSelectedDayToday`; keep the per-day empty state
+- [ ] **Verify:** unit-test `selectDay` loads the right day's breakdown and
+      `isSelectedDayToday` flips; widget-test that tapping a bar calls
+      `onDaySelected` with that day and that "Back to today" resets to today
+
+**Phase 3 — Current-meal bites on the Bite page**
+
+- [ ] Add `currentMealBites` to `BiteManager`: increment/reset in `logBite` on the
+      `mealGapThreshold` rule, and seed it in `initialize` from today's trailing
+      cluster (0 when the last bite is older than the threshold)
+- [ ] Reference `BiteAnalytics.mealGapThreshold` as the single source of the 5-min
+      rule
+- [ ] Show a quiet "This meal: N" line under the day total in `bite_page.dart`,
+      hidden when `currentMealBites == 0`
+- [ ] **Verify:** unit-test increment within the threshold, reset to 1 after a
+      gap, a fresh manager at 0, and the initialize seed (recent tail vs. a stale
+      last bite → 0); widget-test the line shows with a current meal and hides on
+      an empty day
+
+**Phase 4 — Polish**
+- [ ] Accessibility labels on the new tile, the selected-bar highlight, and the
+      current-meal line; consistent theming/spacing; a final `flutter analyze` /
+      `flutter test` pass before pushing

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -136,36 +136,38 @@ no bites.
 ### 3a. What it is
 
 Under "Today's Bites", show the number of bites in the **current meal** — the
-trailing cluster of bites whose consecutive gaps are `≤ mealGapThreshold`
+trailing cluster of today's bites whose consecutive gaps are `≤ mealGapThreshold`
 (5 min), using the same rule as the analytics meal model. It answers "how much
 have I eaten *this* sitting?" next to the all-day total.
 
-A meal is "in progress" while the last bite is within `mealGapThreshold` of now;
-once that lapses the current-meal count clears (the next bite after the gap starts
-a fresh meal at 1). No `minMealBites` gate applies to the live count — it counts
-from the first bite of the sitting, before the cluster is big enough to have
-"qualified" as a meal in the analytics sense.
+No `minMealBites` gate applies to the live count — it counts from the first bite
+of the sitting, before the cluster is big enough to have "qualified" as a meal in
+the analytics sense.
 
-### 3b. Where it lives
+### 3b. Where it lives — derived, not counted
 
-`BiteManager` already holds `_lastBiteAt` in memory and drives the live screen, so
-the current-meal count lives there as derived state:
+`BiteManager` already re-reads today's bites and refreshes `_todayCount` after
+every mutation. The current-meal size follows the exact same pattern: it's
+**recomputed from today's stored bites**, not tracked with a running counter.
 
 ```dart
-/// Bites in the current (in-progress) meal: the trailing run of bites no more
-/// than [BiteAnalytics.mealGapThreshold] apart, ending at the last bite. 0 when
-/// no meal is in progress (no bite within the threshold of now).
+/// Bites in the current meal: the size of the trailing run of today's bites no
+/// more than [BiteAnalytics.mealGapThreshold] apart. Recomputed from the store
+/// alongside [todayCount]; 0 when today has no bites.
 int get currentMealBites;
 ```
 
-- **On `logBite`:** if the previous bite is within `mealGapThreshold` of now,
-  increment; otherwise reset to 1 (this tap starts a new meal).
-- **On `initialize`:** seed by reading today's bites, clustering the tail, and
-  taking the trailing cluster's size — but only when the last bite is within
-  `mealGapThreshold` of now; otherwise seed 0, so opening the app hours later
-  shows no stale in-progress meal.
-- Reuse `BiteAnalytics.mealGapThreshold` as the single source of the 5-min rule
-  rather than redefining it on the manager.
+- **On `logBite` and `initialize`:** cluster today's bites by the
+  `mealGapThreshold` rule and take the trailing cluster's size — folded into the
+  same refresh that already recomputes the day count, off one read of today's
+  bites. There is no increment/reset arithmetic and no `_currentMealCount` state
+  to keep in sync; the number is always a projection of the log.
+- Reuse the meal-clustering already in `BiteAnalytics` (extract its private
+  `_clusterBites` / `mealGapThreshold` into a shared spot) so the live count and
+  the analytics screen apply one identical rule.
+
+Because it's recomputed from the log, resetting is automatic: a tap after a
+`> mealGapThreshold` gap forms a fresh trailing cluster of size 1.
 
 ### 3c. UI
 
@@ -173,11 +175,12 @@ int get currentMealBites;
 (e.g. "This meal: N"), rendered only when `currentMealBites > 0` so an empty day
 stays clean. It reads `biteManager.currentMealBites`; no new provider.
 
-**Live-clear caveat (settled, §4.4):** the number is bite-driven. Between bites it
-does not auto-clear at the 5-min mark — the pacing ticker stops at `b2` (~30 s), so
-there's no periodic rebuild to hide it on. It clears on the next bite after a gap
-(reset to 1) or when the tab/app is left and the page rebuilds. A timer to blank it
-exactly at the 5-min boundary is deliberately out of scope for v1.
+**Bite-driven caveat (settled, §4.4):** the number refreshes only when the manager
+recomputes — on a bite or on open — not on a timer. Between bites it does not
+auto-clear at the 5-min mark (the pacing ticker stops at `b2` (~30 s), so there's
+no periodic rebuild), and on open it reflects today's trailing cluster. It settles
+to the right value on the next bite. A timer to blank it exactly at the 5-min
+boundary is deliberately out of scope for v1.
 
 ---
 
@@ -192,10 +195,12 @@ Defaults chosen to match the shipped screen; confirm or adjust before building.
    with an explicit "Back to today" control. The top stat tiles and "Meals today"
    stay today/window metrics — only the bottom breakdown card follows the
    selection.
-3. **Current meal reuses `mealGapThreshold` (5 min)** and ignores `minMealBites`
-   for the live count (it counts from bite 1 of the sitting).
-4. **Current meal is bite-driven, not timer-driven** — it clears on the next
-   post-gap bite, not at the instant 5 min elapses (§3c).
+3. **Current meal is derived, not counted** — recomputed from today's stored
+   bites (trailing `mealGapThreshold` cluster) alongside the day count, with no
+   running counter. It reuses `mealGapThreshold` (5 min) and ignores
+   `minMealBites` for the live count (it counts from bite 1 of the sitting).
+4. **Current meal is bite-driven, not timer-driven** — it refreshes on a bite or
+   on open, not at the instant 5 min elapses (§3c).
 5. **Current-meal line is hidden when the day has no bites.**
 
 ---
@@ -238,17 +243,19 @@ Chart tap drives the breakdown card; no new analytics.
 
 **Phase 3 — Current-meal bites on the Bite page**
 
-- [ ] Add `currentMealBites` to `BiteManager`: increment/reset in `logBite` on the
-      `mealGapThreshold` rule, and seed it in `initialize` from today's trailing
-      cluster (0 when the last bite is older than the threshold)
-- [ ] Reference `BiteAnalytics.mealGapThreshold` as the single source of the 5-min
-      rule
+- [ ] Extract the meal-clustering rule (`_clusterBites` / `mealGapThreshold`) from
+      `BiteAnalytics` into a shared spot so the manager and the analytics screen
+      apply one identical rule
+- [ ] Add `currentMealBites` to `BiteManager`, **recomputed** from today's bites
+      (trailing `mealGapThreshold` cluster) in the same refresh that recomputes the
+      day count — no running counter, no `initialize` special-casing beyond that
+      refresh
 - [ ] Show a quiet "This meal: N" line under the day total in `bite_page.dart`,
       hidden when `currentMealBites == 0`
-- [ ] **Verify:** unit-test increment within the threshold, reset to 1 after a
-      gap, a fresh manager at 0, and the initialize seed (recent tail vs. a stale
-      last bite → 0); widget-test the line shows with a current meal and hides on
-      an empty day
+- [ ] **Verify:** unit-test the trailing cluster's size within the threshold, a
+      fresh trailing cluster of 1 after a `> mealGapThreshold` gap, a fresh manager
+      at 0, and that it recomputes after a logged bite; widget-test the line shows
+      with a current meal and hides on an empty day
 
 **Phase 4 — Polish**
 - [ ] Accessibility labels on the new tile, the selected-bar highlight, and the

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -262,8 +262,9 @@ Weight is day-granular, so it aligns one-to-one with the bite days. A day with a
 weigh-in but no bites still shows its weight bar; a day with no weigh-in shows only
 the bite bar — no gap-filling, raw values as decided. Weight stays in kg.
 
-Density note: 30 days × 2 rods is tight, so bar width / group spacing get a pass
-(narrower rods, or a shorter default window) to stay legible.
+Density note: two rods per day over 30 days is tight, so each rod is drawn at
+roughly **half** the current single-rod width to fit both. The 30-day window
+stays as is.
 
 ---
 
@@ -375,7 +376,8 @@ Chart tap drives the breakdown card; no new analytics.
 - [ ] Add a second `BarChartRodData` per group in `daily_bites_chart.dart` for
       weight, on a secondary right-hand kg axis fitted to the weight min/max
       (normalise the rod's `toY`, label `rightTitles` in kg); distinct colour, a
-      two-item legend, and bar width/spacing tuned for the denser groups
+      two-item legend, and each rod at ~half the current `_barWidth` (two per day)
+      over the kept 30-day window
 - [ ] Weight bar omitted on days with no weigh-in; bite-only days unchanged
 - [ ] **Verify:** the chart renders bite-only, weight-only, and both-present days;
       the weight axis fits the weight range (small changes stay visible, not

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -10,7 +10,7 @@ across the Bite tab and its analytics screen:
    count, alongside the day's headline total.
 
 > **Status: ready to build.** Nothing here is built yet, but every design
-> decision (§5) is settled — implementation can start at Phase 1.
+> decision (§6) is settled — implementation can start at Phase 1.
 
 ---
 
@@ -186,7 +186,7 @@ shows nothing.
 (e.g. "This meal: N"), rendered only when `currentMealBites > 0` so an empty day
 stays clean. It reads `biteManager.currentMealBites`; no new provider.
 
-**Bite-driven caveat (settled, §5.4):** the recency gate is evaluated when the
+**Bite-driven caveat (settled, §6.4):** the recency gate is evaluated when the
 manager recomputes — on a bite or on open — not on a timer. So opening the app
 after a meal ended correctly shows nothing, but if you sit on the Bite page and
 the 5-min mark passes with no new bite, the line only clears on the next refresh
@@ -233,7 +233,41 @@ instead, and format through `intl`:
 
 ---
 
-## 5. Settled decisions
+## 5. Body weight on the bite chart
+
+### 5a. Shape — grouped bars
+
+`fl_chart` renders side-by-side bars out of the box: a `BarChartGroupData` holds a
+*list* of `BarChartRodData` in `barRods`, drawn grouped per x. The daily-bites
+chart uses one rod today; a second rod per day is the weight bar, in a distinct
+colour with a two-entry legend.
+
+### 5b. The scale still needs a second axis
+
+Two bars don't close the unit gap: bites are a count (0–~150) and weight is kg in
+a narrow band far from zero (e.g. 72–96). Drawn from zero on the shared bite axis,
+every weight bar is a near-identical tall block and the day-to-day change — the
+whole point of overlaying it — is invisible. So the weight rod is mapped onto a
+**secondary right-hand axis** fitted to the weight's own min/max (±~1 kg padding,
+as `weight_chart.dart` does): its `toY` is normalised into the bar chart's Y
+range, and the right axis (`rightTitles`, hidden today) is labelled in kg by
+inverting that mapping. Left axis = bites, right axis = kg, one grouped bar each.
+
+### 5c. Data + wiring
+
+`BiteAnalyticsController` gains a `WeightRepository` (already provided in
+`main.dart`; inject it alongside the bite repo) and loads **raw daily weights**
+over the same 30-day window via `getAllWeights()` filtered to `[from30, to)`.
+Weight is day-granular, so it aligns one-to-one with the bite days. A day with a
+weigh-in but no bites still shows its weight bar; a day with no weigh-in shows only
+the bite bar — no gap-filling, raw values as decided. Weight stays in kg.
+
+Density note: 30 days × 2 rods is tight, so bar width / group spacing get a pass
+(narrower rods, or a shorter default window) to stay legible.
+
+---
+
+## 6. Settled decisions
 
 All confirmed — these fix the behaviour on screen:
 
@@ -257,10 +291,14 @@ All confirmed — these fix the behaviour on screen:
    `14/7` or `7/14` per the phone — through one shared `intl` helper. Full ISO
    dates elsewhere (history list, dialogs, home header, backup filename) are left
    as-is (§4a).
+7. **Weight rides the bite chart as a second grouped bar per day** (`fl_chart`
+   `barRods`), on a **secondary right-hand kg axis fitted to the weight range** —
+   not from zero, which would flatten the day-to-day change (§5b). Raw daily
+   weights, in kg, no gap-filling.
 
 ---
 
-## 6. Phases
+## 7. Phases
 
 Each phase is one sitting on a single subject, ends **green** (`flutter analyze`
 + `flutter test` pass), and is independently committable. Ordered so each assumes
@@ -330,7 +368,20 @@ Chart tap drives the breakdown card; no new analytics.
       it recomputes after a logged bite; widget-test the line shows with a current
       meal and hides when no meal is in progress
 
-**Phase 5 — Polish**
-- [ ] Accessibility labels on the new tile, the selected-bar highlight, and the
-      current-meal line; consistent theming/spacing; a final `flutter analyze` /
-      `flutter test` pass before pushing
+**Phase 5 — Body weight as a second bar on the bite chart**
+
+- [ ] Inject `WeightRepository` into `BiteAnalyticsController` and load raw daily
+      weights over the 30-day window (`getAllWeights()` filtered to `[from30, to)`)
+- [ ] Add a second `BarChartRodData` per group in `daily_bites_chart.dart` for
+      weight, on a secondary right-hand kg axis fitted to the weight min/max
+      (normalise the rod's `toY`, label `rightTitles` in kg); distinct colour, a
+      two-item legend, and bar width/spacing tuned for the denser groups
+- [ ] Weight bar omitted on days with no weigh-in; bite-only days unchanged
+- [ ] **Verify:** the chart renders bite-only, weight-only, and both-present days;
+      the weight axis fits the weight range (small changes stay visible, not
+      flattened from zero); a day without a weigh-in shows only the bite bar
+
+**Phase 6 — Polish**
+- [ ] Accessibility labels on the new tile, the selected-bar highlight, the
+      current-meal line, and the weight bars/legend; consistent theming/spacing; a
+      final `flutter analyze` / `flutter test` pass before pushing

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -10,7 +10,7 @@ across the Bite tab and its analytics screen:
    count, alongside the day's headline total.
 
 > **Status: ready to build.** Nothing here is built yet, but every design
-> decision (§4) is settled — implementation can start at Phase 1.
+> decision (§5) is settled — implementation can start at Phase 1.
 
 ---
 
@@ -124,8 +124,9 @@ final ValueChanged<DateTime>? onDaySelected;
 
 ### 2d. Card
 
-`_MealBreakdownCard`'s title becomes the selected date ("Meals — Jul 14", "Today's
-meals" when it's today), with a small "Back to today" action shown only when
+`_MealBreakdownCard`'s title becomes the selected date (through the shared
+locale-aware date helper from §4 — `14/7` or `7/14` per the phone; "Today's meals"
+when it's today), with a small "Back to today" action shown only when
 `!isSelectedDayToday`. The card keeps its own empty state for a selected day with
 no bites.
 
@@ -185,7 +186,7 @@ shows nothing.
 (e.g. "This meal: N"), rendered only when `currentMealBites > 0` so an empty day
 stays clean. It reads `biteManager.currentMealBites`; no new provider.
 
-**Bite-driven caveat (settled, §4.4):** the recency gate is evaluated when the
+**Bite-driven caveat (settled, §5.4):** the recency gate is evaluated when the
 manager recomputes — on a bite or on open — not on a timer. So opening the app
 after a meal ended correctly shows nothing, but if you sit on the Bite page and
 the 5-min mark passes with no new bite, the line only clears on the next refresh
@@ -194,7 +195,45 @@ the 5-min mark passes with no new bite, the line only clears on the next refresh
 
 ---
 
-## 4. Settled decisions
+## 4. Locale-aware dates in charts and stats
+
+### 4a. What changes
+
+Every date drawn on a chart or a stat is currently hardcoded to US month/day
+order — `'${day.month}/${day.day}'` on the axes and the max-day tile, ISO
+`year-month-day` in the tooltips. This makes the numeric dates follow the
+**device locale's** ordering instead (`14/7` vs `7/14`) — still numbers, no month
+names, just the order the phone uses.
+
+Sites in scope (charts + stats only):
+
+- `daily_bites_chart.dart` — the x-axis day labels and the touch tooltip.
+- `weight_chart.dart` — the x-axis day labels and the touch tooltip.
+- `bite_analytics_page.dart` — `_formatDay` (the 30-day-max stat tile's date).
+- The pickable-day card title from §2d.
+
+**Out of scope, left as-is:** the full ISO dates in the weight history list, the
+add-weight dialog, and the home-tab day header (ISO `yyyy-mm-dd` is
+order-unambiguous), and the backup filename timestamp in `serialization_service.dart`
+(it must stay a stable, sortable format — never localised).
+
+### 4b. How
+
+The app wires no `Localizations` delegates, so `Localizations.localeOf(context)`
+would always resolve to the fallback locale. Read the real device locale directly
+instead, and format through `intl`:
+
+- Add `intl` to `pubspec.yaml` (not currently even a transitive dependency) and
+  call `initializeDateFormatting()` once at startup in `main.dart`.
+- One shared helper in `lib/core/` (beside `csv_serializer.dart`): `shortDate`
+  (`DateFormat.Md` — numeric month/day in locale order) for axis labels and tiles,
+  and `fullDate` (`DateFormat.yMd`) for tooltips, both formatting against
+  `PlatformDispatcher.instance.locale`. Every in-scope site calls this one place,
+  so ordering can never drift between the two charts and the tile again.
+
+---
+
+## 5. Settled decisions
 
 All confirmed — these fix the behaviour on screen:
 
@@ -214,17 +253,37 @@ All confirmed — these fix the behaviour on screen:
    can linger past 5 min only until the next refresh (§3c).
 5. **Current-meal line is hidden when no meal is in progress** — the day has no
    bites, or the most recent bite is more than `mealGapThreshold` (5 min) ago.
+6. **Chart/stat dates follow the device locale**, numeric (no month names) —
+   `14/7` or `7/14` per the phone — through one shared `intl` helper. Full ISO
+   dates elsewhere (history list, dialogs, home header, backup filename) are left
+   as-is (§4a).
 
 ---
 
-## 5. Phases
+## 6. Phases
 
 Each phase is one sitting on a single subject, ends **green** (`flutter analyze`
 + `flutter test` pass), and is independently committable. Ordered so each assumes
 the earlier ones; every phase ships with its tests — the "verify" bullet is the
-definition of done.
+definition of done. The shared date helper (Phase 1) lands first so the later
+chart and stat phases render dates through it from the start.
 
-**Phase 1 — `averageMealSize` on `BiteAnalytics` + the stat tile**
+**Phase 1 — Locale-aware dates in charts and stats (shared foundation)**
+
+The cross-cutting date fix, retrofitting both features' existing charts/stats.
+- [ ] Add `intl` to `pubspec.yaml`; call `initializeDateFormatting()` once at
+      startup in `main.dart`
+- [ ] Add a shared date helper in `lib/core/` — `shortDate` (`DateFormat.Md`,
+      numeric month/day) for axes and tiles, `fullDate` (`DateFormat.yMd`) for
+      tooltips — formatting against `PlatformDispatcher.instance.locale`
+- [ ] Retrofit the hardcoded month/day axis labels and ISO tooltips in
+      `daily_bites_chart.dart` and `weight_chart.dart`, and `_formatDay` (the
+      30-day-max tile) in `bite_analytics_page.dart`, to the helper
+- [ ] **Verify:** unit-test the helper renders `7/14` under `en_US` and `14/7`
+      under `en_GB`; pin the locale in the existing `stat_tile_test` /
+      `bite_analytics_page_test` date expectations so they stay deterministic
+
+**Phase 2 — `averageMealSize` on `BiteAnalytics` + the stat tile**
 
 Pure computation first, then wire it into the existing meals summary row.
 - [ ] Add `averageMealSize(from, to)` to `BiteAnalytics`, factoring the shared
@@ -237,7 +296,7 @@ Pure computation first, then wire it into the existing meals summary row.
       meal (0/`—`), a single meal, and multiple meals across several days; the
       tile reads correctly against a seeded fixture
 
-**Phase 2 — Pickable breakdown day**
+**Phase 3 — Pickable breakdown day**
 
 Chart tap drives the breakdown card; no new analytics.
 - [ ] Replace `breakdownToday` with `selectedDay` / `selectedBreakdown` /
@@ -253,7 +312,7 @@ Chart tap drives the breakdown card; no new analytics.
       `isSelectedDayToday` flips; widget-test that tapping a bar calls
       `onDaySelected` with that day and that "Back to today" resets to today
 
-**Phase 3 — Current-meal bites on the Bite page**
+**Phase 4 — Current-meal bites on the Bite page**
 
 - [ ] Extract the meal-clustering rule (`_clusterBites` / `mealGapThreshold`) from
       `BiteAnalytics` into a shared spot so the manager and the analytics screen
@@ -271,7 +330,7 @@ Chart tap drives the breakdown card; no new analytics.
       it recomputes after a logged bite; widget-test the line shows with a current
       meal and hides when no meal is in progress
 
-**Phase 4 — Polish**
+**Phase 5 — Polish**
 - [ ] Accessibility labels on the new tile, the selected-bar highlight, and the
       current-meal line; consistent theming/spacing; a final `flutter analyze` /
       `flutter test` pass before pushing

--- a/docs/bite_analytics_plan.md
+++ b/docs/bite_analytics_plan.md
@@ -5,8 +5,9 @@ dashboard reached from a small chart button in the top-right corner, surfacing
 daily-bite trends, averages, and a meal/snack breakdown derived from the stored
 timestamps.
 
-> **Status: ready to build.** Nothing here is built yet, but every design
-> decision is settled (§5) — implementation can start at Phase 1.
+> **Status: ✅ complete.** All ten phases (§6) shipped and merged; every design
+> decision (§5) is reflected in the code. This document is kept as the design
+> record for the delivered Bite Analytics screen.
 
 ---
 

--- a/docs/floating_window_plan.md
+++ b/docs/floating_window_plan.md
@@ -1,0 +1,204 @@
+# Food Locker — Floating Bite Button Plan
+
+A phased plan to let you log bites **from a floating window on top of other
+apps** — a small draggable puck that logs a bite on tap and shows the current
+pacing zone as its colour, so you can keep counting while you use the phone for
+something else.
+
+> **Status: ready to build.** Nothing here is built yet, but the scope (§1) and
+> design decisions (§6) are settled — implementation can start at Phase 1.
+>
+> **Android-only, device-verified.** This rides Android's "Display over other
+> apps" overlay; iOS has no equivalent third-party API and is a non-goal (§1). The
+> overlay and its permission cannot run under `flutter test`/CI — most of this is
+> verified manually on a real device (§5).
+
+---
+
+## 0. Guiding principles
+
+Carried over from the bite feature (`bite_pacing_plan.md` §0), and they still hold
+inside the overlay:
+
+- **Store facts, derive views.** The floating button logs the same raw `at_ms`
+  bite the main screen does, into the same append-only `bites` store. It persists
+  nothing new; the pacing zone it paints is a **read-time projection** of the last
+  bite and the effective thresholds, exactly as `BiteManager` derives it.
+- **Bite count is the headline metric, and logging never blocks.** A tap on the
+  puck records a bite immediately, same contract as the main button.
+- **Reuse the pacing model.** `PacingZone`, `PacingConfig` (`b1`/`b2`), and
+  `PacingZoneStyle` already define the zones and their colours. The overlay reuses
+  them rather than inventing a second pacing rule.
+- **Minimal footprint.** The overlay is a puck, not the page. It owns no wake-lock,
+  no countdown text, no count, no haptics — just the tap target and its colour.
+
+---
+
+## 1. What it is (v1 scope)
+
+A **floating circular bite button**, drawn over whatever app is in front:
+
+- **Tap = one bite**, written immediately to the shared bite store.
+- **Fill colour = the current pacing zone** (`tooSoon` / `holdOn` / `inTheClear`),
+  from `PacingZoneStyle`. Because the zone advances with time since the last bite,
+  the overlay runs a small local ticker that recomputes the colour between taps —
+  the same derivation `BiteManager` does, minus the wake-lock and countdown.
+- **Draggable**, so it can be parked out of the way, with a **close gesture** (a
+  small ✕ or long-press) to dismiss it.
+
+Explicitly **out of scope for v1** (kept on the main page only): the running
+count, the countdown seconds, the "in the clear" haptic, and the wake-lock — a
+floating window means the phone is already in use, so the screen won't sleep.
+
+**iOS: non-goal.** No system-wide floating overlay exists for third-party iOS
+apps. The launch control (§4) is Android-only and hidden elsewhere.
+
+---
+
+## 2. The overlay is a separate Flutter engine (the core fact)
+
+Everything below follows from one thing: `flutter_overlay_window` renders the
+overlay from a **second Flutter entrypoint running in its own isolate**. It does
+**not** share the app's `Provider`s, the `BiteManager`, or the open Drift
+connection. So the overlay cannot call into existing UI state — it needs its own
+path to the bite store and its own pacing derivation.
+
+- A dedicated `@pragma('vm:entry-point')` `overlayMain()` boots a minimal
+  `MaterialApp` whose only content is the puck.
+- The puck talks to the **store directly**, not through `BiteManager`.
+- The main app and the overlay stay in sync through the **shared store on disk**
+  (both read/write the same SQLite file), not through shared memory.
+
+---
+
+## 3. Data path — the overlay writes to the store directly
+
+The overlay must work even when the main app is backgrounded or reclaimed by the
+OS, so it **opens its own connection to the same `bites` database** and writes
+there directly, rather than messaging a main isolate that may not be alive.
+
+- **Reuse, don't fork, the data layer.** The overlay constructs its own
+  `BiteDatabase` / `DriftBiteRepository` and calls the existing
+  `logBite(now)` / `lastBite()` / `pacingConfigAt(now)`. Pacing colour comes from
+  `PacingZone.forElapsed(sinceLastBite, b1, b2)` — the same call `BiteManager`
+  makes. No new persistence, no schema change.
+- **Sync back on resume.** Bites logged while floating land in the same file, so
+  the main `BiteManager` must **re-read on `AppLifecycleState.resumed`** to pick up
+  what the puck logged (today's count, the seeded last-bite reference). Optionally
+  the overlay also posts a lightweight "bite logged" message
+  (`FlutterOverlayWindow.shareData`) so a foreground main page updates live.
+- **De-risk first (spike, Phase 1).** Two Drift connections on one SQLite file is
+  the one genuinely uncertain piece: the second engine re-runs `beforeOpen`
+  seeding (idempotent — a no-op once a config row exists) and needs WAL journal
+  mode for safe concurrent access, and `drift`/`sqlite3` native access must work
+  inside the overlay isolate's plugin registrant. A small spike validates this
+  before any UI is built on top of it.
+
+---
+
+## 4. Permission, launch, and lifecycle
+
+Standard "draw over other apps" plumbing, plus a launch control on the Bite tab:
+
+- **Permission.** Add `SYSTEM_ALERT_WINDOW` (and the foreground-service entries the
+  plugin requires) to `AndroidManifest.xml`. At launch time, check
+  `FlutterOverlayWindow.isPermissionGranted()` and, if not, send the user to the
+  system grant screen via `requestPermission()`.
+- **Launch control.** A "Float" / pop-out action on the Bite tab (an app-bar
+  `IconButton`, gated to `Platform.isAndroid`) checks the permission, then
+  `showOverlay(...)` with `enableDrag: true`. Closing is `closeOverlay()`, driven
+  by the puck's close gesture.
+- **Foreground service & SDK.** The plugin backs the overlay with a foreground
+  service (its own notification). Confirm the app's `minSdk` meets the plugin's
+  floor and bump it in `android/app/build.gradle.kts` if needed; add any
+  `FOREGROUND_SERVICE` / service-type entries the plugin's setup calls for.
+
+---
+
+## 5. Testing reality
+
+Be honest about verification, because this repo leans on CI:
+
+- **CI can build and `flutter analyze`** the new code, and **`flutter test`** the
+  parts that don't need the overlay.
+- **The overlay itself is device-only.** The floating window, the permission
+  grant, and the cross-isolate store access can't be exercised in `flutter test` —
+  they're verified **manually on a real Android device**.
+- **Keep the testable core pure.** The pacing-zone-from-last-bite derivation and
+  the bite-logging path are plain Dart over the repository, unit-testable without
+  the overlay; lean on that so the untestable surface is just the thin overlay UI
+  and the platform plumbing.
+
+---
+
+## 6. Settled decisions
+
+1. **v1 is a bare button that changes colour** — tap to log, fill = pacing zone.
+   No count, no countdown, no haptic, **no wake-lock** (a floating window means the
+   phone is already awake and in use).
+2. **Built with `flutter_overlay_window`** (a second Flutter entrypoint), not a
+   hand-written native overlay service.
+3. **The overlay writes to the store directly** through its own `BiteDatabase`
+   connection, so it works with the main app backgrounded; the main page re-reads
+   on resume (§3).
+4. **Reuse the existing pacing model** (`PacingZone`, `PacingConfig`,
+   `PacingZoneStyle`) — one pacing rule across the main button and the puck.
+5. **Android-only.** The launch control is hidden on non-Android; iOS is a non-goal.
+
+---
+
+## 7. Phases
+
+Each phase is one sitting on a single subject and is independently committable.
+Where a phase has testable logic it ends **green** (`flutter analyze` +
+`flutter test`); the overlay-dependent bullets are verified manually on a device
+(§5). The uncertain cross-isolate store access is spiked in Phase 1 before any UI
+is built on it.
+
+**Phase 1 — Isolate-safe bite core + cross-connection spike**
+
+De-risk the one uncertain piece and pin down the shared logging/pacing path.
+- [ ] Spike: open a second `BiteDatabase` connection to the same `bites` file from
+      a separate isolate/engine, confirm a direct `logBite` write is visible to the
+      main connection, and confirm `drift`/`sqlite3` works in that engine; enable
+      WAL journal mode if not already on
+- [ ] Confirm the shared path — construct `DriftBiteRepository` standalone (no
+      `Provider`) and derive the pacing zone via
+      `PacingZone.forElapsed(sinceLastBite, b1, b2)` off `lastBite()` +
+      `pacingConfigAt(now)`
+- [ ] **Verify:** unit-test the pacing-zone-from-last-bite derivation (too-soon /
+      hold-on / clear boundaries) as pure logic; the spike's two-connection write
+      is confirmed on a device
+
+**Phase 2 — Overlay entrypoint + the floating pacing button**
+
+The puck itself, in its own engine.
+- [ ] Add `flutter_overlay_window`; add the `SYSTEM_ALERT_WINDOW` /
+      foreground-service entries to `AndroidManifest.xml`; bump `minSdk` if the
+      plugin needs it
+- [ ] Add the `@pragma('vm:entry-point')` `overlayMain()` booting a minimal
+      `MaterialApp` with a circular bite button: fill from `PacingZoneStyle`, a
+      local ticker recomputing the zone between taps, tap → `logBite(now)` through
+      the overlay's own repository
+- [ ] Draggable puck with a close gesture (✕ / long-press → `closeOverlay()`)
+- [ ] **Verify (device):** the puck floats over other apps, taps log bites, and
+      the colour advances through the zones over time; `flutter analyze` /
+      `flutter test` pass
+
+**Phase 3 — Launch/permission flow + resume sync**
+
+Wire it to the app.
+- [ ] A `Platform.isAndroid`-gated "Float" action on the Bite tab that checks
+      `isPermissionGranted()` / `requestPermission()` then `showOverlay(...)`
+- [ ] Refresh `BiteManager` on `AppLifecycleState.resumed` so bites logged while
+      floating show up on return (optionally an overlay→app `shareData` message for
+      a live foreground update)
+- [ ] **Verify (device):** grant flow works; start/stop from the Bite tab; a bite
+      tapped on the puck is reflected in the main count after returning;
+      `flutter analyze` / `flutter test` pass
+
+**Phase 4 — Polish**
+- [ ] Edge cases (permission denied, overlay already showing, rapid taps); puck
+      theming/size and an accessibility label; a short note in `CLAUDE.md`/README on
+      the overlay permission; final `flutter analyze` / `flutter test` pass before
+      pushing

--- a/docs/floating_window_plan.md
+++ b/docs/floating_window_plan.md
@@ -55,19 +55,27 @@ apps. The launch control (§4) is Android-only and hidden elsewhere.
 
 ---
 
-## 2. The overlay is a separate Flutter engine (the core fact)
+## 2. Same app, second engine — what's reused vs re-created
 
-Everything below follows from one thing: `flutter_overlay_window` renders the
-overlay from a **second Flutter entrypoint running in its own isolate**. It does
-**not** share the app's `Provider`s, the `BiteManager`, or the open Drift
-connection. So the overlay cannot call into existing UI state — it needs its own
-path to the bite store and its own pacing derivation.
+**This is not a new app.** The overlay lives in the same APK and reuses the code
+we already have — `PacingZone`, `PacingConfig`, `PacingZoneStyle`, the
+`BiteDatabase`, `DriftBiteRepository`, and `logBite`. The *only* thing it can't
+reuse is a **live in-memory object**: `flutter_overlay_window` renders the puck
+from a second Flutter entrypoint running in its own isolate, and isolates don't
+share memory, so the overlay can't grab the already-running `BiteManager` /
+`Provider` instance the main screen uses.
+
+The practical consequence is small — instead of reading a repository out of a
+`Provider`, the overlay **re-creates the thin data layer** (a `DriftBiteRepository`
+over the *same* on-disk database) and derives pacing with the same calls:
 
 - A dedicated `@pragma('vm:entry-point')` `overlayMain()` boots a minimal
-  `MaterialApp` whose only content is the puck.
-- The puck talks to the **store directly**, not through `BiteManager`.
-- The main app and the overlay stay in sync through the **shared store on disk**
-  (both read/write the same SQLite file), not through shared memory.
+  `MaterialApp` whose only content is the puck — built from the existing widgets
+  and models, not new ones.
+- The puck reads/writes the **store directly** through its own repository, not
+  through `BiteManager`.
+- The main app and the overlay stay in sync through the **shared database on disk**
+  (the same SQLite file), not through shared memory.
 
 ---
 

--- a/docs/floating_window_plan.md
+++ b/docs/floating_window_plan.md
@@ -43,8 +43,8 @@ A **floating circular bite button**, drawn over whatever app is in front:
   from `PacingZoneStyle`. Because the zone advances with time since the last bite,
   the overlay runs a small local ticker that recomputes the colour between taps —
   the same derivation `BiteManager` does, minus the wake-lock and countdown.
-- **Draggable**, so it can be parked out of the way, with a **close gesture** (a
-  small ✕ or long-press) to dismiss it.
+- **Draggable**, so it can be parked out of the way, with a **small ✕** to dismiss
+  it.
 
 Explicitly **out of scope for v1** (kept on the main page only): the running
 count, the countdown seconds, the "in the clear" haptic, and the wake-lock — a
@@ -188,7 +188,7 @@ The puck itself, in its own engine.
       `MaterialApp` with a circular bite button: fill from `PacingZoneStyle`, a
       local ticker recomputing the zone between taps, tap → `logBite(now)` through
       the overlay's own repository
-- [ ] Draggable puck with a close gesture (✕ / long-press → `closeOverlay()`)
+- [ ] Draggable puck with a small ✕ to dismiss (→ `closeOverlay()`)
 - [ ] **Verify (device):** the puck floats over other apps, taps log bites, and
       the colour advances through the zones over time; `flutter analyze` /
       `flutter test` pass


### PR DESCRIPTION
## Summary

Docs-only. Reviews the shipped bite analytics plan and adds two new design plans for follow-up work. No code changes.

### 1. Marked the bite analytics plan complete
`docs/bite_analytics_plan.md` — all ten phases shipped and merged (PRs #66–#78), so the stale "nothing built yet" banner is flipped to ✅ complete and kept as the design record.

### 2. New — Bite Analytics Enhancements plan
`docs/bite_analytics_enhancements_plan.md`, three refinements over the shipped screen, all settled:
- **Average meal size (30 days)** — a new stat tile (`averageMealSize` on `BiteAnalytics`, meals only).
- **Pickable breakdown day** — tapping a bar in the daily-bites chart drives the meal-breakdown card (chart `onDaySelected` + controller `selectDay`, reusing `breakdownForDay`).
- **Current-meal bites on the main page** — derived (not counted) from today's trailing bite cluster, gated on last-bite recency.
- Plus a **locale-aware date phase** (numeric `14/7` vs `7/14` across the bite/weight charts and stats via one shared `intl` helper) and **body weight as a second grouped bar** on the bite chart (fitted right-hand kg axis, half-width rods over the 30-day window).
- Six phases; date helper lands first as a shared foundation.

### 3. New — Floating Bite Button plan
`docs/floating_window_plan.md`, an Android system-overlay ("Display over other apps") floating puck:
- v1 scope: a bare button that logs a bite on tap and changes colour by pacing zone (no count / countdown / haptic / wake-lock), dismissed via a small ✕.
- Built with `flutter_overlay_window`; reuses the existing pacing model and Drift store (same APK, second Flutter engine — only the live `BiteManager` instance isn't shared).
- Android-only (iOS non-goal); device-verified (overlay can't run under CI).
- Four phases, led by a de-risking spike for cross-isolate Drift access.

## Test plan
- [x] Docs only — no code, no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsiurhMsbx8qcGatQy9NVp)_