### PR TITLE
feat: show a progress toast while importing or exporting a backup

### DIFF
--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -80,13 +80,12 @@ class SerializationService {
     );
   }
 
-  /// Returns whether a backup was actually restored — `false` means the user
-  /// dismissed the file picker, which is not an import and must not be
-  /// reported as one.
+  /// Returns whether a backup was actually restored — `false` means the file
+  /// picker was dismissed, which callers must not report as an import.
   ///
   /// [onRestoreStart] fires once a file is chosen and the restore is about to
-  /// begin, so callers can surface progress for the part that takes time
-  /// without leaving a message on screen while the picker is still open.
+  /// begin, so callers can show progress without leaving a message on screen
+  /// while the picker is still open.
   Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -80,7 +80,14 @@ class SerializationService {
     );
   }
 
-  Future<void> importData(BuildContext context) async {
+  /// Returns whether a backup was actually restored — `false` means the user
+  /// dismissed the file picker, which is not an import and must not be
+  /// reported as one.
+  ///
+  /// [onRestoreStart] fires once a file is chosen and the restore is about to
+  /// begin, so callers can surface progress for the part that takes time
+  /// without leaving a message on screen while the picker is still open.
+  Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
 
@@ -90,12 +97,15 @@ class SerializationService {
     );
     final filePath = result?.files.single.path;
 
-    if (filePath == null) return;
+    if (filePath == null) return false;
+
+    onRestoreStart?.call();
 
     final file = File(filePath);
     final bytes = await file.readAsBytes();
 
     await restoreFromBackup(weightRepo, biteRepo, bytes);
+    return true;
   }
 
   /// Replaces both stores' contents with a backup zip — the destructive core of

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -28,14 +28,21 @@ class SerializationService {
 
   SerializationService();
 
-  Future<void> exportData(BuildContext context) async {
+  /// Returns whether there was anything to export — `false` means both stores
+  /// were empty and no file was produced, which callers must not report as a
+  /// completed export.
+  ///
+  /// [onShareReady] fires once the zip is written and the share sheet is about
+  /// to open, so callers can clear any progress indication before the sheet
+  /// covers it.
+  Future<bool> exportData(BuildContext context, {VoidCallback? onShareReady}) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
 
     final weights = weightRepo.getAllWeights();
     final bites = await _allBites(biteRepo);
 
-    if (weights.isEmpty && bites.isEmpty) return;
+    if (weights.isEmpty && bites.isEmpty) return false;
 
     // Pacing config rides along with real data rather than gating the export:
     // the default is always seeded, so it never on its own makes a backup
@@ -48,8 +55,11 @@ class SerializationService {
     final zipFile = File('${tempDir.path}/${generateZipFileName()}');
     await zipFile.writeAsBytes(zipData);
 
+    onShareReady?.call();
+
     // ignore: deprecated_member_use
     await Share.shareXFiles([XFile(zipFile.path)], text: 'Food Locker Backup');
+    return true;
   }
 
   /// Packs every dataset into a single backup zip — weights, bites, and the

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -10,6 +10,8 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
+  bool _importing = false;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -32,6 +34,7 @@ class _SettingsPageState extends State<SettingsPage> {
             child: Column(
               children: [
                 ListTile(
+                  enabled: !_importing,
                   leading: Icon(Icons.download, color: theme.colorScheme.primary),
                   title: const Text('Export Data', style: TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: const Text('Save your weight history data into a zip file.'),
@@ -54,30 +57,67 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
                 const Divider(height: 1),
                 ListTile(
+                  enabled: !_importing,
                   leading: Icon(Icons.upload, color: theme.colorScheme.primary),
                   title: const Text('Import Data', style: TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: const Text('Restore your weight history data from a zip file.'),
-                  onTap: () async {
-                    try {
-                      await context.read<SerializationService>().importData(context);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Data imported successfully')),
-                        );
-                        setState(() {});
-                      }
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(
-                          context,
-                        ).showSnackBar(SnackBar(content: Text('Import failed: $e')));
-                      }
-                    }
-                  },
+                  onTap: _importData,
                 ),
               ],
             ),
           ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _importData() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final service = context.read<SerializationService>();
+    var progressShown = false;
+
+    try {
+      final imported = await service.importData(
+        context,
+        onRestoreStart: () {
+          if (!mounted) return;
+          progressShown = true;
+          setState(() => _importing = true);
+          messenger.showSnackBar(_importingSnackBar());
+        },
+      );
+      if (progressShown) messenger.removeCurrentSnackBar();
+      // A dismissed file picker imported nothing, so it gets no toast at all.
+      if (imported) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Data imported successfully')),
+        );
+      }
+    } catch (e) {
+      if (progressShown) messenger.removeCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(content: Text('Import failed: $e')));
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  /// Stays up until [_importData] removes it, since the restore has no
+  /// predictable duration.
+  SnackBar _importingSnackBar() {
+    return SnackBar(
+      duration: const Duration(days: 1),
+      content: Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Theme.of(context).colorScheme.onInverseSurface,
+            ),
+          ),
+          const SizedBox(width: 16),
+          const Text('Importing data...'),
         ],
       ),
     );

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -87,7 +87,6 @@ class _SettingsPageState extends State<SettingsPage> {
         },
       );
       if (progressShown) messenger.removeCurrentSnackBar();
