### PR TITLE
feat: add side-by-side test APK build workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    # Keeps a production APK off the rolling `test-builds` prerelease.
+    if: github.event_name != 'release' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,117 @@
+name: Build Test APK
+
+# Pick the branch to test in the "Run workflow" dialog. The APK always lands on
+# the rolling `test-builds` prerelease, so its download URL is stable enough to
+# bookmark on the phone.
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Short build label, e.g. pr94 (defaults to the branch name)'
+        required: false
+        default: ''
+
+env:
+  RELEASE_TAG: test-builds
+  APK_NAME: food_locker-test.apk
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+
+    - name: Install dependencies
+      run: flutter pub get
+
+    - name: Configure Keystore
+      if: env.HAS_KEYSTORE == 'true'
+      run: |
+        echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+        echo "storePassword=$KEYSTORE_PASSWORD" > android/key.properties
+        echo "keyPassword=$KEY_PASSWORD" >> android/key.properties
+        echo "keyAlias=$KEY_ALIAS" >> android/key.properties
+        echo "storeFile=upload-keystore.jks" >> android/key.properties
+      env:
+        HAS_KEYSTORE: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+
+    - name: Resolve Build Name
+      env:
+        INPUT_LABEL: ${{ inputs.label }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        VERSION=$(grep 'version: ' pubspec.yaml | head -1 | awk '{print $2}' | cut -d '+' -f 1)
+        LABEL="$INPUT_LABEL"
+        if [ -z "$LABEL" ]; then
+          LABEL=$(echo "$REF_NAME" | tr -c 'A-Za-z0-9' '-' | cut -c1-24 | sed 's/-*$//')
+        fi
+        echo "BUILD_NAME=$VERSION-$LABEL.${{ github.run_number }}" >> $GITHUB_ENV
+
+    - name: Build APK
+      env:
+        APP_ID_SUFFIX: .test
+        APP_LABEL: FoodLocker Test
+      run: |
+        flutter build apk --release \
+          --build-name="$BUILD_NAME" \
+          --build-number=${{ github.run_number }}
+        mv build/app/outputs/flutter-apk/app-release.apk "$APK_NAME"
+
+    - name: Upload APK as Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: food-locker-test-${{ env.BUILD_NAME }}
+        path: ${{ env.APK_NAME }}
+
+    - name: Publish to Rolling Test Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REF_NAME: ${{ github.ref_name }}
+        COMMIT_SHA: ${{ github.sha }}
+      run: |
+        gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
+        gh release create "$RELEASE_TAG" \
+          --prerelease \
+          --target "$COMMIT_SHA" \
+          --title "Test build - $BUILD_NAME" \
+          --notes "Side-by-side test build (application id \`com.baskorp.food_locker.test\`).
+
+        | | |
+        |---|---|
+        | Branch | \`$REF_NAME\` |
+        | Commit | \`$COMMIT_SHA\` |
+        | Version | \`$BUILD_NAME\` |
+
+        Installs next to the production app as **FoodLocker Test** with its own
+        empty data. To test against real data, export a backup from the production
+        app's Settings tab and import it here.
+
+        This release is replaced by every run - the download URL stays the same." \
+          "$APK_NAME"
+
+    - name: Summary
+      run: |
+        echo "### Test build \`$BUILD_NAME\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Install on the phone from: $URL" >> $GITHUB_STEP_SUMMARY
+      env:
+        URL: ${{ github.server_url }}/${{ github.repository }}/releases/download/test-builds/food_locker-test.apk

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -37,6 +37,14 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        // Set only by the Build Test APK workflow, so a test build installs
+        // alongside the production app instead of replacing it.
+        val appIdSuffix = System.getenv("APP_ID_SUFFIX").orEmpty()
+        if (appIdSuffix.isNotEmpty()) {
+            applicationIdSuffix = appIdSuffix
+        }
+        manifestPlaceholders["appLabel"] = System.getenv("APP_LABEL") ?: "FoodLocker"
     }
 
     signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="FoodLocker"
+        android:label="${appLabel}"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity


### PR DESCRIPTION
## What

A manually dispatched **Build Test APK** workflow that builds any branch with a `.test` application id suffix, so the APK installs *alongside* the production app — its own launcher entry (**FoodLocker Test**), its own data sandbox — instead of upgrading it. Lets a PR be exercised on a real phone without touching production data.

## Changes

- **`.github/workflows/build_test.yml`** — new `workflow_dispatch` workflow. Mirrors the release build (Java 17, Flutter stable, same keystore), but sets `APP_ID_SUFFIX=.test` / `APP_LABEL=FoodLocker Test` for the build. The version name is `<pubspec version>-<label>.<run number>`, where the label is an optional input defaulting to a sanitised branch name — so the existing `AppVersionLabel` on the home page identifies which build is installed.
- **`android/app/build.gradle.kts`** — `defaultConfig` reads `APP_ID_SUFFIX` / `APP_LABEL` from the environment, applying `applicationIdSuffix` only when the variable is set and non-empty.
- **`android/app/src/main/AndroidManifest.xml`** — `android:label` becomes the `${appLabel}` manifest placeholder, defaulting to `FoodLocker`.
- **`.github/workflows/build_release.yml`** — the build job now skips `release` events where `prerelease == true`.

## Notes on the approach

**Env vars rather than product flavors.** The conventional route is `flutter build apk --flavor test` backed by Gradle `productFlavors`, but declaring flavors makes Flutter *require* `--flavor` on every build and run — which would mean changing `build_release.yml`, `build_install_release.sh`, and everyday `flutter run`. Reading the environment in `defaultConfig` keeps all of those paths on exactly the code path they use today: with the variables unset, the resolved `applicationId` and label are unchanged.

The Kotlin package under `android/app/src/main/kotlin/com/baskorp/food_locker/` stays put — `applicationIdSuffix` changes the application id, not the `namespace` that `.MainActivity` resolves against.

**Rolling prerelease rather than a build artifact.** `upload-artifact` produces a zip that needs a GitHub login to download, which is awkward on a phone. The APK is instead published to a `test-builds` prerelease under the fixed asset name `food_locker-test.apk`, giving a stable public URL that opens directly in a phone browser:

```
https://github.com/igorbasko01/food-locker/releases/download/test-builds/food_locker-test.apk
```

The release is deleted and recreated each run so its tag always points at the commit that was built. An artifact is still uploaded as well. release-please ignores the non-semver `test-builds` tag.

The `build_release.yml` guard exists because creating that prerelease fires a `release: published` event. Workflows aren't re-triggered by the default `GITHUB_TOKEN`, so this is belt-and-braces — but it also covers a prerelease created by hand.

## Verification

- Both workflow files parse as YAML.
- The build-name resolution and the `gh release` invocation were dry-run locally with `gh` stubbed, confirming the notes render as a single argument with markdown at column 0 and the APK passed as the asset. Branch names reach the shell through env vars rather than `${{ }}` interpolation.
- **Not verified:** the Gradle and manifest changes. Flutter isn't installed in this session and `flutter_ci.yml` only runs `analyze`/`test`, so nothing on this PR builds Android — a Kotlin DSL error here would not surface in CI.
- Also note `workflow_dispatch` workflows only become dispatchable once they're on the default branch, so the new workflow can't be run from this PR. **Its first run after merge is the real verification** — if the Gradle edit is wrong, that run fails fast and cheaply.

## Trying it after merge

1. Actions → Build Test APK → Run workflow → pick the branch (e.g. `claude/bite-analytics-summary-hh0r2v` for #94), optionally label it `pr94`.
2. Open the URL above on the phone and install.
3. The test app starts with **empty data**. To exercise something like #94's meal breakdown, export a backup from the production app's Settings tab and import it into the test app. Anything logged in the test app stays there — there's no path back into production.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LdKJPSYpahGyj4ouFYLpX)_