### PR TITLE
feat: 30-day average meal size stat tile (Phase 2)

### DIFF
--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -325,13 +325,13 @@ The cross-cutting date fix, retrofitting both features' existing charts/stats.
 **Phase 2 — `averageMealSize` on `BiteAnalytics` + the stat tile**
 
 Pure computation first, then wire it into the existing meals summary row.
-- [ ] Add `averageMealSize(from, to)` to `BiteAnalytics`, factoring the shared
+- [x] Add `averageMealSize(from, to)` to `BiteAnalytics`, factoring the shared
       "meal clusters across a window" walk out of `averageMealsPerDay` so the two
       can't diverge
-- [ ] Add `averageMealSizeLast30` to `BiteAnalyticsController`, loaded over the
+- [x] Add `averageMealSizeLast30` to `BiteAnalyticsController`, loaded over the
       existing `from30 … to` window
-- [ ] Add the third tile ("30-day avg meal size") to `_MealsSummaryRow`
-- [ ] **Verify:** unit-test avg meal size with snacks excluded, a window with no
+- [x] Add the third tile ("30-day avg meal size") to `_MealsSummaryRow`
+- [x] **Verify:** unit-test avg meal size with snacks excluded, a window with no
       meal (0/`—`), a single meal, and multiple meals across several days; the
       tile reads correctly against a seeded fixture
 

--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -172,16 +172,39 @@ class BiteAnalytics {
   /// day with no qualifying meal still counts as a 0-meal day. Returns 0 when
   /// the window holds no bites.
   Future<double> averageMealsPerDay(DateTime from, DateTime to) async {
+    final window = await _mealsInWindow(from, to);
+    if (window.loggedDays == 0) return 0;
+    return window.meals.length / window.loggedDays;
+  }
+
+  /// Mean bites per meal over `[from, to)` — total bites in qualifying meal
+  /// clusters divided by the number of those clusters. Snacks are excluded.
+  /// Returns 0 when the window holds no meal.
+  Future<double> averageMealSize(DateTime from, DateTime to) async {
+    final window = await _mealsInWindow(from, to);
+    if (window.meals.isEmpty) return 0;
+    final totalBites = window.meals.fold<int>(0, (sum, m) => sum + m.length);
+    return totalBites / window.meals.length;
+  }
+
+  /// The qualifying meal clusters across `[from, to)`, and the number of logged
+  /// days (days with any bite). Clustering runs within each local day — as in
+  /// [mealsForDay] — so a meal straddling midnight splits at the boundary. Both
+  /// [averageMealsPerDay] and [averageMealSize] walk the log through here so
+  /// their meal definition can't drift apart.
+  Future<({List<List<Bite>> meals, int loggedDays})> _mealsInWindow(
+    DateTime from,
+    DateTime to,
+  ) async {
     final bites = await _repository.bitesInRange(from, to);
-    if (bites.isEmpty) return 0;
     final byDay = _groupByLocalDay(bites);
-    var totalMeals = 0;
+    final meals = <List<Bite>>[];
     for (final dayBites in byDay.values) {
-      totalMeals += _clusterBites(
-        dayBites,
-      ).where((cluster) => cluster.length >= minMealBites).length;
+      for (final cluster in _clusterBites(dayBites)) {
+        if (cluster.length >= minMealBites) meals.add(cluster);
+      }
     }
-    return totalMeals / byDay.length;
+    return (meals: meals, loggedDays: byDay.length);
   }
 
   /// The clusters of a single local day, meal-qualifying or not.

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -71,6 +71,12 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// days that had at least one bite. 0 when the window holds no bites.
   double get averageMealsLast30 => _averageMealsLast30;
 
+  double _averageMealSizeLast30 = 0;
+
+  /// Mean bites per meal over the last [dailyBitesWindow] days, across only
+  /// qualifying meals (snacks excluded). 0 when the window holds no meal.
+  double get averageMealSizeLast30 => _averageMealSizeLast30;
+
   DayMealBreakdown _breakdownToday = DayMealBreakdown(
     day: DateTime.fromMillisecondsSinceEpoch(0),
     meals: const [],
@@ -103,6 +109,7 @@ class BiteAnalyticsController extends ChangeNotifier {
     _breakdownToday = await _analytics.breakdownForDay(today);
     _mealsToday = _breakdownToday.meals.length;
     _averageMealsLast30 = await _analytics.averageMealsPerDay(from30, to);
+    _averageMealSizeLast30 = await _analytics.averageMealSize(from30, to);
     _isLoading = false;
     notifyListeners();
   }

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -62,6 +62,7 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
               _MealsSummaryRow(
                 mealsToday: _controller.mealsToday,
                 averageMealsLast30: _controller.averageMealsLast30,
+                averageMealSizeLast30: _controller.averageMealSizeLast30,
               ),
               _MealBreakdownCard(breakdown: _controller.breakdownToday),
             ],
@@ -168,18 +169,21 @@ class _StatTilesRow extends StatelessWidget {
   static String _formatDay(DateTime day) => shortDate(day);
 }
 
-/// A meals summary: today's meal count and the 30-day average meals per day. A
-/// meal is a cluster of at least [BiteAnalytics.minMealBites] bites no more than
-/// [BiteAnalytics.mealGapThreshold] apart; the average spans only days that had
-/// bites, so `—` marks a window with no meals rather than zero.
+/// A meals summary: today's meal count, the 30-day average meals per day, and
+/// the 30-day average meal size. A meal is a cluster of at least
+/// [BiteAnalytics.minMealBites] bites no more than [BiteAnalytics.mealGapThreshold]
+/// apart; the averages span only qualifying meals (avg size) or only days that
+/// had bites (avg meals), so `—` marks a window with no meals rather than zero.
 class _MealsSummaryRow extends StatelessWidget {
   const _MealsSummaryRow({
     required this.mealsToday,
     required this.averageMealsLast30,
+    required this.averageMealSizeLast30,
   });
 
   final int mealsToday;
   final double averageMealsLast30;
+  final double averageMealSizeLast30;
 
   @override
   Widget build(BuildContext context) {
@@ -202,6 +206,13 @@ class _MealsSummaryRow extends StatelessWidget {
                 value: _formatMealAverage(averageMealsLast30),
               ),
             ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: StatTile(
+                label: '30-day avg meal size',
+                value: _formatMealSize(averageMealSizeLast30),
+              ),
+            ),
           ],
         ),
       ),
