### PR TITLE
feat: current-meal bites on the Bite page (Phase 4)

### DIFF
--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -353,17 +353,17 @@ Chart tap drives the breakdown card; no new analytics.
 
 **Phase 4 — Current-meal bites on the Bite page**
 
-- [ ] Extract the meal-clustering rule (`_clusterBites` / `mealGapThreshold`) from
+- [x] Extract the meal-clustering rule (`_clusterBites` / `mealGapThreshold`) from
       `BiteAnalytics` into a shared spot so the manager and the analytics screen
       apply one identical rule
-- [ ] Add `currentMealBites` to `BiteManager`, **recomputed** from today's bites
+- [x] Add `currentMealBites` to `BiteManager`, **recomputed** from today's bites
       (trailing `mealGapThreshold` cluster) in the same refresh that recomputes the
       day count, gated on recency — 0 when the most recent bite is more than
       `mealGapThreshold` ago; no running counter, no `initialize` special-casing
       beyond that refresh
-- [ ] Show a quiet "This meal: N" line under the day total in `bite_page.dart`,
+- [x] Show a quiet "This meal: N" line under the day total in `bite_page.dart`,
       hidden when `currentMealBites == 0`
-- [ ] **Verify:** unit-test the trailing cluster's size when the last bite is
+- [x] **Verify:** unit-test the trailing cluster's size when the last bite is
       recent, 0 when the last bite is older than `mealGapThreshold`, a fresh
       cluster of 1 after a `> mealGapThreshold` gap, a fresh manager at 0, and that
       it recomputes after a logged bite; widget-test the line shows with a current

--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -1,5 +1,6 @@
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/meal_clustering.dart';
 
 /// Total bites on a single local calendar day.
 ///
@@ -26,7 +27,7 @@ class DailyBiteCount {
   String toString() => 'DailyBiteCount(day: $day, count: $count)';
 }
 
-/// A single meal: a cluster of bites no more than [BiteAnalytics.mealGapThreshold]
+/// A single meal: a cluster of bites no more than [mealGapThreshold]
 /// apart that reached [BiteAnalytics.minMealBites] bites.
 ///
 /// A read-time projection of the bite log, never persisted. [start] and [end]
