### PR TITLE
feat: show the day's total bites in the meal breakdown

### DIFF
--- a/lib/features/bite/data/bite_analytics.dart
+++ b/lib/features/bite/data/bite_analytics.dart
@@ -77,6 +77,9 @@ class DayMealBreakdown {
   /// Bites outside any meal (snacks), including sub-threshold clusters' bites.
   final int snackBites;
 
+  /// Every bite logged on [day], meals and snacks together.
+  int get totalBites => meals.fold<int>(snackBites, (sum, m) => sum + m.count);
+
   @override
   String toString() =>
       'DayMealBreakdown(day: $day, meals: $meals, snackBites: $snackBites)';

--- a/lib/ui/widgets/meal_breakdown_list.dart
+++ b/lib/ui/widgets/meal_breakdown_list.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 
 /// The meal-by-meal breakdown of a single day: one row per meal with its bite
-/// count and time span, plus a trailing row for the day's snack total (every
-/// bite outside a qualifying meal).
+/// count and time span, a row for the day's snack total (every bite outside a
+/// qualifying meal), and a summary line with the day's total bites.
 ///
 /// A read-only projection of [DayMealBreakdown]. When the day has no bites yet
 /// — no meals and no snacks — it shows an empty state instead of blank rows.
@@ -27,6 +27,8 @@ class MealBreakdownList extends StatelessWidget {
         for (var i = 0; i < meals.length; i++)
           _MealRow(index: i + 1, meal: meals[i]),
         _SnackRow(bites: breakdown.snackBites),
+        const Divider(height: 1),
+        _TotalRow(bites: breakdown.totalBites),
       ],
     );
   }
@@ -109,6 +111,43 @@ class _SnackRow extends StatelessWidget {
               '$bites bites',
               style: theme.textTheme.titleMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Every bite logged on the day, meals and snacks together.
+class _TotalRow extends StatelessWidget {
+  const _TotalRow({required this.bites});
+
+  final int bites;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: 'Total, $bites bites',
+      child: Padding(
+        padding: const EdgeInsets.only(top: 12.0, bottom: 4.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Total',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            Text(
+              '$bites bites',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.primary,
               ),
             ),
           ],

--- a/test/features/bite/data/bite_analytics_test.dart
+++ b/test/features/bite/data/bite_analytics_test.dart
@@ -228,6 +228,21 @@ void main() {
       expect(breakdown.meals.map((m) => m.count), [12]);
       expect(breakdown.snackBites, 3);
     });
+
+    test('totalBites sums the meals and the snacks', () async {
+      await logEvery(DateTime(2026, 7, 15, 8), 12, const Duration(minutes: 1));
+      await logEvery(DateTime(2026, 7, 15, 8, 17), 3, const Duration(minutes: 1));
+      await logEvery(DateTime(2026, 7, 15, 13), 10, const Duration(minutes: 1));
+
+      final breakdown = await analytics.breakdownForDay(DateTime(2026, 7, 15));
+
+      expect(breakdown.totalBites, 25);
+    });
+
+    test('totalBites is 0 on an empty day', () async {
+      final breakdown = await analytics.breakdownForDay(DateTime(2026, 7, 15));
+      expect(breakdown.totalBites, 0);
+    });
   });
 
   group('averageMealsPerDay', () {

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -230,6 +230,8 @@ void main() {
     expect(find.text('15 bites'), findsOneWidget);
     expect(find.text('Snacks'), findsOneWidget);
     expect(find.text('5 bites'), findsOneWidget);
+    expect(find.text('Total'), findsOneWidget);
+    expect(find.text('32 bites'), findsOneWidget);
   });
 
   testWidgets('meal breakdown card shows its empty state when today is empty '
@@ -311,7 +313,8 @@ void main() {
     // back control.
     expect(find.text('Today\'s meals'), findsOneWidget);
     expect(find.text('Back to today'), findsNothing);
-    expect(find.text('12 bites'), findsOneWidget);
+    // The meal row and the day's total, which the lone meal accounts for.
+    expect(find.text('12 bites'), findsNWidgets(2));
 
     // Tap yesterday's bar → card follows it: back control appears, the today
     // title is gone, and yesterday's 20-bite meal shows.
@@ -320,7 +323,7 @@ void main() {
 
     expect(find.text('Today\'s meals'), findsNothing);
     expect(find.text('Back to today'), findsOneWidget);
-    expect(find.text('20 bites'), findsOneWidget);
+    expect(find.text('20 bites'), findsNWidgets(2));
 
     // Back to today resets the card.
     await tester.tap(find.text('Back to today'));
@@ -328,6 +331,6 @@ void main() {
 
     expect(find.text('Today\'s meals'), findsOneWidget);
     expect(find.text('Back to today'), findsNothing);
-    expect(find.text('12 bites'), findsOneWidget);
+    expect(find.text('12 bites'), findsNWidgets(2));
   });
 }

--- a/test/ui/widgets/meal_breakdown_list_test.dart
+++ b/test/ui/widgets/meal_breakdown_list_test.dart
@@ -45,6 +45,8 @@ void main() {
     expect(find.text('15 bites'), findsOneWidget);
     expect(find.text('Snacks'), findsOneWidget);
     expect(find.text('5 bites'), findsOneWidget);
+    expect(find.text('Total'), findsOneWidget);
+    expect(find.text('32 bites'), findsOneWidget);
     // A morning and an afternoon meal read as 12-hour times.
     expect(find.text('8:00 AM – 8:11 AM'), findsOneWidget);
     expect(find.text('1:30 PM – 1:44 PM'), findsOneWidget);
@@ -60,7 +62,9 @@ void main() {
 
     expect(find.text('Meal 1'), findsNothing);
     expect(find.text('Snacks'), findsOneWidget);
-    expect(find.text('8 bites'), findsOneWidget);
+    expect(find.text('Total'), findsOneWidget);
+    // Snack row and total row, both reading the day's only 8 bites.
+    expect(find.text('8 bites'), findsNWidgets(2));
   });
 
   testWidgets('shows the empty state when the day has no bites', (tester) async {
@@ -71,5 +75,6 @@ void main() {
 
     expect(find.text('No bites logged today yet.'), findsOneWidget);
     expect(find.text('Snacks'), findsNothing);
+    expect(find.text('Total'), findsNothing);
   });
 }


### PR DESCRIPTION
## What

The bite analytics breakdown widget now ends with a summary line showing how many bites were logged in total on the selected day — the meals' bites plus the snack total — separated from the rows above by a divider and emphasised in the primary colour.

## Changes

- `DayMealBreakdown.totalBites` — a derived getter summing `meals` + `snackBites`, keeping the total a read-time projection like the rest of the bite analytics.
- `MealBreakdownList` — a trailing `Total` row (with a `Total, N bites` semantics label). The empty state for a day with no bites is unchanged: no rows, no total.
- Tests: unit coverage for `totalBites` (mixed day and empty day), plus widget/page assertions for the new row. A few existing page assertions moved to `findsNWidgets(2)` where a day's single meal accounts for all its bites, so the meal row and the total row read the same text.

## Verification

Flutter isn't installed in this session's environment, so `flutter analyze` / `flutter test` were not run locally — CI covers both on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4Wn8sg2e3XJFWX4gFkkeA)_