### PR TITLE
fix: refresh bite tab count and current meal on tab switch and resume

### DIFF
--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -112,6 +112,22 @@ class BiteManager extends ChangeNotifier {
     }
   }
 
+  /// Re-reads the store so the surfaced numbers reflect time that passed while
+  /// the screen was not the active tab or the app was backgrounded: the day
+  /// count rolls to the new local day, [currentMealBites] drops to 0 once the
+  /// sitting has ended, and the pacing reference is re-seeded from the last
+  /// stored bite. Cheap enough to run every time the Bite tab becomes visible.
+  Future<void> refresh() async {
+    final now = clock.now();
+    _pacingConfig ??= await _repository.pacingConfigAt(now);
+    await _refreshTodayCount();
+
+    final last = await _repository.lastBite();
+    _lastBiteAt =
+        last == null ? null : DateTime.fromMillisecondsSinceEpoch(last.atMs);
+    _startCountdown();
+  }
+
   /// Records one bite at the current instant — one tap = one bite, persisted
   /// immediately and never blocked — then refreshes today's count and
   /// restarts the pacing countdown from the fresh reference.

--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -125,6 +125,10 @@ class BiteManager extends ChangeNotifier {
     final last = await _repository.lastBite();
     _lastBiteAt =
         last == null ? null : DateTime.fromMillisecondsSinceEpoch(last.atMs);
+    // Recompute the zone and ticker against the current clock: the OS freezes
+    // timers while backgrounded, so a resumed countdown would otherwise show a
+    // stale zone, and a bite that went stale (day rollover, ended sitting)
+    // needs the ticker stopped and the zone reset to clear.
     _startCountdown();
   }
 

--- a/lib/ui/pages/bite_page.dart
+++ b/lib/ui/pages/bite_page.dart
@@ -51,19 +51,32 @@ class _BitePageState extends State<BitePage> with WidgetsBindingObserver {
   @override
   void didUpdateWidget(BitePage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // Left the Bite tab: drop the lock immediately rather than waiting out the
-    // remainder of the window on some other screen.
     if (!widget.isActive) {
+      // Left the Bite tab: drop the lock immediately rather than waiting out
+      // the remainder of the window on some other screen.
       _releaseWakelock();
+    } else if (!oldWidget.isActive) {
+      // Became the visible tab: re-read the store so the day count, the
+      // current-meal number, and the pacing state reflect any day rollover or
+      // meal that ended while another tab was showing.
+      _refreshBiteState();
     }
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Nothing to keep awake once the app is no longer in the foreground.
     if (state != AppLifecycleState.resumed) {
+      // Nothing to keep awake once the app is no longer in the foreground.
       _releaseWakelock();
+    } else if (widget.isActive) {
+      // Resumed onto the Bite tab: the app may have sat backgrounded across a
+      // day boundary or the end of a meal, so re-read the store.
+      _refreshBiteState();
     }
+  }
+
+  void _refreshBiteState() {
+    unawaited(context.read<BiteManager>().refresh());
   }
 
   Future<void> _handleBite() async {

--- a/test/features/bite/data/bite_manager_current_meal_test.dart
+++ b/test/features/bite/data/bite_manager_current_meal_test.dart
@@ -101,6 +101,70 @@ void main() {
       manager.dispose();
     });
   });
+
+  group('refresh', () {
+    test('drops currentMealBites to 0 once the sitting has ended', () {
+      fakeAsync((async) {
+        final now = clock.now();
+        final repo = _FakeBiteRepository(config: config, bites: [
+          now.subtract(const Duration(minutes: 1)),
+        ]);
+        final manager = BiteManager(repo, onReachedClear: () async {});
+
+        manager.initialize();
+        async.flushMicrotasks();
+        expect(manager.currentMealBites, 1);
+
+        // Time passes past the meal-gap threshold while another tab shows; a
+        // refresh on return to the Bite tab recomputes the ended sitting.
+        async.elapse(const Duration(minutes: 6));
+        manager.refresh();
+        async.flushMicrotasks();
+        expect(manager.currentMealBites, 0);
+
+        manager.dispose();
+      }, initialTime: DateTime(2024, 6, 15, 12));
+    });
+
+    test('rolls todayCount to the new local day', () {
+      fakeAsync((async) {
+        final now = clock.now();
+        final repo = _FakeBiteRepository(config: config, bites: [
+          now.subtract(const Duration(minutes: 1)),
+        ]);
+        final manager = BiteManager(repo, onReachedClear: () async {});
+
+        manager.initialize();
+        async.flushMicrotasks();
+        expect(manager.todayCount, 1);
+
+        // The app sits idle across midnight; the new day starts empty and a
+        // refresh reflects it without an app restart.
+        async.elapse(const Duration(days: 1));
+        manager.refresh();
+        async.flushMicrotasks();
+        expect(manager.todayCount, 0);
+
+        manager.dispose();
+      }, initialTime: DateTime(2024, 6, 15, 12));
+    });
+
+    test('notifies listeners so the tab rebuilds', () {
+      fakeAsync((async) {
+        final repo = _FakeBiteRepository(config: config);
+        final manager = BiteManager(repo, onReachedClear: () async {});
+        var notifications = 0;
+        manager.addListener(() => notifications++);
+
+        manager.refresh();
+        async.flushMicrotasks();
+
+        expect(notifications, greaterThan(0));
+
+        manager.dispose();
+      });
+    });
+  });
 }
 
 /// An in-memory [BiteRepository] returning bites chronologically, for exercising


### PR DESCRIPTION
## Problem

The Bite tab showed stale numbers until the app was closed and reopened:

- **Current meal number didn't refresh on tab switch** — a sitting that ended while you were on another tab kept showing its old `This meal: N`.
- **The day count didn't roll over** — when a new day arrived, `Today's Bites` stayed on the previous day's count even after switching tabs; only a full app restart reset it.

Root cause: `BiteManager` recomputed `todayCount` and `currentMealBites` only in `initialize()` (once, at startup) and after each `logBite()`. Nothing re-read the store when returning to the Bite tab or when the app resumed, so the day window and the trailing-meal projection were never recomputed against the current time.

## Fix

- **`BiteManager.refresh()`** — new method that re-reads the store: rolls the day count to the current local day, drops `currentMealBites` to 0 once the sitting has ended, and re-seeds the pacing reference from the last stored bite (restarting or freezing the countdown as appropriate).
- **`BitePage`** — calls `refresh()` when it becomes the visible tab (`didUpdateWidget`, inactive→active) and when the app resumes onto the Bite tab (`didChangeAppLifecycleState`).

## Tests

Added a `refresh` group to `bite_manager_current_meal_test.dart` covering:

- meal ends past the gap threshold → `currentMealBites` becomes 0;
- day rollover → `todayCount` becomes 0;
- `refresh()` notifies listeners so the tab rebuilds.

Flutter isn't installed in the web session used to author this, so `flutter analyze`/`flutter test` run here on CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013zL9GgaDu7PE8LbbYcZDr9)_