### PR TITLE
feat: pickable breakdown day (Phase 3)

### DIFF
--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -338,16 +338,16 @@ Pure computation first, then wire it into the existing meals summary row.
 **Phase 3 — Pickable breakdown day**
 
 Chart tap drives the breakdown card; no new analytics.
-- [ ] Replace `breakdownToday` with `selectedDay` / `selectedBreakdown` /
+- [x] Replace `breakdownToday` with `selectedDay` / `selectedBreakdown` /
       `isSelectedDayToday` on the controller, plus `selectDay(day)` re-querying
       `breakdownForDay` behind a per-card loading flag; seed `selectedDay = today`
       in `load()`
-- [ ] Add `selectedDay` + `onDaySelected` to `DailyBitesChart`: select via
+- [x] Add `selectedDay` + `onDaySelected` to `DailyBitesChart`: select via
       `barTouchData.touchCallback` (tap-up → `firstDay + index`), and highlight the
       selected bar
-- [ ] `_MealBreakdownCard` titles the selected date and shows a "Back to today"
+- [x] `_MealBreakdownCard` titles the selected date and shows a "Back to today"
       control only when `!isSelectedDayToday`; keep the per-day empty state
-- [ ] **Verify:** unit-test `selectDay` loads the right day's breakdown and
+- [x] **Verify:** unit-test `selectDay` loads the right day's breakdown and
       `isSelectedDayToday` flips; widget-test that tapping a bar calls
       `onDaySelected` with that day and that "Back to today" resets to today
 

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -59,12 +59,6 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// window holds no bites — the max stat tile's value and its date.
   DailyBiteCount? get maxLast30 => _maxLast30;
 
-  int _mealsToday = 0;
-
-  /// The number of meals logged today — clusters that reached
-  /// [BiteAnalytics.minMealBites]. 0 when today has no qualifying meal.
-  int get mealsToday => _mealsToday;
-
   double _averageMealsLast30 = 0;
 
   /// Mean meals per day over the last [dailyBitesWindow] days, across only the
@@ -77,15 +71,53 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// qualifying meals (snacks excluded). 0 when the window holds no meal.
   double get averageMealSizeLast30 => _averageMealSizeLast30;
 
-  DayMealBreakdown _breakdownToday = DayMealBreakdown(
+  int _mealsToday = 0;
+
+  DateTime _selectedDay = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// The calendar day the breakdown card is showing, at local midnight. Seeded
+  /// to today by [load] and moved by [selectDay] when a chart bar is tapped.
+  DateTime get selectedDay => _selectedDay;
+
+  /// Whether [selectedDay] is today — drives the card's "Back to today"
+  /// affordance, shown only while browsing another day.
+  bool get isSelectedDayToday {
+    final now = DateTime.now();
+    return _selectedDay == DateTime(now.year, now.month, now.day);
+  }
+
+  DayMealBreakdown _selectedBreakdown = DayMealBreakdown(
     day: DateTime.fromMillisecondsSinceEpoch(0),
     meals: const [],
     snackBites: 0,
   );
 
-  /// Today split into its meals and its snack total — the meal-breakdown card's
-  /// data. Empty (no meals, no snack bites) until today has a bite.
-  DayMealBreakdown get breakdownToday => _breakdownToday;
+  /// [selectedDay] split into its meals and its snack total — the meal-breakdown
+  /// card's data. Empty (no meals, no snack bites) when the day has no bite.
+  DayMealBreakdown get selectedBreakdown => _selectedBreakdown;
+
+  bool _isBreakdownLoading = false;
+
+  /// Whether a [selectDay] re-query is in flight — lets the card show its own
+  /// spinner without blocking the rest of the screen.
+  bool get isBreakdownLoading => _isBreakdownLoading;
+
+  /// Selects [day] for the breakdown card: normalises to local midnight, marks
+  /// the card loading, re-queries [BiteAnalytics.breakdownForDay], and notifies.
+  /// The rest of the screen's metrics stay put — only the breakdown follows.
+  Future<void> selectDay(DateTime day) async {
+    _selectedDay = DateTime(day.year, day.month, day.day);
+    _isBreakdownLoading = true;
+    notifyListeners();
+    _selectedBreakdown = await _analytics.breakdownForDay(_selectedDay);
+    _isBreakdownLoading = false;
+    notifyListeners();
+  }
+
+  /// The number of meals logged today — clusters that reached
+  /// [BiteAnalytics.minMealBites]. 0 when today has no qualifying meal. Stays a
+  /// today metric independent of [selectedDay].
+  int get mealsToday => _mealsToday;
 
   /// Loads the analytics for the screen, notifying at the start and end so the
   /// spinner shows while the store is read.
@@ -106,8 +138,9 @@ class BiteAnalyticsController extends ChangeNotifier {
     _averageLast30 = await _analytics.averagePerDay(from30, to);
     _maxLast30 = await _analytics.maxDay(from30, to);
     _averageLastYear = await _analytics.averagePerDay(fromYear, to);
-    _breakdownToday = await _analytics.breakdownForDay(today);
-    _mealsToday = _breakdownToday.meals.length;
+    _selectedDay = today;
+    _selectedBreakdown = await _analytics.breakdownForDay(today);
+    _mealsToday = _selectedBreakdown.meals.length;
     _averageMealsLast30 = await _analytics.averageMealsPerDay(from30, to);
     _averageMealSizeLast30 = await _analytics.averageMealSize(from30, to);
     _isLoading = false;

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -53,7 +53,11 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
           }
           return ListView(
             children: [
-              _DailyBitesCard(counts: _controller.dailyCounts),
+              _DailyBitesCard(
+                counts: _controller.dailyCounts,
+                selectedDay: _controller.selectedDay,
+                onDaySelected: _controller.selectDay,
+              ),
               _StatTilesRow(
                 averageLast30: _controller.averageLast30,
                 averageLastYear: _controller.averageLastYear,
@@ -64,7 +68,12 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
                 averageMealsLast30: _controller.averageMealsLast30,
                 averageMealSizeLast30: _controller.averageMealSizeLast30,
               ),
-              _MealBreakdownCard(breakdown: _controller.breakdownToday),
+              _MealBreakdownCard(
+                breakdown: _controller.selectedBreakdown,
+                isToday: _controller.isSelectedDayToday,
+                isLoading: _controller.isBreakdownLoading,
+                onBackToToday: () => _controller.selectDay(DateTime.now()),
+              ),
             ],
           );
         },