-      // A dismissed file picker imported nothing, so it gets no toast at all.
       if (imported) {
         messenger.showSnackBar(
           const SnackBar(content: Text('Data imported successfully')),
@@ -101,8 +100,8 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
-  /// Stays up until [_importData] removes it, since the restore has no
-  /// predictable duration.
+  /// The restore has no predictable length, so this stays up until
+  /// [_importData] removes it.
   SnackBar _importingSnackBar() {
     return SnackBar(
       duration: const Duration(days: 1),

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -10,7 +10,7 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  bool _importing = false;
+  bool _busy = false;
 
   @override
   Widget build(BuildContext context) {
@@ -34,30 +34,15 @@ class _SettingsPageState extends State<SettingsPage> {
             child: Column(
               children: [
                 ListTile(
-                  enabled: !_importing,
+                  enabled: !_busy,
                   leading: Icon(Icons.download, color: theme.colorScheme.primary),
                   title: const Text('Export Data', style: TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: const Text('Save your weight history data into a zip file.'),
-                  onTap: () async {
-                    try {
-                      await context.read<SerializationService>().exportData(context);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Data exported successfully')),
-                        );
-                      }
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(
-                          context,
-                        ).showSnackBar(SnackBar(content: Text('Export failed: $e')));
-                      }
-                    }
-                  },
+                  onTap: _exportData,
                 ),
                 const Divider(height: 1),
                 ListTile(
-                  enabled: !_importing,
+                  enabled: !_busy,
                   leading: Icon(Icons.upload, color: theme.colorScheme.primary),
                   title: const Text('Import Data', style: TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: const Text('Restore your weight history data from a zip file.'),
@@ -71,6 +56,32 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
+  Future<void> _exportData() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final service = context.read<SerializationService>();
+
+    setState(() => _busy = true);
+    messenger.showSnackBar(_progressSnackBar('Exporting data...'));
+
+    try {
+      final exported = await service.exportData(
+        context,
+        onShareReady: messenger.removeCurrentSnackBar,
+      );
+      messenger.removeCurrentSnackBar();
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(exported ? 'Data exported successfully' : 'No data to export'),
+        ),
+      );
+    } catch (e) {
+      messenger.removeCurrentSnackBar();
+      messenger.showSnackBar(SnackBar(content: Text('Export failed: $e')));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
   Future<void> _importData() async {
     final messenger = ScaffoldMessenger.of(context);
     final service = context.read<SerializationService>();
@@ -80,12 +91,13 @@ class _SettingsPageState extends State<SettingsPage> {
       final imported = await service.importData(
         context,
         onRestoreStart: () {
-          if (!mounted) return;
           progressShown = true;
-          setState(() => _importing = true);
-          messenger.showSnackBar(_importingSnackBar());
+          messenger.showSnackBar(_progressSnackBar('Importing data...'));
+          if (mounted) setState(() => _busy = true);
         },
       );
+      // Only clear a toast this call put up: a dismissed picker shows none, and
+      // removing unconditionally would cut short whatever else is on screen.
       if (progressShown) messenger.removeCurrentSnackBar();
       if (imported) {
         messenger.showSnackBar(
@@ -96,30 +108,8 @@ class _SettingsPageState extends State<SettingsPage> {
       if (progressShown) messenger.removeCurrentSnackBar();
       messenger.showSnackBar(SnackBar(content: Text('Import failed: $e')));
     } finally {
-      if (mounted) setState(() => _importing = false);
+      if (mounted) setState(() => _busy = false);
     }
-  }
-
-  /// The restore has no predictable length, so this stays up until
-  /// [_importData] removes it.
-  SnackBar _importingSnackBar() {
-    return SnackBar(
-      duration: const Duration(days: 1),
-      content: Row(
-        children: [
-          SizedBox(
-            width: 16,
-            height: 16,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: Theme.of(context).colorScheme.onInverseSurface,
-            ),
-          ),
-          const SizedBox(width: 16),
-          const Text('Importing data...'),
-        ],
-      ),
-    );
   }
 
   Widget _buildHeader(ThemeData theme, String title) {
@@ -134,4 +124,30 @@ class _SettingsPageState extends State<SettingsPage> {
       ),
     );
   }
+}
+
+/// Export and restore have no predictable length, so this stays up until the
+/// caller removes it. The [Builder] reads the theme from the snackbar's own
+/// context, keeping the spinner legible on the inverse-surface background
+/// without depending on the page still being mounted.
+SnackBar _progressSnackBar(String message) {
+  return SnackBar(
+    duration: const Duration(days: 1),
+    content: Builder(
+      builder: (context) => Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: Theme.of(context).colorScheme.onInverseSurface,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Text(message),
+        ],
+      ),
+    ),
+  );
 }

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -6,8 +6,8 @@ import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/ui/pages/settings_page.dart';
 import 'package:provider/provider.dart';
 
-/// Import feedback on [SettingsPage]: the restore reports itself while it runs,
-/// and only a real import reports success.
+/// Import feedback on [SettingsPage]: a running restore says so, and only a
+/// real import reports success.
 void main() {
   Future<void> pumpPage(WidgetTester tester, SerializationService service) {
     return tester.pumpWidget(
@@ -71,9 +71,8 @@ void main() {
   });
 }
 
-/// Stands in for the real import so the page's feedback can be driven without a
-/// file picker: [finishRestore] / [failRestore] decide when — and how — the
-/// restore ends.
+/// Replaces the file picker and the restore, holding the import open until
+/// [finishRestore] or [failRestore] ends it.
 class _FakeSerializationService extends SerializationService {
   _FakeSerializationService({this.cancelled = false});
 

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/ui/pages/settings_page.dart';
+import 'package:provider/provider.dart';
+
+/// Import feedback on [SettingsPage]: the restore reports itself while it runs,
+/// and only a real import reports success.
+void main() {
+  Future<void> pumpPage(WidgetTester tester, SerializationService service) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Provider<SerializationService>.value(
+          value: service,
+          child: const SettingsPage(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows a progress toast while restoring, then the success toast',
+      (tester) async {
+    final service = _FakeSerializationService();
+    await pumpPage(tester, service);
+
+    await tester.tap(find.text('Import Data'));
+    await tester.pump();
+
+    expect(find.text('Importing data...'), findsOneWidget);
+    expect(find.text('Data imported successfully'), findsNothing);
+
+    service.finishRestore();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 750));
+
+    expect(find.text('Importing data...'), findsNothing);
+    expect(find.text('Data imported successfully'), findsOneWidget);
+  });
+
+  testWidgets('reports nothing when the file picker is dismissed',
+      (tester) async {
+    final service = _FakeSerializationService(cancelled: true);
+    await pumpPage(tester, service);
+
+    await tester.tap(find.text('Import Data'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 750));
+
+    expect(find.text('Importing data...'), findsNothing);
+    expect(find.text('Data imported successfully'), findsNothing);
+  });
+
+  testWidgets('replaces the progress toast with the failure toast',
+      (tester) async {
+    final service = _FakeSerializationService();
+    await pumpPage(tester, service);
+
+    await tester.tap(find.text('Import Data'));
+    await tester.pump();
+
+    expect(find.text('Importing data...'), findsOneWidget);
+
+    service.failRestore('boom');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 750));
+
+    expect(find.text('Importing data...'), findsNothing);
+    expect(find.textContaining('Import failed'), findsOneWidget);
+  });
+}
+
+/// Stands in for the real import so the page's feedback can be driven without a
+/// file picker: [finishRestore] / [failRestore] decide when — and how — the
+/// restore ends.
+class _FakeSerializationService extends SerializationService {
+  _FakeSerializationService({this.cancelled = false});
+
+  final bool cancelled;
+  final _restore = Completer<void>();
+
+  void finishRestore() => _restore.complete();
+
+  void failRestore(String message) => _restore.completeError(message);
+
+  @override
+  Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
+    if (cancelled) return false;
+    onRestoreStart?.call();
+    await _restore.future;
+    return true;
+  }
+}

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -6,8 +6,8 @@ import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/ui/pages/settings_page.dart';
 import 'package:provider/provider.dart';
 
-/// Import feedback on [SettingsPage]: a running restore says so, and only a
-/// real import reports success.
+/// Backup feedback on [SettingsPage]: work in flight says so, and only work
+/// that actually moved data reports success.
 void main() {
   Future<void> pumpPage(WidgetTester tester, SerializationService service) {
     return tester.pumpWidget(
@@ -20,74 +20,124 @@ void main() {
     );
   }
 
-  testWidgets('shows a progress toast while restoring, then the success toast',
-      (tester) async {
-    final service = _FakeSerializationService();
-    await pumpPage(tester, service);
-
-    await tester.tap(find.text('Import Data'));
-    await tester.pump();
-
-    expect(find.text('Importing data...'), findsOneWidget);
-    expect(find.text('Data imported successfully'), findsNothing);
-
-    service.finishRestore();
+  /// Long enough for a snackbar to finish animating in or out.
+  Future<void> pumpToast(WidgetTester tester) async {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 750));
+  }
 
-    expect(find.text('Importing data...'), findsNothing);
-    expect(find.text('Data imported successfully'), findsOneWidget);
+  group('import', () {
+    testWidgets('shows a progress toast while restoring, then the success toast',
+        (tester) async {
+      final service = _FakeSerializationService();
+      await pumpPage(tester, service);
+
+      await tester.tap(find.text('Import Data'));
+      await tester.pump();
+
+      expect(find.text('Importing data...'), findsOneWidget);
+      expect(find.text('Data imported successfully'), findsNothing);
+
+      service.finish();
+      await pumpToast(tester);
+
+      expect(find.text('Importing data...'), findsNothing);
+      expect(find.text('Data imported successfully'), findsOneWidget);
+    });
+
+    testWidgets('reports nothing when the file picker is dismissed',
+        (tester) async {
+      final service = _FakeSerializationService(cancelled: true);
+      await pumpPage(tester, service);
+
+      await tester.tap(find.text('Import Data'));
+      await pumpToast(tester);
+
+      expect(find.text('Importing data...'), findsNothing);
+      expect(find.text('Data imported successfully'), findsNothing);
+    });
+
+    testWidgets('replaces the progress toast with the failure toast',
+        (tester) async {
+      final service = _FakeSerializationService();
+      await pumpPage(tester, service);
+
+      await tester.tap(find.text('Import Data'));
+      await tester.pump();
+
+      expect(find.text('Importing data...'), findsOneWidget);
+
+      service.fail('boom');
+      await pumpToast(tester);
+
+      expect(find.text('Importing data...'), findsNothing);
+      expect(find.textContaining('Import failed'), findsOneWidget);
+    });
   });
 
-  testWidgets('reports nothing when the file picker is dismissed',
-      (tester) async {
-    final service = _FakeSerializationService(cancelled: true);
-    await pumpPage(tester, service);
+  group('export', () {
+    testWidgets('shows a progress toast while exporting, then the success toast',
+        (tester) async {
+      final service = _FakeSerializationService();
+      await pumpPage(tester, service);
 
-    await tester.tap(find.text('Import Data'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 750));
+      await tester.tap(find.text('Export Data'));
+      await tester.pump();
 
-    expect(find.text('Importing data...'), findsNothing);
-    expect(find.text('Data imported successfully'), findsNothing);
-  });
+      expect(find.text('Exporting data...'), findsOneWidget);
+      expect(find.text('Data exported successfully'), findsNothing);
 
-  testWidgets('replaces the progress toast with the failure toast',
-      (tester) async {
-    final service = _FakeSerializationService();
-    await pumpPage(tester, service);
+      service.finish();
+      await pumpToast(tester);
 
-    await tester.tap(find.text('Import Data'));
-    await tester.pump();
+      expect(find.text('Exporting data...'), findsNothing);
+      expect(find.text('Data exported successfully'), findsOneWidget);
+    });
 
-    expect(find.text('Importing data...'), findsOneWidget);
+    testWidgets('reports an empty export rather than success', (tester) async {
+      final service = _FakeSerializationService(empty: true);
+      await pumpPage(tester, service);
 
-    service.failRestore('boom');
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 750));
+      await tester.tap(find.text('Export Data'));
+      service.finish();
+      await pumpToast(tester);
 
-    expect(find.text('Importing data...'), findsNothing);
-    expect(find.textContaining('Import failed'), findsOneWidget);
+      expect(find.text('Data exported successfully'), findsNothing);
+      expect(find.text('No data to export'), findsOneWidget);
+    });
   });
 }
 
-/// Replaces the file picker and the restore, holding the import open until
-/// [finishRestore] or [failRestore] ends it.
+/// Replaces the file picker, the restore, and the share sheet, holding the work
+/// open until [finish] or [fail] ends it.
 class _FakeSerializationService extends SerializationService {
-  _FakeSerializationService({this.cancelled = false});
+  _FakeSerializationService({this.cancelled = false, this.empty = false});
 
+  /// Import only: the user dismissed the file picker.
   final bool cancelled;
-  final _restore = Completer<void>();
 
-  void finishRestore() => _restore.complete();
+  /// Export only: both stores were empty.
+  final bool empty;
 
-  void failRestore(String message) => _restore.completeError(message);
+  final _work = Completer<void>();
+
+  void finish() => _work.complete();
+
+  void fail(String message) => _work.completeError(message);
 
   @override
   Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
     if (cancelled) return false;
     onRestoreStart?.call();
-    await _restore.future;
+    await _work.future;
+    return true;
+  }
+
+  @override
+  Future<bool> exportData(BuildContext context, {VoidCallback? onShareReady}) async {
+    await _work.future;
+    if (empty) return false;
+    onShareReady?.call();
     return true;
   }
 }


### PR DESCRIPTION
Backup and restore gave no feedback between the tap and the final toast, so a long operation looked like nothing was happening. Both directions now report themselves while they run, and neither claims success for work that didn't happen.

## Changes

**Import**
- `importData` takes an `onRestoreStart` callback, fired once a file is chosen and the restore is about to begin — after the picker closes, so the message never sits behind the file browser.
- It returns whether a restore actually ran. Dismissing the file picker previously still showed "Data imported successfully"; it now shows nothing.

**Export** (added in response to review)
- `exportData` takes an `onShareReady` callback, fired once the zip is written and the share sheet is about to open, so the progress toast is cleared instead of sitting behind the sheet.
- It returns whether there was anything to export. Both stores empty meant an early return with no file, but the page still said "Data exported successfully"; it now says "No data to export".

**Page**
- An indefinite "Importing data..." / "Exporting data..." snackbar with a spinner runs for the duration of the work, swapped for the success or failure toast when it ends.
- A shared busy flag disables both tiles during either operation, so a double-tap can't start a second destructive clear-then-restore.
- The progress snackbar reads its theme from its own build context via a `Builder`, so showing it doesn't depend on the page still being mounted — the `mounted` check narrows to the one `setState` that requires a live element.

## Tests

New `test/ui/pages/settings_page_test.dart` drives the page against a fake `SerializationService` that holds the work open: progress toast then success for both directions, no toast on a dismissed picker, "No data to export" on an empty export, and the failure toast replacing the progress toast.

`flutter analyze` / `flutter test` were not run locally — Flutter isn't installed in the session environment, so CI is the check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b9tJLoUJTiAi1gDjxMMkm