### PR TITLE
feat: locale-aware dates in charts and stats (Phase 1)

### DIFF
--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -310,15 +310,15 @@ chart and stat phases render dates through it from the start.
 **Phase 1 — Locale-aware dates in charts and stats (shared foundation)**
 
 The cross-cutting date fix, retrofitting both features' existing charts/stats.
-- [ ] Add `intl` to `pubspec.yaml`; call `initializeDateFormatting()` once at
+- [x] Add `intl` to `pubspec.yaml`; call `initializeDateFormatting()` once at
       startup in `main.dart`
-- [ ] Add a shared date helper in `lib/core/` — `shortDate` (`DateFormat.Md`,
+- [x] Add a shared date helper in `lib/core/` — `shortDate` (`DateFormat.Md`,
       numeric month/day) for axes and tiles, `fullDate` (`DateFormat.yMd`) for
       tooltips — formatting against `PlatformDispatcher.instance.locale`
-- [ ] Retrofit the hardcoded month/day axis labels and ISO tooltips in
+- [x] Retrofit the hardcoded month/day axis labels and ISO tooltips in
       `daily_bites_chart.dart` and `weight_chart.dart`, and `_formatDay` (the
       30-day-max tile) in `bite_analytics_page.dart`, to the helper
-- [ ] **Verify:** unit-test the helper renders `7/14` under `en_US` and `14/7`
+- [x] **Verify:** unit-test the helper renders `7/14` under `en_US` and `14/7`
       under `en_GB`; pin the locale in the existing `stat_tile_test` /
       `bite_analytics_page_test` date expectations so they stay deterministic
 

--- a/lib/core/date_format.dart
+++ b/lib/core/date_format.dart
@@ -1,0 +1,21 @@
+import 'dart:ui';
+
+import 'package:intl/intl.dart';
+
+/// Locale-aware numeric date formatting for charts and stat tiles.
+///
+/// Dates are drawn in the device locale's field order — `7/14` under `en_US`,
+/// `14/7` under `en_GB` — as numbers, never month names. Both helpers default to
+/// [PlatformDispatcher.instance.locale]; an explicit [locale] override keeps them
+/// deterministic under test. Non-`en_US` locales need `initializeDateFormatting()`
+/// (called once at startup in `main.dart`).
+
+/// Numeric month/day in [locale] order, for axis labels and stat tiles.
+String shortDate(DateTime date, [String? locale]) =>
+    DateFormat.Md(locale ?? _deviceLocale).format(date);
+
+/// Numeric year/month/day in [locale] order, for chart tooltips.
+String fullDate(DateTime date, [String? locale]) =>
+    DateFormat.yMd(locale ?? _deviceLocale).format(date);
+
+String get _deviceLocale => PlatformDispatcher.instance.locale.toString();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,10 +12,12 @@ import 'package:food_locker/hive_registrar.g.dart';
 import 'package:food_locker/ui/app_shell.dart';
 import 'package:food_locker/ui/theme.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  initializeDateFormatting();
   await Hive.initFlutter();
   Hive.registerAdapters();
   final weightBox = await Hive.openBox<Weight>('weights');

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_analytics_controller.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
@@ -162,8 +163,9 @@ class _StatTilesRow extends StatelessWidget {
   static String _formatAverage(double average) =>
       average == 0 ? '—' : average.toStringAsFixed(0);
 
-  /// A day as `month/day`, matching the daily-bites chart's axis labels.
-  static String _formatDay(DateTime day) => '${day.month}/${day.day}';
+  /// A day in the device locale's numeric order, matching the daily-bites
+  /// chart's axis labels.
+  static String _formatDay(DateTime day) => shortDate(day);
 }
 
 /// A meals summary: today's meal count and the 30-day average meals per day. A

--- a/lib/ui/widgets/daily_bites_chart.dart
+++ b/lib/ui/widgets/daily_bites_chart.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 
 /// A bar chart of total bites per calendar day over the analytics window.
@@ -133,7 +134,7 @@ class DailyBitesChart extends StatelessWidget {
                     return Padding(
                       padding: const EdgeInsets.only(top: 8.0),
                       child: Text(
-                        '${day.month}/${day.day}',
+                        shortDate(day),
                         style: const TextStyle(fontSize: 10),
                       ),
                     );
@@ -160,8 +161,7 @@ class DailyBitesChart extends StatelessWidget {
                     firstDay.day + group.x,
                   );
                   return BarTooltipItem(
-                    '${day.year}-${day.month.toString().padLeft(2, '0')}-'
-                    '${day.day.toString().padLeft(2, '0')}\n${rod.toY.toInt()} bites',
+                    '${fullDate(day)}\n${rod.toY.toInt()} bites',
                     const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,

--- a/lib/ui/widgets/weight_chart.dart
+++ b/lib/ui/widgets/weight_chart.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 
 class WeightChart extends StatelessWidget {
@@ -72,7 +73,7 @@ class WeightChart extends StatelessWidget {
                   final date = DateTime.fromMillisecondsSinceEpoch(value.toInt());
                   return Padding(
                     padding: const EdgeInsets.only(top: 8.0),
-                    child: Text('${date.month}/${date.day}', style: const TextStyle(fontSize: 10)),
+                    child: Text(shortDate(date), style: const TextStyle(fontSize: 10)),
                   );
                 },
               ),
@@ -89,7 +90,7 @@ class WeightChart extends StatelessWidget {
                 return touchedSpots.map((spot) {
                   final date = DateTime.fromMillisecondsSinceEpoch(spot.x.toInt());
                   return LineTooltipItem(
-                    '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}\n${spot.y} kg',
+                    '${fullDate(date)}\n${spot.y} kg',
                     const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
                   );
                 }).toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     sdk: flutter
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
+  intl: ^0.20.2
   path_provider: ^2.1.5
   provider: ^6.1.5+1
   share_plus: ^12.0.1

--- a/test/core/date_format_test.dart
+++ b/test/core/date_format_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+/// The numeric fields a formatted date carries, in render order and with any
+/// locale zero-padding stripped — so we assert field *order* without depending
+/// on whether a locale pads (`14/07` vs `14/7`).
+List<int> _fields(String formatted) => formatted
+    .split(RegExp(r'\D+'))
+    .where((part) => part.isNotEmpty)
+    .map(int.parse)
+    .toList();
+
+void main() {
+  setUpAll(initializeDateFormatting);
+
+  final date = DateTime(2026, 7, 14);
+
+  test('shortDate renders month/day in the locale field order', () {
+    expect(_fields(shortDate(date, 'en_US')), [7, 14]); // 7/14
+    expect(_fields(shortDate(date, 'en_GB')), [14, 7]); // 14/7
+  });
+
+  test('fullDate renders year/month/day in the locale field order', () {
+    expect(_fields(fullDate(date, 'en_US')), [7, 14, 2026]); // 7/14/2026
+    expect(_fields(fullDate(date, 'en_GB')), [14, 7, 2026]); // 14/7/2026
+  });
+}

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -40,6 +40,10 @@ void main() {
   }
 
   Future<void> pumpPage(WidgetTester tester) async {
+    // Pin the locale so the 30-day-max tile's date renders deterministically
+    // (`shortDate` formats against the platform locale).
+    tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
+    addTearDown(tester.platformDispatcher.clearLocaleTestValue);
     await tester.pumpWidget(
       Provider<BiteRepository>.value(
         value: repo,


### PR DESCRIPTION
Implements **Phase 1** of the Bite Analytics Enhancements plan (`docs/bite_analytics_enhancements_plan.md`) — the shared, locale-aware date foundation that later chart/stat phases build on.

## What changed

Numeric dates on charts and stat tiles now follow the **device locale's field order** (`7/14` under en_US, `14/7` under en_GB) instead of hardcoded US month/day on axes and ISO `year-month-day` in tooltips.

- **`intl` dependency + startup init** — added `intl: ^0.20.2` to `pubspec.yaml` and call `initializeDateFormatting()` once in `main.dart`.
- **Shared helper** — new `lib/core/date_format.dart` with `shortDate` (`DateFormat.Md`, axes/tiles) and `fullDate` (`DateFormat.yMd`, tooltips), formatting against `PlatformDispatcher.instance.locale` with an optional explicit-locale override for deterministic tests.
- **Retrofit** — routed the hardcoded month/day axis labels and ISO tooltips in `daily_bites_chart.dart` and `weight_chart.dart`, and `_formatDay` (the 30-day-max tile) in `bite_analytics_page.dart`, through the helper.

## Verification (per the phase's Verify bullet)

- New `test/core/date_format_test.dart` asserts `shortDate`/`fullDate` render the correct **field order** under `en_US` and `en_GB` (comparing parsed numeric fields, so it's robust to a locale's zero-padding, e.g. `14/07` vs `14/7`).
- `bite_analytics_page_test` pins the platform locale to `en_US` so the max-day tile's date stays deterministic.

Flutter isn't available in this environment, so `flutter analyze` / `flutter test` are **deferred to the `flutter_ci.yml` PR checks** rather than run locally.

## Deviations from the plan

- The Verify bullet mentions pinning the locale in `stat_tile_test` too, but that test only passes **literal** date strings (`'7/14'`) and never formats a date, so there was nothing to pin there — only `bite_analytics_page_test` needed it.
- Out-of-scope ISO dates (weight history list, home-tab header, backup filename) are intentionally left as-is per §4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhX8HdHb98Xhcs3FEVtruH

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhX8HdHb98Xhcs3FEVtruH)_