### PR TITLE
fix: confirm before an import replaces stored data

### DIFF
--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -13,6 +13,11 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+/// Asks the user to confirm replacing their data with the backup [fileName].
+/// Returning `false` — including a dismissed dialog — must leave every store
+/// untouched.
+typedef ConfirmRestore = Future<bool> Function(String fileName);
+
 class SerializationService {
   @visibleForTesting
   static String generateZipFileName([DateTime? now]) {
@@ -91,12 +96,21 @@ class SerializationService {
   }
 
   /// Returns whether a backup was actually restored — `false` means the file
-  /// picker was dismissed, which callers must not report as an import.
+  /// picker was dismissed or [onConfirm] declined, neither of which callers
+  /// may report as an import.
   ///
-  /// [onRestoreStart] fires once a file is chosen and the restore is about to
-  /// begin, so callers can show progress without leaving a message on screen
-  /// while the picker is still open.
-  Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
+  /// [onConfirm] gates the restore once a file is chosen, so the page can own
+  /// the modal while the sequencing stays here. Omitting it restores without
+  /// asking.
+  ///
+  /// [onRestoreStart] fires once the restore is about to begin, so callers can
+  /// show progress without leaving a message on screen while the picker or the
+  /// confirmation is still up.
+  Future<bool> importData(
+    BuildContext context, {
+    ConfirmRestore? onConfirm,
+    VoidCallback? onRestoreStart,
+  }) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
 
@@ -104,16 +118,43 @@ class SerializationService {
       type: FileType.custom,
       allowedExtensions: ['zip'],
     );
-    final filePath = result?.files.single.path;
+    final picked = result?.files.single;
+    final filePath = picked?.path;
 
-    if (filePath == null) return false;
+    if (picked == null || filePath == null) return false;
+
+    // Reading the file ahead of the confirmation is safe: nothing is written
+    // until [confirmAndRestore] clears the gate.
+    final bytes = await File(filePath).readAsBytes();
+
+    return confirmAndRestore(
+      weightRepo,
+      biteRepo,
+      bytes,
+      fileName: picked.name,
+      onConfirm: onConfirm,
+      onRestoreStart: onRestoreStart,
+    );
+  }
+
+  /// Gates the destructive [restoreFromBackup] behind [onConfirm], kept apart
+  /// from the picker and file I/O so the decline path stays unit-testable.
+  /// A declined confirmation returns `false` without touching a store, reading
+  /// to callers exactly like a dismissed picker.
+  @visibleForTesting
+  Future<bool> confirmAndRestore(
+    WeightRepository weightRepo,
+    BiteRepository biteRepo,
+    List<int> zipBytes, {
+    required String fileName,
+    ConfirmRestore? onConfirm,
+    VoidCallback? onRestoreStart,
+  }) async {
+    if (onConfirm != null && !await onConfirm(fileName)) return false;
 
     onRestoreStart?.call();
 
-    final file = File(filePath);
-    final bytes = await file.readAsBytes();
-
-    await restoreFromBackup(weightRepo, biteRepo, bytes);
+    await restoreFromBackup(weightRepo, biteRepo, zipBytes);
     return true;
   }
 

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -14,8 +14,7 @@ import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 /// Asks the user to confirm replacing their data with the backup [fileName].
-/// Returning `false` — including a dismissed dialog — must leave every store
-/// untouched.
+/// Returning `false` leaves every store untouched.
 typedef ConfirmRestore = Future<bool> Function(String fileName);
 
 class SerializationService {
@@ -100,8 +99,7 @@ class SerializationService {
   /// may report as an import.
   ///
   /// [onConfirm] gates the restore once a file is chosen, so the page can own
-  /// the modal while the sequencing stays here. Omitting it restores without
-  /// asking.
+  /// the modal; omitting it restores without asking.
   ///
   /// [onRestoreStart] fires once the restore is about to begin, so callers can
   /// show progress without leaving a message on screen while the picker or the
@@ -123,8 +121,7 @@ class SerializationService {
 
     if (picked == null || filePath == null) return false;
 
-    // Reading the file ahead of the confirmation is safe: nothing is written
-    // until [confirmAndRestore] clears the gate.
+    // Reading the file writes nothing; the gate below is what guards the stores.
     final bytes = await File(filePath).readAsBytes();
 
     return confirmAndRestore(
@@ -137,10 +134,9 @@ class SerializationService {
     );
   }
 
-  /// Gates the destructive [restoreFromBackup] behind [onConfirm], kept apart
-  /// from the picker and file I/O so the decline path stays unit-testable.
-  /// A declined confirmation returns `false` without touching a store, reading
-  /// to callers exactly like a dismissed picker.
+  /// Gates the destructive [restoreFromBackup] behind [onConfirm], apart from
+  /// the picker and file I/O so the decline path stays unit-testable. Declining
+  /// returns `false` without touching a store.
   @visibleForTesting
   Future<bool> confirmAndRestore(
     WeightRepository weightRepo,

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -45,7 +45,7 @@ class _SettingsPageState extends State<SettingsPage> {
                   enabled: !_busy,
                   leading: Icon(Icons.upload, color: theme.colorScheme.primary),
                   title: const Text('Import Data', style: TextStyle(fontWeight: FontWeight.bold)),
-                  subtitle: const Text('Restore your weight history data from a zip file.'),
+                  subtitle: const Text('Replace your data with a backup zip file.'),
                   onTap: _importData,
                 ),
               ],
@@ -90,6 +90,7 @@ class _SettingsPageState extends State<SettingsPage> {
     try {
       final imported = await service.importData(
         context,
+        onConfirm: _confirmImport,
         onRestoreStart: () {
           progressShown = true;
           messenger.showSnackBar(_progressSnackBar('Importing data...'));
@@ -110,6 +111,41 @@ class _SettingsPageState extends State<SettingsPage> {
     } finally {
       if (mounted) setState(() => _busy = false);
     }
+  }
+
+  /// An import replaces what is already stored, so it asks first — and names
+  /// the chosen file, since picking the wrong zip is the easiest way to get
+  /// here by mistake. A dismissed dialog reads as a decline.
+  Future<bool> _confirmImport(String fileName) async {
+    if (!mounted) return false;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        final theme = Theme.of(context);
+        return AlertDialog(
+          title: const Text('Replace all data?'),
+          content: Text(
+            'Importing "$fileName" permanently replaces your weight history, '
+            'and the bite log and pacing settings when the backup contains '
+            'them. This cannot be undone.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              style: TextButton.styleFrom(foregroundColor: theme.colorScheme.error),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Replace'),
+            ),
+          ],
+        );
+      },
+    );
+
+    return confirmed ?? false;
   }
 
   Widget _buildHeader(ThemeData theme, String title) {

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -114,8 +114,7 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   /// An import replaces what is already stored, so it asks first — and names
-  /// the chosen file, since picking the wrong zip is the easiest way to get
-  /// here by mistake. A dismissed dialog reads as a decline.
+  /// the file, since picking the wrong zip is the likely mistake.
   Future<bool> _confirmImport(String fileName) async {
     if (!mounted) return false;
 

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -364,4 +364,101 @@ void main() {
       expect(biteRepo.configOperations, isEmpty);
     });
   });
+
+  group('SerializationService confirmAndRestore', () {
+    final service = SerializationService();
+
+    /// A full backup — weights, bites and pacing config — so a declined
+    /// confirmation can be shown to spare every store, not just weights.
+    List<int> fullBackup() => service.encodeBackup(
+          [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
+          [const Bite(id: 1, atMs: 1000)],
+          [const PacingConfig(id: 1, effectiveMs: 0, b1S: 15, b2S: 30)],
+        );
+
+    test('leaves every store untouched when the confirmation is declined',
+        () async {
+      final weightRepo = _RecordingWeightRepository();
+      await weightRepo.saveWeight(Weight(date: DateTime(2020, 1, 1), value: 99.9));
+      weightRepo.operations.clear(); // ignore the setup save
+      final biteRepo = _RecordingBiteRepository();
+      var restoreStarted = false;
+
+      final restored = await service.confirmAndRestore(
+        weightRepo,
+        biteRepo,
+        fullBackup(),
+        fileName: 'backup.zip',
+        onConfirm: (_) async => false,
+        onRestoreStart: () => restoreStarted = true,
+      );
+
+      expect(restored, isFalse);
+      expect(restoreStarted, isFalse);
+      expect(weightRepo.operations, isEmpty);
+      expect(biteRepo.operations, isEmpty);
+      expect(biteRepo.configOperations, isEmpty);
+      expect(weightRepo.getAllWeights().single.value, 99.9);
+    });
+
+    test('restores when the confirmation is accepted', () async {
+      final weightRepo = InMemoryWeightRepository();
+      await weightRepo.saveWeight(Weight(date: DateTime(2020, 1, 1), value: 99.9));
+      final biteRepo = _RecordingBiteRepository();
+      var restoreStarted = false;
+
+      final restored = await service.confirmAndRestore(
+        weightRepo,
+        biteRepo,
+        fullBackup(),
+        fileName: 'backup.zip',
+        onConfirm: (_) async => true,
+        onRestoreStart: () => restoreStarted = true,
+      );
+
+      expect(restored, isTrue);
+      expect(restoreStarted, isTrue);
+      expect(weightRepo.getAllWeights().single.value, 75.5);
+      expect(biteRepo.loggedMs, [1000]);
+      expect(biteRepo.savedConfigs, hasLength(1));
+    });
+
+    test('asks before touching a store, and names the file it would replace',
+        () async {
+      final weightRepo = _RecordingWeightRepository();
+      await weightRepo.saveWeight(Weight(date: DateTime(2020, 1, 1), value: 99.9));
+      weightRepo.operations.clear();
+      final asked = <String>[];
+
+      await service.confirmAndRestore(
+        weightRepo,
+        _RecordingBiteRepository(),
+        fullBackup(),
+        fileName: 'food_locker_20260101120000.zip',
+        onConfirm: (fileName) async {
+          asked.add(fileName);
+          // The gate is what protects the data: nothing may have been cleared
+          // by the time the user is asked.
+          expect(weightRepo.operations, isEmpty);
+          return true;
+        },
+      );
+
+      expect(asked, ['food_locker_20260101120000.zip']);
+    });
+
+    test('restores without asking when no confirmation is supplied', () async {
+      final weightRepo = InMemoryWeightRepository();
+
+      final restored = await service.confirmAndRestore(
+        weightRepo,
+        _RecordingBiteRepository(),
+        fullBackup(),
+        fileName: 'backup.zip',
+      );
+
+      expect(restored, isTrue);
+      expect(weightRepo.getAllWeights().single.value, 75.5);
+    });
+  });
 }

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -368,8 +368,8 @@ void main() {
   group('SerializationService confirmAndRestore', () {
     final service = SerializationService();
 
-    /// A full backup — weights, bites and pacing config — so a declined
-    /// confirmation can be shown to spare every store, not just weights.
+    /// A full backup, so a decline can be shown to spare every store, not just
+    /// weights.
     List<int> fullBackup() => service.encodeBackup(
           [Weight(date: DateTime(2023, 10, 27), value: 75.5)],
           [const Bite(id: 1, atMs: 1000)],
@@ -437,8 +437,7 @@ void main() {
         fileName: 'food_locker_20260101120000.zip',
         onConfirm: (fileName) async {
           asked.add(fileName);
-          // The gate is what protects the data: nothing may have been cleared
-          // by the time the user is asked.
+          // Nothing may have been cleared by the time the user is asked.
           expect(weightRepo.operations, isEmpty);
           return true;
         },

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -48,7 +48,7 @@ void main() {
         find.textContaining(_FakeSerializationService.fileName),
         findsOneWidget,
       );
-      // Nothing has started: the restore waits behind the dialog.
+      // The restore waits behind the dialog.
       expect(find.text('Importing data...'), findsNothing);
     });
 
@@ -155,7 +155,6 @@ class _FakeSerializationService extends SerializationService {
   /// Export only: both stores were empty.
   final bool empty;
 
-  /// The name the picker resolved, as handed to the confirmation.
   static const fileName = 'food_locker_20260101120000.zip';
 
   final _work = Completer<void>();

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -26,14 +26,51 @@ void main() {
     await tester.pump(const Duration(milliseconds: 750));
   }
 
+  /// Taps Import and answers the confirmation dialog it raises.
+  Future<void> tapImport(WidgetTester tester, {required bool confirm}) async {
+    await tester.tap(find.text('Import Data'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(confirm ? 'Replace' : 'Cancel'));
+    await tester.pump();
+  }
+
   group('import', () {
-    testWidgets('shows a progress toast while restoring, then the success toast',
+    testWidgets('asks before restoring, naming the file it would replace',
         (tester) async {
       final service = _FakeSerializationService();
       await pumpPage(tester, service);
 
       await tester.tap(find.text('Import Data'));
-      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Replace all data?'), findsOneWidget);
+      expect(
+        find.textContaining(_FakeSerializationService.fileName),
+        findsOneWidget,
+      );
+      // Nothing has started: the restore waits behind the dialog.
+      expect(find.text('Importing data...'), findsNothing);
+    });
+
+    testWidgets('reports nothing when the confirmation is cancelled',
+        (tester) async {
+      final service = _FakeSerializationService();
+      await pumpPage(tester, service);
+
+      await tapImport(tester, confirm: false);
+      await pumpToast(tester);
+
+      expect(find.text('Replace all data?'), findsNothing);
+      expect(find.text('Importing data...'), findsNothing);
+      expect(find.text('Data imported successfully'), findsNothing);
+    });
+
+    testWidgets('shows a progress toast while restoring, then the success toast',
+        (tester) async {
+      final service = _FakeSerializationService();
+      await pumpPage(tester, service);
+
+      await tapImport(tester, confirm: true);
 
       expect(find.text('Importing data...'), findsOneWidget);
       expect(find.text('Data imported successfully'), findsNothing);
@@ -62,8 +99,7 @@ void main() {
       final service = _FakeSerializationService();
       await pumpPage(tester, service);
 
-      await tester.tap(find.text('Import Data'));
-      await tester.pump();
+      await tapImport(tester, confirm: true);
 
       expect(find.text('Importing data...'), findsOneWidget);
 
@@ -119,6 +155,9 @@ class _FakeSerializationService extends SerializationService {
   /// Export only: both stores were empty.
   final bool empty;
 
+  /// The name the picker resolved, as handed to the confirmation.
+  static const fileName = 'food_locker_20260101120000.zip';
+
   final _work = Completer<void>();
 
   void finish() => _work.complete();
@@ -126,8 +165,13 @@ class _FakeSerializationService extends SerializationService {
   void fail(String message) => _work.completeError(message);
 
   @override
-  Future<bool> importData(BuildContext context, {VoidCallback? onRestoreStart}) async {
+  Future<bool> importData(
+    BuildContext context, {
+    ConfirmRestore? onConfirm,
+    VoidCallback? onRestoreStart,
+  }) async {
     if (cancelled) return false;
+    if (onConfirm != null && !await onConfirm(fileName)) return false;
     onRestoreStart?.call();
     await _work.future;
     return true;


### PR DESCRIPTION
## What changed

Import Data used to wipe every store the moment a file was picked — `restoreFromBackup` calls `weightRepo.clear()` before anything is decoded — so a mis-tap plus the wrong zip erased the whole weight history with no prompt and no undo.

- `SerializationService.importData` takes an `onConfirm` callback (`ConfirmRestore = Future<bool> Function(String fileName)`), invoked after the picker resolves and before any store is written. Declining returns `false`.
- The gate itself lives in a new `confirmAndRestore`, kept apart from the picker and file I/O the same way `restoreFromBackup` already is, so the decline path is unit-testable without a widget pump.
- `SettingsPage` owns the modal: an `AlertDialog` ("Replace all data?") that names the chosen file, states the import permanently replaces the weight history — and the bite log and pacing settings when the backup carries them — and offers **Cancel** plus a destructive **Replace**. A barrier-dismissed dialog counts as a decline.
- The Import tile's subtitle now reads "Replace your data with a backup zip file." so the replace-semantics are visible before the tap, not only in the dialog (the issue's "worth reconsidering" note).

No dialog code entered `SerializationService`.

## Acceptance criteria

- [x] **Choosing a file for import shows a confirmation modal before any store is modified** — `confirmAndRestore` returns early on a decline, ahead of `restoreFromBackup`; covered by the unit test that asserts the recording repository has seen no operation at the moment `onConfirm` is called.
- [x] **Cancelling leaves weights, bites and pacing config untouched, and shows no success message** — the decline test asserts no weight, bite or pacing-config mutation and that the pre-existing weight survives; the widget test taps Cancel and asserts neither the progress nor the success toast appears. `importData` returning `false` reaches the caller's existing "no snackbar" branch.
- [x] **Confirming restores exactly as it does today** — accepting runs the unchanged `restoreFromBackup`; the accept test asserts the weights, bites and pacing config all land.
- [x] **Dismissing the file picker behaves as before** — the `picked == null` early return is unchanged and precedes the confirmation; the existing widget test for a dismissed picker still passes untouched.
- [x] **Test coverage for the cancel path proving no data was cleared** — new `SerializationService confirmAndRestore` group in `test/features/settings/data/serialization_service_test.dart` (decline, accept, ask-before-touching + filename, and no-callback), plus two new widget tests in `test/ui/pages/settings_page_test.dart`.
- [x] **`flutter analyze` and `flutter test` pass** — green on CI, see Verification.

## Decisions

- **`onConfirm` on `importData`, as the issue suggested**, rather than wiring the dialog into the service — smallest change that keeps the service free of UI.
- **The file is read before the confirmation.** Reading is non-destructive and nothing is written until the gate clears, so this keeps `confirmAndRestore` to a simple `List<int>` parameter instead of a lazy byte-reader callback. Noted in a comment at the call site.
- **`onRestoreStart` now fires after the confirmation**, not right after the picker — otherwise the progress toast would sit behind the dialog. Its doc comment was updated to say so.
- **Confirm button labelled "Replace"** rather than "Import", to name what is lost; Cancel is listed first and is what a dismissed dialog resolves to.
- **`onConfirm` stays optional**, so an omitted callback restores without asking and existing/other callers keep working.

## Verification

Flutter is not installed in this environment and `CLAUDE.md` says not to install it, so `flutter analyze` / `flutter test` were **not** run locally — verification is deferred to `flutter_ci.yml`, which has passed on every head of this branch, including the current one after the merge from `main`. The diff was kept small and self-reviewed; the widget tests that tap Import now route through the new dialog via a shared `tapImport(confirm:)` helper, and the test fake's `importData` override was updated to honour `onConfirm`.

A test APK of this branch was built and published to the rolling `test-builds` prerelease ([run #7](https://github.com/igorbasko01/food-locker/actions/runs/32890227891), version `1.17.0-pr106.7`, built before the `main` merge).

`main` was merged in (no conflicts), and a comments-only pass was applied per the concise-comments step added to the skill in #107.

Closes #102