### PR TITLE
docs: add concise-comments pass to resolve-github-issue skill

### DIFF
--- a/.claude/skills/resolve-github-issue/SKILL.md
+++ b/.claude/skills/resolve-github-issue/SKILL.md
@@ -61,6 +61,10 @@ Never commit to `main`.
 - Cover the acceptance criteria with tests, mirroring `lib/` under `test/`.
   Prefer `InMemoryWeightRepository` and `BiteDatabase.forTesting` over real
   stores.
+- Once the change is written, run the **concise-comments** skill
+  (`Skill(concise-comments)`) over the diff and apply its edits, so every
+  comment you added or touched matches the repo's house style before you
+  commit.
 
 If the issue turns out to be far larger than it reads, already fixed on `main`,
 or resting on a wrong premise: stop, comment on the issue with what you found,


### PR DESCRIPTION
## What

Adds one bullet to the Implement step of the `resolve-github-issue` skill: after the change is written, run the `concise-comments` skill over the diff and apply its edits, so the nightly issue→PR routine produces comments in the repo's house style before committing.

## Why

The routine's PRs should read like the rest of the codebase. `concise-comments` is the repo's own comment style; folding it into the skill's implement phase applies it automatically on every nightly run, at the point where the code (and its comments) has just been written.

## Notes

- Docs-only, one bullet added; no renumbering, no code touched.
- Placed as the last Implement bullet (after tests, before the bail-out clause) so the comment pass runs over the finished diff and ahead of the commit.
- A second proposed tweak — building a test APK after the PR is handled — was dropped: the nightly session ends at PR creation, so it can't act after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Kgasn3wiip18Nbm9pGppj)_