@@ -94,11 +95,6 @@ class BiteAnalytics {
   /// Days below this bite count don't count toward [averagePerDay]: a day you
   /// forgot to log — or only logged a few bites on — never dilutes the mean.
   static const int minBitesForAverage = 40;
-
-  /// A gap longer than this between two consecutive bites closes the current
-  /// meal cluster and starts a new one. Measured bite-to-bite, not from the
-  /// cluster's start, so a long slow meal stays one cluster.
-  static const Duration mealGapThreshold = Duration(minutes: 5);
 
   /// A cluster is only promoted to a meal at this many bites; smaller clusters
   /// are snacking and their bites roll into the day's snack total.
@@ -200,7 +196,7 @@ class BiteAnalytics {
     final byDay = _groupByLocalDay(bites);
     final meals = <List<Bite>>[];
     for (final dayBites in byDay.values) {
-      for (final cluster in _clusterBites(dayBites)) {
+      for (final cluster in clusterBites(dayBites)) {
         if (cluster.length >= minMealBites) meals.add(cluster);
       }
     }
@@ -212,23 +208,7 @@ class BiteAnalytics {
     final startOfDay = DateTime(day.year, day.month, day.day);
     final startOfNextDay = DateTime(day.year, day.month, day.day + 1);
     final bites = await _repository.bitesInRange(startOfDay, startOfNextDay);
-    return _clusterBites(bites);
-  }
-
-  /// Splits chronologically-ordered [bites] into clusters, breaking wherever a
-  /// gap from the previous bite exceeds [mealGapThreshold].
-  List<List<Bite>> _clusterBites(List<Bite> bites) {
-    final clusters = <List<Bite>>[];
-    for (final bite in bites) {
-      final current = clusters.isEmpty ? null : clusters.last;
-      if (current != null &&
-          bite.atMs - current.last.atMs <= mealGapThreshold.inMilliseconds) {
-        current.add(bite);
-      } else {
-        clusters.add([bite]);
-      }
-    }
-    return clusters;
+    return clusterBites(bites);
   }
 
   /// Groups [bites] by their local calendar day, preserving chronological order

--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/bite/data/meal_clustering.dart';
 import 'package:food_locker/features/bite/data/pacing_zone.dart';
 
 /// UI-facing state holder for the bite-logging screen.
@@ -46,6 +47,21 @@ class BiteManager extends ChangeNotifier {
   /// Bites logged so far during the current local day — the headline metric.
   /// Zero until [initialize] (or a [logBite]) has run.
   int get todayCount => _todayCount;
+
+  int _currentMealBites = 0;
+
+  /// Bites in the current meal, or 0 when no meal is in progress. Recomputed
+  /// from the store alongside [todayCount]: the size of the trailing run of
+  /// today's bites no more than [mealGapThreshold] apart — but only when the
+  /// most recent bite is within that threshold of now. A last bite older than
+  /// the threshold means the sitting has ended, so this reads 0.
+  ///
+  /// A projection of the log, not a running counter, so there is no
+  /// increment/reset arithmetic to keep in sync: a just-logged bite always
+  /// starts a fresh cluster after a `> mealGapThreshold` gap, while opening the
+  /// app long after the last bite shows nothing. No [minMealBites] gate applies
+  /// — it counts from the first bite of the sitting.
+  int get currentMealBites => _currentMealBites;
 
   DateTime? _lastBiteAt;
 
@@ -116,8 +132,20 @@ class BiteManager extends ChangeNotifier {
     // month/year rollover and DST correct where a fixed 24-hour offset would not.
     final startOfDay = DateTime(now.year, now.month, now.day);
     final startOfNextDay = DateTime(now.year, now.month, now.day + 1);
-    _todayCount = await _repository.biteCount(startOfDay, startOfNextDay);
+    final bites = await _repository.bitesInRange(startOfDay, startOfNextDay);
+    _todayCount = bites.length;
+    _currentMealBites = _currentMealSize(bites, now);
     notifyListeners();
+  }
+
+  /// The trailing meal cluster's size given today's chronologically-ordered
+  /// [bites] and the current instant [now]. 0 when the day is empty or the most
+  /// recent bite is more than [mealGapThreshold] ago — the sitting has ended.
+  int _currentMealSize(List<Bite> bites, DateTime now) {
+    if (bites.isEmpty) return 0;
+    final lastAt = DateTime.fromMillisecondsSinceEpoch(bites.last.atMs);
+    if (now.difference(lastAt) > mealGapThreshold) return 0;
+    return clusterBites(bites).last.length;
   }
 
   /// (Re)starts the pacing countdown from the current [_lastBiteAt]. Sets the

--- a/lib/features/bite/data/meal_clustering.dart
+++ b/lib/features/bite/data/meal_clustering.dart
@@ -1,0 +1,25 @@
+import 'package:food_locker/features/bite/data/bite_database.dart';
+
+/// A gap longer than this between two consecutive bites closes the current
+/// meal cluster and starts a new one. Measured bite-to-bite, not from the
+/// cluster's start, so a long slow meal stays one cluster.
+///
+/// The single clustering rule shared by the analytics meal projections and the
+/// Bite page's live current-meal count, so the two can't drift apart.
+const Duration mealGapThreshold = Duration(minutes: 5);
+
+/// Splits chronologically-ordered [bites] into clusters, breaking wherever a
+/// gap from the previous bite exceeds [mealGapThreshold].
+List<List<Bite>> clusterBites(List<Bite> bites) {
+  final clusters = <List<Bite>>[];
+  for (final bite in bites) {
+    final current = clusters.isEmpty ? null : clusters.last;
+    if (current != null &&
+        bite.atMs - current.last.atMs <= mealGapThreshold.inMilliseconds) {
+      current.add(bite);
+    } else {
+      clusters.add([bite]);
+    }
+  }
+  return clusters;
+}

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -193,7 +193,7 @@ class _StatTilesRow extends StatelessWidget {
 
 /// A meals summary: today's meal count, the 30-day average meals per day, and
 /// the 30-day average meal size. A meal is a cluster of at least
-/// [BiteAnalytics.minMealBites] bites no more than [BiteAnalytics.mealGapThreshold]
+/// [BiteAnalytics.minMealBites] bites no more than the meal-gap threshold
 /// apart; the averages span only qualifying meals (avg size) or only days that
 /// had bites (avg meals), so `—` marks a window with no meals rather than zero.
 class _MealsSummaryRow extends StatelessWidget {

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -135,6 +135,18 @@ class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
                     color: theme.colorScheme.primary,
                   ),
                 ),
+                // The in-progress sitting's running count, shown only while a
+                // meal is actually underway (0 once the sitting has ended).
+                if (biteManager.currentMealBites > 0) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    'This meal: ${biteManager.currentMealBites}',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
                 const Spacer(),
                 _BiteButton(
                   zone: biteManager.pacingZone,

--- a/test/features/bite/data/bite_manager_current_meal_test.dart
+++ b/test/features/bite/data/bite_manager_current_meal_test.dart
@@ -1,0 +1,160 @@
+import 'package:clock/clock.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+
+/// [BiteManager.currentMealBites] — the trailing meal cluster of today's bites,
+/// recomputed from the store alongside the day count. Driven with [fakeAsync]
+/// so `clock.now()` and the seeded bite offsets stay deterministic without a
+/// real drift database.
+void main() {
+  const config = PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30);
+
+  test('is zero on a fresh manager before any refresh', () {
+    final repo = _FakeBiteRepository(config: config);
+    final manager = BiteManager(repo, onReachedClear: () async {});
+    expect(manager.currentMealBites, 0);
+    manager.dispose();
+  });
+
+  test('counts the trailing cluster when the last bite is recent', () {
+    fakeAsync((async) {
+      final now = clock.now();
+      // An earlier, separate cluster (a 16-min gap breaks it off) then a fresh
+      // run of three within the 5-min threshold — only the trailing run counts.
+      final repo = _FakeBiteRepository(config: config, bites: [
+        now.subtract(const Duration(minutes: 20)),
+        now.subtract(const Duration(minutes: 4)),
+        now.subtract(const Duration(minutes: 2)),
+        now.subtract(const Duration(minutes: 1)),
+      ]);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+
+      expect(manager.currentMealBites, 3);
+
+      manager.dispose();
+    });
+  });
+
+  test('is zero when the last bite is older than the meal-gap threshold', () {
+    fakeAsync((async) {
+      final now = clock.now();
+      // A two-bite cluster, but the sitting ended: the last bite is 8 min ago.
+      final repo = _FakeBiteRepository(config: config, bites: [
+        now.subtract(const Duration(minutes: 10)),
+        now.subtract(const Duration(minutes: 8)),
+      ]);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+
+      expect(manager.currentMealBites, 0);
+
+      manager.dispose();
+    });
+  });
+
+  test('a bite after a long gap starts a fresh cluster of one', () {
+    fakeAsync((async) {
+      final now = clock.now();
+      // A stale bite from 10 min ago: on open the sitting has ended (0).
+      final repo = _FakeBiteRepository(config: config, bites: [
+        now.subtract(const Duration(minutes: 10)),
+      ]);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+      expect(manager.currentMealBites, 0);
+
+      // A new bite lands more than the threshold after the stale one — a fresh
+      // trailing cluster of exactly one, recomputed by the logBite refresh.
+      manager.logBite();
+      async.flushMicrotasks();
+      expect(manager.currentMealBites, 1);
+
+      manager.dispose();
+    });
+  });
+
+  test('recomputes and grows as consecutive bites are logged', () {
+    fakeAsync((async) {
+      final repo = _FakeBiteRepository(config: config);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.logBite();
+      async.flushMicrotasks();
+      expect(manager.currentMealBites, 1);
+
+      async.elapse(const Duration(seconds: 30));
+      manager.logBite();
+      async.flushMicrotasks();
+      expect(manager.currentMealBites, 2);
+
+      manager.dispose();
+    });
+  });
+}
+
+/// An in-memory [BiteRepository] returning bites chronologically, for exercising
+/// the current-meal recompute under [fakeAsync] without a drift database.
+class _FakeBiteRepository implements BiteRepository {
+  _FakeBiteRepository({this.config, List<DateTime>? bites})
+      : _bites = [...?bites];
+
+  final PacingConfig? config;
+  final List<DateTime> _bites;
+
+  @override
+  Future<void> logBite(DateTime at) async => _bites.add(at);
+
+  @override
+  Future<Bite?> lastBite() async => _bites.isEmpty
+      ? null
+      : Bite(id: _bites.length, atMs: _bites.last.millisecondsSinceEpoch);
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) async {
+    final inRange = _bites
+        .where((at) => !at.isBefore(from) && at.isBefore(to))
+        .toList()
+      ..sort();
+    var id = 0;
+    return [
+      for (final at in inRange) Bite(id: ++id, atMs: at.millisecondsSinceEpoch),
+    ];
+  }
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) async =>
+      _bites.where((at) => !at.isBefore(from) && at.isBefore(to)).length;
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(
+    DateTime from,
+    DateTime to,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async {}
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
+
+  @override
+  Future<List<PacingConfig>> allPacingConfigs() async => [?config];
+
+  @override
+  Future<void> clearBites() async => _bites.clear();
+
+  @override
+  Future<void> clearPacingConfigs() async {}
+}

--- a/test/ui/pages/bite_page_test.dart
+++ b/test/ui/pages/bite_page_test.dart
@@ -1,0 +1,119 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/ui/pages/bite_page.dart';
+import 'package:provider/provider.dart';
+
+/// The "This meal: N" line on [BitePage]: present while a sitting is in
+/// progress, absent once it has ended.
+void main() {
+  const config = PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30);
+
+  Future<BiteManager> pumpPage(
+    WidgetTester tester,
+    _FakeBiteRepository repo,
+  ) async {
+    final manager = BiteManager(repo, onReachedClear: () async {});
+    await manager.initialize();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<BiteManager>.value(
+          value: manager,
+          child: const BitePage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    return manager;
+  }
+
+  testWidgets('shows the current-meal line while a meal is in progress',
+      (tester) async {
+    final now = clock.now();
+    final repo = _FakeBiteRepository(config: config, bites: [
+      now.subtract(const Duration(minutes: 3)),
+      now.subtract(const Duration(minutes: 2)),
+      now.subtract(const Duration(seconds: 10)),
+    ]);
+
+    final manager = await pumpPage(tester, repo);
+
+    expect(find.text('This meal: 3'), findsOneWidget);
+
+    manager.dispose();
+  });
+
+  testWidgets('hides the current-meal line when no meal is in progress',
+      (tester) async {
+    final now = clock.now();
+    // A stale bite from 10 min ago: the sitting has ended.
+    final repo = _FakeBiteRepository(config: config, bites: [
+      now.subtract(const Duration(minutes: 10)),
+    ]);
+
+    final manager = await pumpPage(tester, repo);
+
+    expect(find.textContaining('This meal:'), findsNothing);
+
+    manager.dispose();
+  });
+}
+
+/// A minimal in-memory [BiteRepository] returning bites chronologically.
+class _FakeBiteRepository implements BiteRepository {
+  _FakeBiteRepository({this.config, List<DateTime>? bites})
+      : _bites = [...?bites];
+
+  final PacingConfig? config;
+  final List<DateTime> _bites;
+
+  @override
+  Future<void> logBite(DateTime at) async => _bites.add(at);
+
+  @override
+  Future<Bite?> lastBite() async => _bites.isEmpty
+      ? null
+      : Bite(id: _bites.length, atMs: _bites.last.millisecondsSinceEpoch);
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) async {
+    final inRange = _bites
+        .where((at) => !at.isBefore(from) && at.isBefore(to))
+        .toList()
+      ..sort();
+    var id = 0;
+    return [
+      for (final at in inRange) Bite(id: ++id, atMs: at.millisecondsSinceEpoch),
+    ];
+  }
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) async =>
+      _bites.where((at) => !at.isBefore(from) && at.isBefore(to)).length;
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(
+    DateTime from,
+    DateTime to,
+  ) async =>
+      [];
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async {}
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
+
+  @override
+  Future<List<PacingConfig>> allPacingConfigs() async => [?config];
+
+  @override
+  Future<void> clearBites() async => _bites.clear();
+
+  @override
+  Future<void> clearPacingConfigs() async {}
+}


### PR DESCRIPTION
Implements **Phase 4 — Current-meal bites on the Bite page** of `docs/bite_analytics_enhancements_plan.md`.

## What changed

- **Shared meal-clustering rule.** Extracted `mealGapThreshold` and the `clusterBites` walk out of `BiteAnalytics` into a new `lib/features/bite/data/meal_clustering.dart`, so the analytics screen and the live current-meal count cluster by one identical rule and can't drift apart. `BiteAnalytics` now imports the shared helpers; `minMealBites` stays on the analytics class as before.
- **`BiteManager.currentMealBites`.** Recomputed from today's stored bites in the same refresh that recomputes the day count — the trailing `mealGapThreshold` cluster's size, gated on recency: it reads `0` once the most recent bite is more than the threshold ago (the sitting has ended). No running counter and no `initialize` special-casing; the day refresh now reads today's bites once and derives both the count and the current-meal size from that single read. No `minMealBites` gate on the live count — it counts from the first bite of the sitting.
- **UI.** A quiet "This meal: N" line under the big day total on the Bite page, rendered only when `currentMealBites > 0` so an empty (or ended) day stays clean.

## Checklist (Phase 4)

- [x] Extract the meal-clustering rule into a shared spot
- [x] Add `currentMealBites` to `BiteManager`, recomputed and recency-gated, no running counter
- [x] Show the "This meal: N" line, hidden when `currentMealBites == 0`
- [x] Verify — unit + widget tests (below)

## Verification

Flutter isn't installed in this web session, so `flutter analyze` / `flutter test` are deferred to the `flutter_ci.yml` PR checks. Tests added:

- `test/features/bite/data/bite_manager_current_meal_test.dart` — trailing cluster size when the last bite is recent, `0` when the last bite is older than `mealGapThreshold`, a fresh cluster of 1 after a `> mealGapThreshold` gap, a fresh manager at 0, and recompute-after-logBite.
- `test/ui/pages/bite_page_test.dart` — the line shows with a current meal in progress and hides when the sitting has ended.

## Notes / deviations

- `BiteRepository.biteCount` is left in place (still part of the interface and covered by its own repository test) but is no longer called from `BiteManager`, which now reads today's bites via `bitesInRange` to derive both the count and the current-meal size from one read, as the plan describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012n84BZTzFMfZdDeXSqYmuK)_