### PR TITLE
feat: show app version on the Home tab

### DIFF
--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/widgets/add_weight_dialog.dart';
+import 'package:food_locker/ui/widgets/app_version_label.dart';
 import 'package:food_locker/ui/widgets/longest_streak_banner.dart';
 import 'package:food_locker/ui/widgets/streak_banner.dart';
 import 'package:food_locker/ui/widgets/weight_history_tile.dart';
@@ -75,7 +76,7 @@ class HomePage extends StatelessWidget {
           ),
           _buildHistorySection(latest7, history),
           const SliverToBoxAdapter(
-            child: SizedBox(height: 40),
+            child: AppVersionLabel(),
           ),
         ],
       ),

--- a/lib/ui/widgets/app_version_label.dart
+++ b/lib/ui/widgets/app_version_label.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// A muted footer showing the installed app version, read at runtime so it
+/// tracks `pubspec.yaml` without a hardcoded string. Renders nothing until the
+/// version resolves (and on error), so the layout never flashes a placeholder.
+class AppVersionLabel extends StatelessWidget {
+  const AppVersionLabel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24.0),
+          child: Center(
+            child: Text(
+              'Version ${snapshot.data!.version}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
   intl: ^0.20.2
-  package_info_plus: ^10.2.1
+  package_info_plus: ^9.0.1
   path_provider: ^2.1.5
   provider: ^6.1.5+1
   share_plus: ^12.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   hive_ce: ^2.19.3
   hive_ce_flutter: ^2.3.4
   intl: ^0.20.2
+  package_info_plus: ^10.2.1
   path_provider: ^2.1.5
   provider: ^6.1.5+1
   share_plus: ^12.0.1

--- a/test/ui/widgets/app_version_label_test.dart
+++ b/test/ui/widgets/app_version_label_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/ui/widgets/app_version_label.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  Widget createWidgetUnderTest() {
+    return const MaterialApp(
+      home: Scaffold(
+        body: AppVersionLabel(),
+      ),
+    );
+  }
+
+  testWidgets('AppVersionLabel shows the installed version', (tester) async {
+    PackageInfo.setMockInitialValues(
+      appName: 'food_locker',
+      packageName: 'com.example.food_locker',
+      version: '1.2.3',
+      buildNumber: '42',
+      buildSignature: '',
+    );
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Version 1.2.3'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a subtle version footer to the bottom of the **Home** tab so users can see which build they're running (handy for bug reports and confirming updates).

The version is read at runtime via `package_info_plus` rather than hardcoded, so it stays correct as release-please bumps `pubspec.yaml`.

## Changes

- **`pubspec.yaml`** — add `package_info_plus` dependency.
- **`lib/ui/widgets/app_version_label.dart`** (new) — a self-contained `StatelessWidget` that resolves the installed version via a `FutureBuilder<PackageInfo>` and renders a muted, centered `Version X.Y.Z` line. Renders nothing while pending or on error, so the layout never flashes a placeholder. Keeping it a separate widget lets `HomePage` stay stateless and makes it independently testable.
- **`lib/ui/pages/home_page.dart`** — replace the trailing spacer sliver with the new `AppVersionLabel`.
- **`test/ui/widgets/app_version_label_test.dart`** (new) — widget test using `PackageInfo.setMockInitialValues(...)` to assert the version text renders.

## Testing

Flutter isn't installed in the web session, so `flutter analyze` and `flutter test` run via the `flutter_ci.yml` workflow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgSh98RU8cj5eSBKe7Bn2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgSh98RU8cj5eSBKe7Bn2b)_