@@ -211,6 +222,11 @@ class _MealsSummaryRow extends StatelessWidget {
   /// Meals per day to one decimal, with `—` for a window that held no meals.
   static String _formatMealAverage(double average) =>
       average == 0 ? '—' : average.toStringAsFixed(1);
+
+  /// Mean bites per meal as a whole number, with `—` for a window that held no
+  /// meal.
+  static String _formatMealSize(double average) =>
+      average == 0 ? '—' : average.toStringAsFixed(0);
 }
 
 /// Today's meal breakdown, framed in a titled card matching the daily-bites

--- a/test/features/bite/data/bite_analytics_test.dart
+++ b/test/features/bite/data/bite_analytics_test.dart
@@ -257,4 +257,69 @@ void main() {
       expect(avg, 0);
     });
   });
+
+  group('averageMealSize', () {
+    test('averages a single meal to its own size', () async {
+      await logEvery(DateTime(2026, 7, 15, 8), 12, const Duration(minutes: 1));
+
+      final avg = await analytics.averageMealSize(
+        DateTime(2026, 7, 15),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(avg, 12);
+    });
+
+    test('excludes snack clusters from the mean', () async {
+      // A 12-bite meal, then a 6-min gap and a 4-bite snack that must not
+      // drag the average down (it would be (12 + 4) / 2 = 8 if counted).
+      await logEvery(DateTime(2026, 7, 15, 8), 12, const Duration(minutes: 1));
+      await logEvery(DateTime(2026, 7, 15, 8, 17), 4, const Duration(minutes: 1));
+
+      final avg = await analytics.averageMealSize(
+        DateTime(2026, 7, 15),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(avg, 12);
+    });
+
+    test('averages meal bites over the meal count across several days', () async {
+      // 7/13: two meals, 10 and 20 bites.
+      await logEvery(DateTime(2026, 7, 13, 8), 10, const Duration(minutes: 1));
+      await logEvery(DateTime(2026, 7, 13, 8, 20), 20, const Duration(minutes: 1));
+      // 7/14: one meal, 15 bites, plus a 3-bite snack that is excluded.
+      await logEvery(DateTime(2026, 7, 14, 8), 15, const Duration(minutes: 1));
+      await logEvery(DateTime(2026, 7, 14, 8, 20), 3, const Duration(minutes: 1));
+
+      final avg = await analytics.averageMealSize(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      // (10 + 20 + 15) bites over 3 meals.
+      expect(avg, 15);
+    });
+
+    test('is 0 for a window with no meal', () async {
+      // Bites logged, but every cluster is a sub-threshold snack.
+      await logEvery(DateTime(2026, 7, 15, 8), 5, const Duration(minutes: 1));
+
+      final avg = await analytics.averageMealSize(
+        DateTime(2026, 7, 15),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(avg, 0);
+    });
+
+    test('is 0 for an empty window', () async {
+      final avg = await analytics.averageMealSize(
+        DateTime(2026, 7, 13),
+        DateTime(2026, 7, 16),
+      );
+
+      expect(avg, 0);
+    });
+  });
 }

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -146,6 +146,7 @@ void main() {
     // Three days ago: 8 bites — a snack, so a logged day with 0 meals.
     await logCluster(earlier, 8, 8);
     // Days with bites in the window: 3; meals 2 + 1 + 0 = 3 → average 1.0.
+    // Meal sizes 12, 15, 20 → (47 / 3) = 15.67 → 16 (snacks excluded).
 
     await pumpPage(tester);
 
@@ -160,6 +161,13 @@ void main() {
       find.descendant(
         of: find.widgetWithText(StatTile, '30-day avg meals'),
         matching: find.text('1.0'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.widgetWithText(StatTile, '30-day avg meal size'),
+        matching: find.text('16'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Implements **Phase 2** of `docs/bite_analytics_enhancements_plan.md` — the 30-day average meal size, as a new stat tile.

## What changed (keyed to the phase checklist)

- **`averageMealSize(from, to)` on `BiteAnalytics`** — mean bites per qualifying meal (`Σ meal bites / meal count`), snacks (sub-`minMealBites` clusters) excluded, returns `0` when the window holds no meal (rendered `—`). The shared "meal clusters across a window" walk is factored out of `averageMealsPerDay` into a private `_mealsInWindow` helper that returns both the qualifying meal clusters and the logged-day count, so the two metrics apply one identical meal definition and can't drift.
- **`averageMealSizeLast30` on `BiteAnalyticsController`** — loaded over the same `from30 … to` window the other 30-day metrics use.
- **Third tile on `_MealsSummaryRow`** — "30-day avg meal size", shown as a whole number of bites, `—` for a window with no meal, matching the three-across stat row above it.

## Verification

Flutter isn't installed in this web session (per `CLAUDE.md`, the toolchain isn't installed here), so local `flutter analyze` / `flutter test` are **deferred to the `flutter_ci.yml` PR checks**.

Tests added/updated:
- `bite_analytics_test.dart` — new `averageMealSize` group: single meal, snacks excluded from the mean, meal bites averaged over meal count across several days, a window with only snacks (`0`), and an empty window (`0`).
- `bite_analytics_page_test.dart` — the meal-tiles fixture (meals of 12/15/20 bites) now also asserts the "30-day avg meal size" tile reads `16` (47/3 = 15.67).

No deviations from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYAmdkYcwH8m8RJkSEHurE)_