### PR TITLE
feat: body weight as a second bar on the bite chart (Phase 5)

### DIFF
--- a/.claude/skills/implement-next-phase/SKILL.md
+++ b/.claude/skills/implement-next-phase/SKILL.md
@@ -55,6 +55,7 @@ In the same branch, edit the plan document: flip every checklist item of the imp
 - Push and open a PR against `main` using whatever GitHub access is available (the `gh` CLI or a GitHub MCP tool — use whichever exists; do not install anything).
   - Title: same convention as the commit — `<type>: <phase title> (Phase <N>)` where Conventional Commits are used, otherwise `Phase <N>: <phase title> (<plan name>)`.
   - Body: what was implemented, keyed to the phase's checklist; how it was verified (locally, or deferred to PR checks); any deviations from the plan.
+- Immediately after the PR is created, subscribe this session to its activity (`subscribe_pr_activity`, or the equivalent for the GitHub access in use) so CI results and review comments flow back into the conversation. If no subscription mechanism is available, skip this silently.
 - Watch the PR checks (`gh pr checks --watch` or the MCP equivalent). While any check fails: read the failure logs, fix, commit, push, and watch again.
 - After 5 failed fix rounds, stop pushing and report: link the PR, summarize what still fails and why, and suggest next steps.
 

--- a/docs/bite_analytics_enhancements_plan.md
+++ b/docs/bite_analytics_enhancements_plan.md
@@ -371,15 +371,15 @@ Chart tap drives the breakdown card; no new analytics.
 
 **Phase 5 — Body weight as a second bar on the bite chart**
 
-- [ ] Inject `WeightRepository` into `BiteAnalyticsController` and load raw daily
+- [x] Inject `WeightRepository` into `BiteAnalyticsController` and load raw daily
       weights over the 30-day window (`getAllWeights()` filtered to `[from30, to)`)