@@ -76,9 +85,15 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
 /// The daily-bites chart, framed in a titled card with a fixed height so the
 /// bars have room without the surrounding [ListView] collapsing them.
 class _DailyBitesCard extends StatelessWidget {
-  const _DailyBitesCard({required this.counts});
+  const _DailyBitesCard({
+    required this.counts,
+    required this.selectedDay,
+    required this.onDaySelected,
+  });
 
   final List<DailyBiteCount> counts;
+  final DateTime selectedDay;
+  final ValueChanged<DateTime> onDaySelected;
 
   @override
   Widget build(BuildContext context) {
@@ -97,7 +112,14 @@ class _DailyBitesCard extends StatelessWidget {
               'Daily bites — last 30 days',
               style: theme.textTheme.titleMedium,
             ),
-            SizedBox(height: 240, child: DailyBitesChart(counts: counts)),
+            SizedBox(
+              height: 240,
+              child: DailyBitesChart(
+                counts: counts,
+                selectedDay: selectedDay,
+                onDaySelected: onDaySelected,
+              ),
+            ),
           ],
         ),
       ),
@@ -229,17 +251,29 @@ class _MealsSummaryRow extends StatelessWidget {
       average == 0 ? '—' : average.toStringAsFixed(0);
 }
 
-/// Today's meal breakdown, framed in a titled card matching the daily-bites
-/// card. The [MealBreakdownList] carries its own empty state for a day with no
-/// bites yet, so the card is always shown once the log holds any bite at all.
+/// The selected day's meal breakdown, framed in a titled card matching the
+/// daily-bites card. Tapping a chart bar changes [breakdown]; the title follows
+/// the day — "Today's meals" for today, the locale date otherwise — with a
+/// "Back to today" action while browsing another day. The [MealBreakdownList]
+/// carries its own empty state for a day with no bites, so the card is always
+/// shown once the log holds any bite at all.
 class _MealBreakdownCard extends StatelessWidget {
-  const _MealBreakdownCard({required this.breakdown});
+  const _MealBreakdownCard({
+    required this.breakdown,
+    required this.isToday,
+    required this.isLoading,
+    required this.onBackToToday,
+  });
 
   final DayMealBreakdown breakdown;
+  final bool isToday;
+  final bool isLoading;
+  final VoidCallback onBackToToday;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final title = isToday ? 'Today\'s meals' : shortDate(breakdown.day);
     return Card(
       elevation: 0,
       margin: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 16.0),
@@ -250,9 +284,26 @@ class _MealBreakdownCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Today\'s meals', style: theme.textTheme.titleMedium),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(title, style: theme.textTheme.titleMedium),
+                ),
+                if (!isToday)
+                  TextButton(
+                    onPressed: onBackToToday,
+                    child: const Text('Back to today'),
+                  ),
+              ],
+            ),
             const SizedBox(height: 8),
-            MealBreakdownList(breakdown: breakdown),
+            if (isLoading)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24.0),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else
+              MealBreakdownList(breakdown: breakdown),
           ],
         ),
       ),

--- a/lib/ui/widgets/daily_bites_chart.dart
+++ b/lib/ui/widgets/daily_bites_chart.dart
@@ -11,11 +11,24 @@ import 'package:food_locker/features/bite/data/bite_analytics.dart';
 /// reference line at that threshold, so the chart visibly explains why they
 /// don't count. Themed like `weight_chart.dart`.
 class DailyBitesChart extends StatelessWidget {
-  const DailyBitesChart({super.key, required this.counts});
+  const DailyBitesChart({
+    super.key,
+    required this.counts,
+    this.selectedDay,
+    this.onDaySelected,
+  });
 
   /// Daily totals, one entry per day that had at least one bite. Zero days are
   /// absent and rendered as gaps; the widget zero-fills between the extremes.
   final List<DailyBiteCount> counts;
+
+  /// The calendar day whose bar is highlighted, linking the chart to the
+  /// breakdown card below it. Null leaves every bar in its default treatment.
+  final DateTime? selectedDay;
+
+  /// Called with the calendar day of a tapped bar. Null makes the chart
+  /// read-only (no selection).
+  final ValueChanged<DateTime>? onDaySelected;
 
   @override
   Widget build(BuildContext context) {
@@ -38,6 +51,9 @@ class DailyBitesChart extends StatelessWidget {
     final days = byDay.keys.toList()..sort();
     final firstDay = days.first;
     final lastDay = days.last;
+    final selected = selectedDay == null
+        ? null
+        : DateTime(selectedDay!.year, selectedDay!.month, selectedDay!.day);
 
     // One bar per calendar day in [firstDay, lastDay], zero-filling gap days.
     final bars = <BarChartGroupData>[];
@@ -49,15 +65,21 @@ class DailyBitesChart extends StatelessWidget {
     ) {
       final count = byDay[day] ?? 0;
       final belowThreshold = count < BiteAnalytics.minBitesForAverage;
+      final isSelected = day == selected;
       bars.add(
         BarChartGroupData(
           x: x,
           barRods: [
             BarChartRodData(
               toY: count.toDouble(),
-              color: belowThreshold ? mutedColor : fullColor,
+              // The selected bar reads at full colour even when it's muted
+              // below the threshold, so the link to the card below is visible.
+              color: (belowThreshold && !isSelected) ? mutedColor : fullColor,
               width: _barWidth(days.length),
               borderRadius: const BorderRadius.vertical(top: Radius.circular(2)),
+              borderSide: isSelected
+                  ? BorderSide(color: theme.colorScheme.onSurface, width: 1.5)
+                  : BorderSide.none,
             ),
           ],
         ),
@@ -153,6 +175,17 @@ class DailyBitesChart extends StatelessWidget {
               ],
             ),
             barTouchData: BarTouchData(
+              touchCallback: (event, response) {
+                if (onDaySelected == null) return;
+                // Select on tap-up so a scroll/drag over the chart doesn't
+                // reselect; the tooltip still shows on the same touch.
+                if (event is! FlTapUpEvent) return;
+                final group = response?.spot?.touchedBarGroup;
+                if (group == null) return;
+                onDaySelected!(
+                  DateTime(firstDay.year, firstDay.month, firstDay.day + group.x),
+                );
+              },
               touchTooltipData: BarTouchTooltipData(
                 getTooltipItem: (group, groupIndex, rod, rodIndex) {
                   final day = DateTime(

--- a/test/features/bite/data/bite_analytics_controller_test.dart
+++ b/test/features/bite/data/bite_analytics_controller_test.dart
@@ -1,0 +1,102 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics_controller.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+
+/// [BiteAnalyticsController] over an in-memory Drift store, covering the
+/// pickable breakdown day: `load` seeds today, `selectDay` re-queries another
+/// day, and `isSelectedDayToday` tracks whether the card is on today.
+void main() {
+  late BiteDatabase db;
+  late BiteRepository repo;
+  late BiteAnalyticsController controller;
+
+  setUp(() {
+    db = BiteDatabase.forTesting(NativeDatabase.memory());
+    repo = DriftBiteRepository(db);
+    controller = BiteAnalyticsController(repo);
+  });
+
+  tearDown(() async {
+    controller.dispose();
+    await db.close();
+  });
+
+  /// Logs [count] bites one per minute from [hour]:00 on [day] — a single
+  /// cluster (consecutive-minute gaps stay under the meal-gap threshold).
+  Future<void> logCluster(DateTime day, int hour, int count) async {
+    for (var i = 0; i < count; i++) {
+      await repo.logBite(DateTime(day.year, day.month, day.day, hour, i));
+    }
+  }
+
+  test('load seeds the selected day to today and its breakdown', () async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    await logCluster(today, 8, 12);
+
+    await controller.load();
+
+    expect(controller.selectedDay, today);
+    expect(controller.isSelectedDayToday, isTrue);
+    expect(controller.selectedBreakdown.meals, hasLength(1));
+    expect(controller.selectedBreakdown.meals.single.count, 12);
+  });
+
+  test('selectDay loads the chosen day\'s breakdown and flips '
+      'isSelectedDayToday', () async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+    await logCluster(today, 8, 12);
+    await logCluster(yesterday, 9, 20);
+
+    await controller.load();
+    expect(controller.isSelectedDayToday, isTrue);
+
+    await controller.selectDay(yesterday);
+
+    expect(controller.selectedDay, yesterday);
+    expect(controller.isSelectedDayToday, isFalse);
+    expect(controller.selectedBreakdown.meals, hasLength(1));
+    expect(controller.selectedBreakdown.meals.single.count, 20);
+
+    // Back to today re-selects today and its breakdown.
+    await controller.selectDay(today);
+    expect(controller.isSelectedDayToday, isTrue);
+    expect(controller.selectedBreakdown.meals.single.count, 12);
+  });
+
+  test('selectDay normalises a timestamp to local midnight', () async {
+    final now = DateTime.now();
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+    await logCluster(yesterday, 9, 20);
+
+    await controller.load();
+    await controller.selectDay(DateTime(now.year, now.month, now.day - 1, 15, 30));
+
+    expect(controller.selectedDay, yesterday);
+  });
+
+  test('selecting another day leaves the today metrics untouched', () async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+    // Today: one meal. Yesterday: two meals.
+    await logCluster(today, 8, 12);
+    await logCluster(yesterday, 8, 15);
+    await logCluster(yesterday, 10, 20);
+
+    await controller.load();
+    expect(controller.mealsToday, 1);
+
+    await controller.selectDay(yesterday);
+
+    // The breakdown follows the selection, but "meals today" stays a today
+    // metric.
+    expect(controller.selectedBreakdown.meals, hasLength(2));
+    expect(controller.mealsToday, 1);
+  });
+}

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -1,4 +1,6 @@
 import 'package:drift/native.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
@@ -37,6 +39,31 @@ void main() {
     for (var i = 0; i < count; i++) {
       await repo.logBite(DateTime(day.year, day.month, day.day, hour, i));
     }
+  }
+
+  /// Drives the daily-bites chart's tap callback for the bar at [groupIndex],
+  /// as fl_chart would on a tap-up — the canvas bars can't be tapped by
+  /// coordinate reliably, so we invoke the wired callback directly.
+  void tapBar(WidgetTester tester, int groupIndex) {
+    final data = tester.widget<BarChart>(find.byType(BarChart)).data;
+    final group = data.barGroups[groupIndex];
+    data.barTouchData.touchCallback!(
+      const FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+      BarTouchResponse(
+        touchLocation: Offset.zero,
+        touchChartCoordinate: Offset.zero,
+        spot: BarTouchedSpot(
+          group,
+          groupIndex,
+          group.barRods.first,
+          0,
+          null,
+          -1,
+          const FlSpot(0, 0),
+          Offset.zero,
+        ),
+      ),
+    );
   }
 
   Future<void> pumpPage(WidgetTester tester) async {
@@ -211,5 +238,48 @@ void main() {
     expect(find.text('Today\'s meals'), findsOneWidget);
     expect(find.text('No bites logged today yet.'), findsOneWidget);
     expect(find.text('Snacks'), findsNothing);
+  });
+
+  testWidgets('tapping a bar switches the breakdown card to that day, and '
+      '"Back to today" returns to today', (tester) async {
+    // A tall surface so the whole scroll view builds — the breakdown card and
+    // the chart are both on-screen, so no scrolling is needed between tapping a
+    // bar and reading the card.
+    await tester.binding.setSurfaceSize(const Size(600, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+
+    // Today: a 12-bite meal. Yesterday: a 20-bite meal. Two bars: index 0 is
+    // the earlier day (yesterday), index 1 is today.
+    await logCluster(today, 8, 12);
+    await logCluster(yesterday, 9, 20);
+
+    await pumpPage(tester);
+
+    // Defaults to today: card titled "Today's meals", showing today's meal, no
+    // back control.
+    expect(find.text('Today\'s meals'), findsOneWidget);
+    expect(find.text('Back to today'), findsNothing);
+    expect(find.text('12 bites'), findsOneWidget);
+
+    // Tap yesterday's bar → card follows it: back control appears, the today
+    // title is gone, and yesterday's 20-bite meal shows.
+    tapBar(tester, 0);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Today\'s meals'), findsNothing);
+    expect(find.text('Back to today'), findsOneWidget);
+    expect(find.text('20 bites'), findsOneWidget);
+
+    // Back to today resets the card.
+    await tester.tap(find.text('Back to today'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Today\'s meals'), findsOneWidget);
+    expect(find.text('Back to today'), findsNothing);
+    expect(find.text('12 bites'), findsOneWidget);
   });
 }

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -48,7 +48,7 @@ void main() {
     final data = tester.widget<BarChart>(find.byType(BarChart)).data;
     final group = data.barGroups[groupIndex];
     data.barTouchData.touchCallback!(
-      const FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+      FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
       BarTouchResponse(
         touchLocation: Offset.zero,
         touchChartCoordinate: Offset.zero,

--- a/test/ui/widgets/daily_bites_chart_test.dart
+++ b/test/ui/widgets/daily_bites_chart_test.dart
@@ -50,7 +50,7 @@ void main() {
       ),
     );
     data.barTouchData.touchCallback!(
-      const FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+      FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
       response,
     );
   }

--- a/test/ui/widgets/daily_bites_chart_test.dart
+++ b/test/ui/widgets/daily_bites_chart_test.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
@@ -8,17 +9,50 @@ import 'package:food_locker/ui/widgets/daily_bites_chart.dart';
 void main() {
   Future<BarChartData> pumpChart(
     WidgetTester tester,
-    List<DailyBiteCount> counts,
-  ) async {
+    List<DailyBiteCount> counts, {
+    DateTime? selectedDay,
+    ValueChanged<DateTime>? onDaySelected,
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: appTheme,
         home: Scaffold(
-          body: SizedBox(height: 300, child: DailyBitesChart(counts: counts)),
+          body: SizedBox(
+            height: 300,
+            child: DailyBitesChart(
+              counts: counts,
+              selectedDay: selectedDay,
+              onDaySelected: onDaySelected,
+            ),
+          ),
         ),
       ),
     );
     return tester.widget<BarChart>(find.byType(BarChart)).data;
+  }
+
+  /// A tap-up touch on the bar at [groupIndex], as fl_chart would deliver it to
+  /// `barTouchData.touchCallback`.
+  void tapBar(BarChartData data, int groupIndex) {
+    final group = data.barGroups[groupIndex];
+    final response = BarTouchResponse(
+      touchLocation: Offset.zero,
+      touchChartCoordinate: Offset.zero,
+      spot: BarTouchedSpot(
+        group,
+        groupIndex,
+        group.barRods.first,
+        0,
+        null,
+        -1,
+        const FlSpot(0, 0),
+        Offset.zero,
+      ),
+    );
+    data.barTouchData.touchCallback!(
+      const FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+      response,
+    );
   }
 
   testWidgets('empty data shows a placeholder, no chart', (tester) async {
@@ -101,5 +135,48 @@ void main() {
       findsOneWidget,
     );
     handle.dispose();
+  });
+
+  testWidgets('tapping a bar reports its calendar day to onDaySelected', (
+    tester,
+  ) async {
+    DateTime? selected;
+    // First day 1/1, a gap day 1/2, then 1/3 → bars at index 0, 1, 2.
+    final data = await pumpChart(
+      tester,
+      [
+        DailyBiteCount(day: DateTime(2026, 1, 1), count: 50),
+        DailyBiteCount(day: DateTime(2026, 1, 3), count: 20),
+      ],
+      onDaySelected: (day) => selected = day,
+    );
+
+    tapBar(data, 2);
+    expect(selected, DateTime(2026, 1, 3));
+
+    tapBar(data, 0);
+    expect(selected, DateTime(2026, 1, 1));
+  });
+
+  testWidgets('the selected day\'s bar is highlighted with a border', (
+    tester,
+  ) async {
+    final data = await pumpChart(
+      tester,
+      [
+        DailyBiteCount(day: DateTime(2026, 1, 1), count: 60),
+        DailyBiteCount(day: DateTime(2026, 1, 2), count: 20),
+      ],
+      selectedDay: DateTime(2026, 1, 2),
+    );
+
+    // Unselected bar has no border; the selected one does.
+    expect(data.barGroups[0].barRods.single.borderSide.width, 0);
+    expect(
+      data.barGroups[1].barRods.single.borderSide.width,
+      greaterThan(0),
+    );
+    // The selected below-threshold bar reads at full colour, not muted.
+    expect(data.barGroups[1].barRods.single.color, appTheme.colorScheme.primary);
   });
 }


### PR DESCRIPTION
## Phase 3 — Pickable breakdown day

Implements Phase 3 of `docs/bite_analytics_enhancements_plan.md`: the meal-breakdown card on the Bite Analytics page now follows a **selectable day**, driven by tapping a bar in the daily-bites chart. No new analytics — `breakdownForDay` already takes any day; this is a controller + chart-wiring change.

### What changed, keyed to the checklist

- **Controller (`BiteAnalyticsController`)** — replaced the fixed `breakdownToday` with a selected-day model: `selectedDay`, `selectedBreakdown`, `isSelectedDayToday`, and `selectDay(day)` which normalises to local midnight, sets a per-card loading flag (`isBreakdownLoading`), re-queries `breakdownForDay`, and notifies. `load()` seeds `selectedDay = today`. `mealsToday` and the 30-day tiles stay today/window metrics, unaffected by the selection.
- **Chart (`DailyBitesChart`)** — added optional `selectedDay` + `onDaySelected`, staying a stateless widget. Selection rides `barTouchData.touchCallback` on a tap-up event, mapping `group.x` back to its calendar day (`firstDay + index`, the same arithmetic the tooltip/axis already use). The selected bar is highlighted with a border and drawn at full colour even when it's below the average threshold; the existing tooltip still shows on the same touch.
- **Card (`_MealBreakdownCard`)** — the title follows the selected day: "Today's meals" for today, otherwise the locale-aware `shortDate`. A "Back to today" action shows only when `!isSelectedDayToday`. The `MealBreakdownList`'s per-day empty state is kept, and a spinner shows while a re-query is in flight.

### Verification

Flutter isn't available in this web session (per `CLAUDE.md`, the toolchain isn't installed here), so local `flutter analyze` / `flutter test` were **deferred to the PR's `flutter_ci.yml` checks**. Tests added for the phase's Verify bullet:

- `test/features/bite/data/bite_analytics_controller_test.dart` — `selectDay` loads the chosen day's breakdown, `isSelectedDayToday` flips, timestamps normalise to midnight, and the today metrics stay put when browsing another day.
- `test/ui/widgets/daily_bites_chart_test.dart` — tapping a bar reports its calendar day to `onDaySelected`; the selected bar is highlighted with a border and full colour.
- `test/ui/pages/bite_analytics_page_test.dart` — tapping a bar switches the card to that day and surfaces "Back to today", which resets the card to today.

### Deviations

None. The date-title assertions in the page/chart tests avoid matching the exact `shortDate` string with `findsOneWidget` because the chart x-axis labels and the 30-day-max tile render the same locale date; the tests assert the switch behaviourally (title, "Back to today" control, meal content) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XXkHJgyyyGWewV56Fz7Sq

---
_Generated by [Claude Code](https://claude.ai/code/session_019XXkHJgyyyGWewV56Fz7Sq)_