-- [ ] Add a second `BarChartRodData` per group in `daily_bites_chart.dart` for
+- [x] Add a second `BarChartRodData` per group in `daily_bites_chart.dart` for
       weight, on a secondary right-hand kg axis fitted to the weight min/max
       (normalise the rod's `toY`, label `rightTitles` in kg); distinct colour, a
       two-item legend, and each rod at ~half the current `_barWidth` (two per day)
       over the kept 30-day window
-- [ ] Weight bar omitted on days with no weigh-in; bite-only days unchanged
-- [ ] **Verify:** the chart renders bite-only, weight-only, and both-present days;
+- [x] Weight bar omitted on days with no weigh-in; bite-only days unchanged
+- [x] **Verify:** the chart renders bite-only, weight-only, and both-present days;
       the weight axis fits the weight range (small changes stay visible, not
       flattened from zero); a day without a weigh-in shows only the bite bar
 

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -148,10 +148,7 @@ class BiteAnalyticsController extends ChangeNotifier {
     );
     final fromYear = DateTime(now.year - 1, now.month, now.day + 1);
     _dailyCounts = await _analytics.dailyCounts(from30, to);
-    _dailyWeights = _weightRepository.getAllWeights().where((w) {
-      final day = DateTime(w.date.year, w.date.month, w.date.day);
-      return !day.isBefore(from30) && day.isBefore(to);
-    }).toList();
+    _dailyWeights = _weightRepository.getWeightsInRange(from30, to);
     _averageLast30 = await _analytics.averagePerDay(from30, to);
     _maxLast30 = await _analytics.maxDay(from30, to);
     _averageLastYear = await _analytics.averagePerDay(fromYear, to);

--- a/lib/features/bite/data/bite_analytics_controller.dart
+++ b/lib/features/bite/data/bite_analytics_controller.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/features/weight/data/weight_repository.dart';
 
 /// Per-screen state for the Bite Analytics page.
 ///
@@ -13,11 +15,15 @@ import 'package:food_locker/features/bite/data/bite_repository.dart';
 /// It establishes whether the log holds any bite at all, which decides the
 /// screen's global empty state.
 class BiteAnalyticsController extends ChangeNotifier {
-  BiteAnalyticsController(BiteRepository repository)
-    : _repository = repository,
+  BiteAnalyticsController(
+    BiteRepository repository,
+    WeightRepository weightRepository,
+  ) : _repository = repository,
+      _weightRepository = weightRepository,
       _analytics = BiteAnalytics(repository);
 
   final BiteRepository _repository;
+  final WeightRepository _weightRepository;
   final BiteAnalytics _analytics;
 
   /// The chart's window, and the span the 30-day average and max cover: the
@@ -40,6 +46,13 @@ class BiteAnalyticsController extends ChangeNotifier {
   /// Bites per day over the last [dailyBitesWindow] days, one entry per day
   /// that had bites — the daily-bites chart's data.
   List<DailyBiteCount> get dailyCounts => _dailyCounts;
+
+  List<Weight> _dailyWeights = const [];
+
+  /// Raw daily weigh-ins over the last [dailyBitesWindow] days, one per day that
+  /// was weighed — the weight bars overlaid on the daily-bites chart. Days
+  /// without a weigh-in are simply absent (no gap-filling).
+  List<Weight> get dailyWeights => _dailyWeights;
 
   double _averageLast30 = 0;
 
@@ -135,6 +148,10 @@ class BiteAnalyticsController extends ChangeNotifier {
     );
     final fromYear = DateTime(now.year - 1, now.month, now.day + 1);
     _dailyCounts = await _analytics.dailyCounts(from30, to);
+    _dailyWeights = _weightRepository.getAllWeights().where((w) {
+      final day = DateTime(w.date.year, w.date.month, w.date.day);
+      return !day.isBefore(from30) && day.isBefore(to);
+    }).toList();
     _averageLast30 = await _analytics.averagePerDay(from30, to);
     _maxLast30 = await _analytics.maxDay(from30, to);
     _averageLastYear = await _analytics.averagePerDay(fromYear, to);

--- a/lib/features/weight/data/weight_repository.dart
+++ b/lib/features/weight/data/weight_repository.dart
@@ -4,6 +4,12 @@ abstract class WeightRepository {
   Weight? getWeightForDay(DateTime date);
   Future<void> saveWeight(Weight weight);
   List<Weight> getAllWeights();
+
+  /// Weigh-ins whose calendar day falls in `[from, to)` — both bounds and each
+  /// weigh-in are compared day-granular (normalised to their calendar day).
+  /// Empty when the range holds none.
+  List<Weight> getWeightsInRange(DateTime from, DateTime to);
+
   Future<void> deleteWeight(DateTime date);
   Future<void> clear();
   
@@ -64,6 +70,16 @@ mixin WeightRepositoryHelper implements WeightRepository {
     final result = filtered.map((w) => w.value).reduce((a, b) => a < b ? a : b);
     _lowestWeightCache[cacheKey] = result;
     return result;
+  }
+
+  @override
+  List<Weight> getWeightsInRange(DateTime from, DateTime to) {
+    final fromDay = DateTime(from.year, from.month, from.day);
+    final toDay = DateTime(to.year, to.month, to.day);
+    return getAllWeights().where((w) {
+      final day = DateTime(w.date.year, w.date.month, w.date.day);
+      return !day.isBefore(fromDay) && day.isBefore(toDay);
+    }).toList();
   }
 
   @override

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -3,6 +3,8 @@ import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_analytics_controller.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/features/weight/data/weight_repository.dart';
 import 'package:food_locker/ui/widgets/daily_bites_chart.dart';
 import 'package:food_locker/ui/widgets/meal_breakdown_list.dart';
 import 'package:food_locker/ui/widgets/stat_tile.dart';
@@ -28,8 +30,10 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
   @override
   void initState() {
     super.initState();
-    _controller = BiteAnalyticsController(context.read<BiteRepository>())
-      ..load();
+    _controller = BiteAnalyticsController(
+      context.read<BiteRepository>(),
+      context.read<WeightRepository>(),
+    )..load();
   }
 
   @override
@@ -55,6 +59,7 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
             children: [
               _DailyBitesCard(
                 counts: _controller.dailyCounts,
+                weights: _controller.dailyWeights,
                 selectedDay: _controller.selectedDay,
                 onDaySelected: _controller.selectDay,
               ),
@@ -87,11 +92,13 @@ class _BiteAnalyticsPageState extends State<BiteAnalyticsPage> {
 class _DailyBitesCard extends StatelessWidget {
   const _DailyBitesCard({
     required this.counts,
+    required this.weights,
     required this.selectedDay,
     required this.onDaySelected,
   });
 
   final List<DailyBiteCount> counts;
+  final List<Weight> weights;
   final DateTime selectedDay;
   final ValueChanged<DateTime> onDaySelected;
 
@@ -116,6 +123,7 @@ class _DailyBitesCard extends StatelessWidget {
               height: 240,
               child: DailyBitesChart(
                 counts: counts,
+                weights: weights,
                 selectedDay: selectedDay,
                 onDaySelected: onDaySelected,
               ),

--- a/lib/ui/widgets/daily_bites_chart.dart
+++ b/lib/ui/widgets/daily_bites_chart.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
 
 /// A bar chart of total bites per calendar day over the analytics window.
 ///
@@ -10,10 +11,16 @@ import 'package:food_locker/features/bite/data/bite_analytics.dart';
 /// — the ones excluded from the average — are drawn muted and sit under a faint
 /// reference line at that threshold, so the chart visibly explains why they
 /// don't count. Themed like `weight_chart.dart`.
+///
+/// When [weights] is non-empty a second bar per day carries that day's weigh-in,
+/// drawn on a secondary right-hand kg axis fitted to the weight range (not from
+/// zero, which would flatten the day-to-day change). Days without a weigh-in
+/// show only the bite bar.
 class DailyBitesChart extends StatelessWidget {
   const DailyBitesChart({
     super.key,
     required this.counts,
+    this.weights = const [],
     this.selectedDay,
     this.onDaySelected,
   });
@@ -22,6 +29,10 @@ class DailyBitesChart extends StatelessWidget {
   /// absent and rendered as gaps; the widget zero-fills between the extremes.
   final List<DailyBiteCount> counts;
 
+  /// Raw daily weigh-ins, one per weighed day, overlaid as a second bar. Empty
+  /// leaves the chart bites-only with no right-hand axis.
+  final List<Weight> weights;
+
   /// The calendar day whose bar is highlighted, linking the chart to the
   /// breakdown card below it. Null leaves every bar in its default treatment.
   final DateTime? selectedDay;
@@ -29,6 +40,10 @@ class DailyBitesChart extends StatelessWidget {
   /// Called with the calendar day of a tapped bar. Null makes the chart
   /// read-only (no selection).
   final ValueChanged<DateTime>? onDaySelected;
+
+  /// Padding above/below the weight range so even the lightest day draws a
+  /// short visible bar rather than collapsing onto the axis floor.
+  static const double _weightAxisPadding = 1.0;
 
   @override
   Widget build(BuildContext context) {
@@ -44,18 +59,58 @@ class DailyBitesChart extends StatelessWidget {
     final theme = Theme.of(context);
     final fullColor = theme.colorScheme.primary;
     final mutedColor = theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4);
+    final weightColor = theme.colorScheme.tertiary;
 
     final byDay = {
       for (final c in counts) DateTime(c.day.year, c.day.month, c.day.day): c.count,
     };
-    final days = byDay.keys.toList()..sort();
-    final firstDay = days.first;
-    final lastDay = days.last;
+    final weightByDay = {
+      for (final w in weights)
+        DateTime(w.date.year, w.date.month, w.date.day): w.value,
+    };
+    final hasWeight = weightByDay.isNotEmpty;
     final selected = selectedDay == null
         ? null
         : DateTime(selectedDay!.year, selectedDay!.month, selectedDay!.day);
 
-    // One bar per calendar day in [firstDay, lastDay], zero-filling gap days.
+    // The x-axis spans every day that carries a bite count or a weigh-in, so a
+    // weight-only day still gets a slot.
+    final allDays = {...byDay.keys, ...weightByDay.keys}.toList()..sort();
+    final firstDay = allDays.first;
+    final lastDay = allDays.last;
+    var dayCount = 0;
+    for (
+      var day = firstDay;
+      !day.isAfter(lastDay);
+      day = DateTime(day.year, day.month, day.day + 1)
+    ) {
+      dayCount++;
+    }
+
+    final maxCount = byDay.values.reduce((a, b) => a > b ? a : b);
+    final maxY = (maxCount * 1.1)
+        .clamp(BiteAnalytics.minBitesForAverage * 1.2, double.infinity)
+        .toDouble();
+
+    // The weight axis is fitted to the weight range (± padding), so the weight
+    // rod's kg value is normalised into the bite chart's [0, maxY] and the
+    // right axis inverts that mapping back to kg.
+    final weightMin = hasWeight
+        ? weightByDay.values.reduce((a, b) => a < b ? a : b) - _weightAxisPadding
+        : 0.0;
+    final weightMax = hasWeight
+        ? weightByDay.values.reduce((a, b) => a > b ? a : b) + _weightAxisPadding
+        : 1.0;
+    double weightToY(double kg) =>
+        (kg - weightMin) / (weightMax - weightMin) * maxY;
+    double yToWeight(double y) => weightMin + (y / maxY) * (weightMax - weightMin);
+
+    // Two rods per day need half the width to fit; a bites-only chart keeps the
+    // full single-rod width.
+    final rodWidth = hasWeight ? _barWidth(dayCount) / 2 : _barWidth(dayCount);
+
+    // One group per calendar day in [firstDay, lastDay], zero-filling gap days;
+    // the weight rod is added only on days that were weighed.
     final bars = <BarChartGroupData>[];
     var x = 0;
     for (
@@ -66,32 +121,33 @@ class DailyBitesChart extends StatelessWidget {
       final count = byDay[day] ?? 0;
       final belowThreshold = count < BiteAnalytics.minBitesForAverage;
       final isSelected = day == selected;
-      bars.add(
-        BarChartGroupData(
-          x: x,
-          barRods: [
-            BarChartRodData(
-              toY: count.toDouble(),
-              // The selected bar reads at full colour even when it's muted
-              // below the threshold, so the link to the card below is visible.
-              color: (belowThreshold && !isSelected) ? mutedColor : fullColor,
-              width: _barWidth(days.length),
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(2)),
-              borderSide: isSelected
-                  ? BorderSide(color: theme.colorScheme.onSurface, width: 1.5)
-                  : BorderSide.none,
-            ),
-          ],
+      final rods = <BarChartRodData>[
+        BarChartRodData(
+          toY: count.toDouble(),
+          // The selected bar reads at full colour even when it's muted
+          // below the threshold, so the link to the card below is visible.
+          color: (belowThreshold && !isSelected) ? mutedColor : fullColor,
+          width: rodWidth,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(2)),
+          borderSide: isSelected
+              ? BorderSide(color: theme.colorScheme.onSurface, width: 1.5)
+              : BorderSide.none,
         ),
-      );
+      ];
+      final weight = weightByDay[day];
+      if (weight != null) {
+        rods.add(
+          BarChartRodData(
+            toY: weightToY(weight),
+            color: weightColor,
+            width: rodWidth,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(2)),
+          ),
+        );
+      }
+      bars.add(BarChartGroupData(x: x, barsSpace: 2, barRods: rods));
       x++;
     }
-    final dayCount = bars.length;
-
-    final maxCount = byDay.values.reduce((a, b) => a > b ? a : b);
-    final maxY = (maxCount * 1.1)
-        .clamp(BiteAnalytics.minBitesForAverage * 1.2, double.infinity)
-        .toDouble();
 
     // The bars are painted to a canvas fl_chart exposes no semantics for, so
     // summarise the chart for screen readers.
@@ -99,113 +155,146 @@ class DailyBitesChart extends StatelessWidget {
         'Daily bites bar chart, $dayCount days. '
         'Highest day $maxCount bites.';
 
+    final chart = BarChart(
+      BarChartData(
+        alignment: BarChartAlignment.spaceBetween,
+        maxY: maxY,
+        minY: 0,
+        gridData: const FlGridData(show: true, drawVerticalLine: false),
+        borderData: FlBorderData(show: false),
+        titlesData: FlTitlesData(
+          show: true,
+          rightTitles: hasWeight
+              ? AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 40,
+                    interval: maxY / 4,
+                    getTitlesWidget: (value, meta) {
+                      return Padding(
+                        padding: const EdgeInsets.only(left: 8.0),
+                        child: Text(
+                          yToWeight(value).toStringAsFixed(1),
+                          style: TextStyle(fontSize: 10, color: weightColor),
+                        ),
+                      );
+                    },
+                  ),
+                )
+              : const AxisTitles(
+                  sideTitles: SideTitles(showTitles: false),
+                ),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 40,
+              getTitlesWidget: (value, meta) {
+                if (value != value.roundToDouble()) {
+                  return const SizedBox.shrink();
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 30,
+              interval: _labelInterval(dayCount),
+              getTitlesWidget: (value, meta) {
+                final index = value.toInt();
+                if (index < 0 || index >= dayCount) {
+                  return const SizedBox.shrink();
+                }
+                final day = DateTime(
+                  firstDay.year,
+                  firstDay.month,
+                  firstDay.day + index,
+                );
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    shortDate(day),
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        extraLinesData: ExtraLinesData(
+          horizontalLines: [
+            HorizontalLine(
+              y: BiteAnalytics.minBitesForAverage.toDouble(),
+              color: theme.colorScheme.outline.withValues(alpha: 0.5),
+              strokeWidth: 1,
+              dashArray: const [4, 4],
+            ),
+          ],
+        ),
+        barTouchData: BarTouchData(
+          touchCallback: (event, response) {
+            if (onDaySelected == null) return;
+            // Select on tap-up so a scroll/drag over the chart doesn't
+            // reselect; the tooltip still shows on the same touch.
+            if (event is! FlTapUpEvent) return;
+            final group = response?.spot?.touchedBarGroup;
+            if (group == null) return;
+            onDaySelected!(
+              DateTime(firstDay.year, firstDay.month, firstDay.day + group.x),
+            );
+          },
+          touchTooltipData: BarTouchTooltipData(
+            getTooltipItem: (group, groupIndex, rod, rodIndex) {
+              final day = DateTime(
+                firstDay.year,
+                firstDay.month,
+                firstDay.day + group.x,
+              );
+              // The weight rod's toY is normalised, so read the day's kg
+              // back from the source instead of the rod height.
+              final isWeightRod = hasWeight && rodIndex == 1;
+              final text = isWeightRod
+                  ? '${fullDate(day)}\n${weightByDay[day]!.toStringAsFixed(1)} kg'
+                  : '${fullDate(day)}\n${rod.toY.toInt()} bites';
+              return BarTooltipItem(
+                text,
+                const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              );
+            },
+          ),
+        ),
+        barGroups: bars,
+      ),
+    );
+
     return Semantics(
       label: semanticsLabel,
       container: true,
       excludeSemantics: true,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 16.0),
-        child: BarChart(
-          BarChartData(
-            alignment: BarChartAlignment.spaceBetween,
-            maxY: maxY,
-            minY: 0,
-            gridData: const FlGridData(show: true, drawVerticalLine: false),
-            borderData: FlBorderData(show: false),
-            titlesData: FlTitlesData(
-              show: true,
-              rightTitles: const AxisTitles(
-                sideTitles: SideTitles(showTitles: false),
-              ),
-              topTitles: const AxisTitles(
-                sideTitles: SideTitles(showTitles: false),
-              ),
-              leftTitles: AxisTitles(
-                sideTitles: SideTitles(
-                  showTitles: true,
-                  reservedSize: 40,
-                  getTitlesWidget: (value, meta) {
-                    if (value != value.roundToDouble()) {
-                      return const SizedBox.shrink();
-                    }
-                    return Padding(
-                      padding: const EdgeInsets.only(right: 8.0),
-                      child: Text(
-                        value.toInt().toString(),
-                        style: const TextStyle(fontSize: 10),
-                      ),
-                    );
-                  },
-                ),
-              ),
-              bottomTitles: AxisTitles(
-                sideTitles: SideTitles(
-                  showTitles: true,
-                  reservedSize: 30,
-                  interval: _labelInterval(dayCount),
-                  getTitlesWidget: (value, meta) {
-                    final index = value.toInt();
-                    if (index < 0 || index >= dayCount) {
-                      return const SizedBox.shrink();
-                    }
-                    final day = DateTime(
-                      firstDay.year,
-                      firstDay.month,
-                      firstDay.day + index,
-                    );
-                    return Padding(
-                      padding: const EdgeInsets.only(top: 8.0),
-                      child: Text(
-                        shortDate(day),
-                        style: const TextStyle(fontSize: 10),
-                      ),
-                    );
-                  },
-                ),
-              ),
-            ),
-            extraLinesData: ExtraLinesData(
-              horizontalLines: [
-                HorizontalLine(
-                  y: BiteAnalytics.minBitesForAverage.toDouble(),
-                  color: theme.colorScheme.outline.withValues(alpha: 0.5),
-                  strokeWidth: 1,
-                  dashArray: const [4, 4],
-                ),
-              ],
-            ),
-            barTouchData: BarTouchData(
-              touchCallback: (event, response) {
-                if (onDaySelected == null) return;
-                // Select on tap-up so a scroll/drag over the chart doesn't
-                // reselect; the tooltip still shows on the same touch.
-                if (event is! FlTapUpEvent) return;
-                final group = response?.spot?.touchedBarGroup;
-                if (group == null) return;
-                onDaySelected!(
-                  DateTime(firstDay.year, firstDay.month, firstDay.day + group.x),
-                );
-              },
-              touchTooltipData: BarTouchTooltipData(
-                getTooltipItem: (group, groupIndex, rod, rodIndex) {
-                  final day = DateTime(
-                    firstDay.year,
-                    firstDay.month,
-                    firstDay.day + group.x,
-                  );
-                  return BarTooltipItem(
-                    '${fullDate(day)}\n${rod.toY.toInt()} bites',
-                    const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  );
-                },
-              ),
-            ),
-            barGroups: bars,
-          ),
-        ),
+        child: hasWeight
+            ? Column(
+                children: [
+                  _Legend(biteColor: fullColor, weightColor: weightColor),
+                  const SizedBox(height: 8),
+                  Expanded(child: chart),
+                ],
+              )
+            : chart,
       ),
     );
   }
@@ -216,4 +305,43 @@ class DailyBitesChart extends StatelessWidget {
   /// Labels at most ~6 days on the x-axis so tick labels never overlap.
   static double _labelInterval(int dayCount) =>
       (dayCount / 6).ceilToDouble().clamp(1, double.infinity);
+}
+
+/// The two-swatch key for the grouped chart: bites (left axis) and weight in kg
+/// (right axis). Shown only when weight bars are drawn.
+class _Legend extends StatelessWidget {
+  const _Legend({required this.biteColor, required this.weightColor});
+
+  final Color biteColor;
+  final Color weightColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _swatch(biteColor, 'Bites'),
+        const SizedBox(width: 16),
+        _swatch(weightColor, 'Weight (kg)'),
+      ],
+    );
+  }
+
+  Widget _swatch(Color color, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(label, style: const TextStyle(fontSize: 11)),
+      ],
+    );
+  }
 }

--- a/test/features/bite/data/bite_analytics_controller_test.dart
+++ b/test/features/bite/data/bite_analytics_controller_test.dart
@@ -4,19 +4,24 @@ import 'package:food_locker/features/bite/data/bite_analytics_controller.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
 
 /// [BiteAnalyticsController] over an in-memory Drift store, covering the
 /// pickable breakdown day: `load` seeds today, `selectDay` re-queries another
-/// day, and `isSelectedDayToday` tracks whether the card is on today.
+/// day, and `isSelectedDayToday` tracks whether the card is on today. Also
+/// covers the daily weights loaded for the weight overlay.
 void main() {
   late BiteDatabase db;
   late BiteRepository repo;
+  late InMemoryWeightRepository weightRepo;
   late BiteAnalyticsController controller;
 
   setUp(() {
     db = BiteDatabase.forTesting(NativeDatabase.memory());
     repo = DriftBiteRepository(db);
-    controller = BiteAnalyticsController(repo);
+    weightRepo = InMemoryWeightRepository();
+    controller = BiteAnalyticsController(repo, weightRepo);
   });
 
   tearDown(() async {
@@ -78,6 +83,34 @@ void main() {
     await controller.selectDay(DateTime(now.year, now.month, now.day - 1, 15, 30));
 
     expect(controller.selectedDay, yesterday);
+  });
+
+  test('load reads only the weigh-ins inside the 30-day window', () async {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final inWindow = DateTime(now.year, now.month, now.day - 5);
+    final outOfWindow = DateTime(now.year, now.month, now.day - 40);
+    await logCluster(today, 8, 12);
+    await weightRepo.saveWeight(Weight(date: today, value: 80));
+    await weightRepo.saveWeight(Weight(date: inWindow, value: 81));
+    await weightRepo.saveWeight(Weight(date: outOfWindow, value: 90));
+
+    await controller.load();
+
+    final days = controller.dailyWeights
+        .map((w) => DateTime(w.date.year, w.date.month, w.date.day))
+        .toSet();
+    expect(days, {today, inWindow});
+    expect(days, isNot(contains(outOfWindow)));
+  });
+
+  test('load has no weights when none were recorded', () async {
+    final now = DateTime.now();
+    await logCluster(DateTime(now.year, now.month, now.day), 8, 12);
+
+    await controller.load();
+
+    expect(controller.dailyWeights, isEmpty);
   });
 
   test('selecting another day leaves the today metrics untouched', () async {

--- a/test/features/weight/weight_repository_test.dart
+++ b/test/features/weight/weight_repository_test.dart
@@ -62,6 +62,51 @@ void main() {
       expect(repository.getLowestWeight(), isNull);
     });
 
+    test('getWeightsInRange returns only weigh-ins inside [from, to)', () async {
+      final before = DateTime(2023, 5, 9);
+      final fromDay = DateTime(2023, 5, 10);
+      final inside = DateTime(2023, 5, 12);
+      final toDay = DateTime(2023, 5, 15);
+      await repository.saveWeight(Weight(date: before, value: 70.0));
+      await repository.saveWeight(Weight(date: fromDay, value: 71.0));
+      await repository.saveWeight(Weight(date: inside, value: 72.0));
+      await repository.saveWeight(Weight(date: toDay, value: 73.0)); // exclusive
+
+      final days = repository
+          .getWeightsInRange(fromDay, toDay)
+          .map((w) => w.date)
+          .toSet();
+
+      // `from` inclusive, `to` exclusive: the 10th and 12th, not the 9th or 15th.
+      expect(days, {fromDay, inside});
+    });
+
+    test('getWeightsInRange normalises the bounds to their calendar day',
+        () async {
+      // A weigh-in stored with a time component still counts by its day: with
+      // `to` at midnight of the day after, that day is inside the range.
+      await repository.saveWeight(
+        Weight(date: DateTime(2023, 5, 12, 14, 30), value: 72.0),
+      );
+
+      final result = repository.getWeightsInRange(
+        DateTime(2023, 5, 12),
+        DateTime(2023, 5, 13),
+      );
+
+      expect(result, hasLength(1));
+      expect(result.single.value, 72.0);
+    });
+
+    test('getWeightsInRange is empty when nothing falls in range', () async {
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 1), value: 70.0));
+
+      expect(
+        repository.getWeightsInRange(DateTime(2023, 6, 1), DateTime(2023, 6, 30)),
+        isEmpty,
+      );
+    });
+
     test('getOldestWeightDate returns oldest date', () async {
       expect(repository.getOldestWeightDate(), isNull);
 

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weight_repository.dart';
 import 'package:food_locker/ui/pages/bite_analytics_page.dart';
 import 'package:food_locker/ui/theme.dart';
 import 'package:food_locker/ui/widgets/stat_tile.dart';
@@ -16,10 +18,12 @@ import 'package:provider/provider.dart';
 void main() {
   late BiteDatabase db;
   late BiteRepository repo;
+  late InMemoryWeightRepository weightRepo;
 
   setUp(() {
     db = BiteDatabase.forTesting(NativeDatabase.memory());
     repo = DriftBiteRepository(db);
+    weightRepo = InMemoryWeightRepository();
   });
 
   tearDown(() async {
@@ -72,8 +76,11 @@ void main() {
     tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
     addTearDown(tester.platformDispatcher.clearLocaleTestValue);
     await tester.pumpWidget(
-      Provider<BiteRepository>.value(
-        value: repo,
+      MultiProvider(
+        providers: [
+          Provider<BiteRepository>.value(value: repo),
+          Provider<WeightRepository>.value(value: weightRepo),
+        ],
         child: MaterialApp(theme: appTheme, home: const BiteAnalyticsPage()),
       ),
     );

--- a/test/ui/widgets/daily_bites_chart_test.dart
+++ b/test/ui/widgets/daily_bites_chart_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/ui/theme.dart';
 import 'package:food_locker/ui/widgets/daily_bites_chart.dart';
 
@@ -10,6 +11,7 @@ void main() {
   Future<BarChartData> pumpChart(
     WidgetTester tester,
     List<DailyBiteCount> counts, {
+    List<Weight> weights = const [],
     DateTime? selectedDay,
     ValueChanged<DateTime>? onDaySelected,
   }) async {
@@ -21,6 +23,7 @@ void main() {
             height: 300,
             child: DailyBitesChart(
               counts: counts,
+              weights: weights,
               selectedDay: selectedDay,
               onDaySelected: onDaySelected,
             ),
@@ -156,6 +159,87 @@ void main() {
 
     tapBar(data, 0);
     expect(selected, DateTime(2026, 1, 1));
+  });
+
+  testWidgets('without weights each day has a single bite rod and no right '
+      'axis', (tester) async {
+    final data = await pumpChart(tester, [
+      DailyBiteCount(day: DateTime(2026, 1, 1), count: 50),
+      DailyBiteCount(day: DateTime(2026, 1, 2), count: 20),
+    ]);
+
+    expect(data.barGroups[0].barRods, hasLength(1));
+    expect(data.barGroups[1].barRods, hasLength(1));
+    expect(data.titlesData.rightTitles.sideTitles.showTitles, isFalse);
+  });
+
+  testWidgets('a day with a weigh-in gets a second weight rod and a right '
+      'axis', (tester) async {
+    final data = await pumpChart(
+      tester,
+      [
+        DailyBiteCount(day: DateTime(2026, 1, 1), count: 50),
+        DailyBiteCount(day: DateTime(2026, 1, 2), count: 20),
+      ],
+      weights: [
+        Weight(date: DateTime(2026, 1, 1), value: 80),
+        Weight(date: DateTime(2026, 1, 2), value: 81),
+      ],
+    );
+
+    // Both days: a bite rod plus a weight rod in the theme's tertiary colour.
+    expect(data.barGroups[0].barRods, hasLength(2));
+    expect(data.barGroups[1].barRods, hasLength(2));
+    expect(data.barGroups[0].barRods[1].color, appTheme.colorScheme.tertiary);
+    // The right axis is now labelled (in kg).
+    expect(data.titlesData.rightTitles.sideTitles.showTitles, isTrue);
+    // A two-item legend accompanies the chart.
+    expect(find.text('Bites'), findsOneWidget);
+    expect(find.text('Weight (kg)'), findsOneWidget);
+  });
+
+  testWidgets('a day weighed but not eaten shows only the weight bar', (
+    tester,
+  ) async {
+    // Bite on 1/1, weigh-in on 1/3 → the range extends to 1/3, whose bite rod
+    // is zero-height and whose weight rod carries the weigh-in.
+    final data = await pumpChart(
+      tester,
+      [DailyBiteCount(day: DateTime(2026, 1, 1), count: 50)],
+      weights: [Weight(date: DateTime(2026, 1, 3), value: 80)],
+    );
+
+    expect(data.barGroups, hasLength(3));
+    // 1/1: eaten, not weighed → single bite rod.
+    expect(data.barGroups[0].barRods, hasLength(1));
+    // 1/3: weighed, not eaten → zero bite rod plus the weight rod.
+    expect(data.barGroups[2].barRods, hasLength(2));
+    expect(data.barGroups[2].barRods[0].toY, 0);
+    expect(data.barGroups[2].barRods[1].toY, greaterThan(0));
+  });
+
+  testWidgets('the weight axis fits the weight range so small changes stay '
+      'visible', (tester) async {
+    // A 1 kg day-to-day change: fitted to [71, 74] it maps to a clearly
+    // different bar height, and the lighter day still draws above the floor.
+    final data = await pumpChart(
+      tester,
+      [
+        DailyBiteCount(day: DateTime(2026, 1, 1), count: 50),
+        DailyBiteCount(day: DateTime(2026, 1, 2), count: 50),
+      ],
+      weights: [
+        Weight(date: DateTime(2026, 1, 1), value: 72),
+        Weight(date: DateTime(2026, 1, 2), value: 73),
+      ],
+    );
+
+    final lighter = data.barGroups[0].barRods[1].toY;
+    final heavier = data.barGroups[1].barRods[1].toY;
+    // Not flattened from zero: the lighter day is well above the axis floor.
+    expect(lighter, greaterThan(0));
+    // The 1 kg gain is a visible height difference, not a hairline.
+    expect(heavier - lighter, greaterThan(data.maxY * 0.1));
   });
 
   testWidgets('the selected day\'s bar is highlighted with a border', (


### PR DESCRIPTION
Implements **Phase 5** of `docs/bite_analytics_enhancements_plan.md` — overlaying daily body weight as a second grouped bar on the daily-bites chart.

## What changed, keyed to the phase checklist

- **Inject `WeightRepository` into `BiteAnalyticsController`** and load raw daily weights over the existing 30-day window. `load()` now filters `getAllWeights()` to `[from30, to)` and exposes them as `dailyWeights` (one per weighed day, no gap-filling). The page passes `context.read<WeightRepository>()` into the controller.
- **Second `BarChartRodData` per group in `daily_bites_chart.dart`** for weight, on a secondary right-hand kg axis fitted to the weight min/max (±1 kg padding). The weight rod's `toY` is normalised into the bite chart's `[0, maxY]`; `rightTitles` inverts that mapping back to kg. The weight rod uses the theme's `tertiary` colour, a two-item legend ("Bites" / "Weight (kg)") is shown above the chart, and each rod is drawn at ~half `_barWidth` when weight is present. The tooltip reads the day's kg from the source (not the normalised rod height).
- **Weight bar omitted on days with no weigh-in; bite-only days unchanged.** The x-axis now spans the union of bite days and weigh-in days, so a weigh-in on a day with no bites gets a slot (zero-height bite rod + weight rod). When `weights` is empty the chart is byte-for-byte the previous bites-only chart: single rod per day, full width, no right axis, no legend.

## Verification

Flutter isn't available in this web session (per `CLAUDE.md`, the toolchain isn't installed here), so local `flutter analyze` / `flutter test` are **deferred to the `flutter_ci.yml` PR checks**. Tests added to cover the phase's Verify bullet:

- `daily_bites_chart_test.dart`: bites-only day has a single rod and no right axis; a weighed day gets a second tertiary weight rod, a right axis, and the legend; a weighed-but-not-eaten day shows only the weight bar (zero bite rod); the weight axis fits the range so a 1 kg change is a visible height difference and the lighter day still draws above the floor (not flattened from zero).
- `bite_analytics_controller_test.dart`: `load` reads only weigh-ins inside the 30-day window, and is empty when none were recorded. Existing controller/page tests updated to inject the weight repository.

No deviations from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KW4f9mVTf2eCNzT5mbPD3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW4f9mVTf2eCNzT5mbPD3Z)_