### PR TITLE
fix: refresh the managers after a backup restore

### DIFF
--- a/lib/features/bite/data/bite_manager.dart
+++ b/lib/features/bite/data/bite_manager.dart
@@ -117,9 +117,12 @@ class BiteManager extends ChangeNotifier {
   /// count rolls to the new local day, [currentMealBites] drops to 0 once the
   /// sitting has ended, and the pacing reference is re-seeded from the last
   /// stored bite. Cheap enough to run every time the Bite tab becomes visible.
+  ///
+  /// The thresholds are re-read on every call: a backup restore can replace the
+  /// config history underneath the manager.
   Future<void> refresh() async {
     final now = clock.now();
-    _pacingConfig ??= await _repository.pacingConfigAt(now);
+    _pacingConfig = await _repository.pacingConfigAt(now) ?? _pacingConfig;
     await _refreshTodayCount();
 
     final last = await _repository.lastBite();

--- a/lib/features/weight/data/weight_manager.dart
+++ b/lib/features/weight/data/weight_manager.dart
@@ -22,6 +22,13 @@ class WeightManager extends ChangeNotifier {
     _reloadHistory();
   }
 
+  /// Re-reads the store, for callers that replaced its contents without going
+  /// through this manager — a backup restore. Ordinary mutations reload
+  /// themselves.
+  Future<void> refresh() async {
+    _reloadHistory();
+  }
+
   DateRange get historyRange => _historyRange;
 
   /// The weigh-ins inside [historyRange], newest first.

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:provider/provider.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -85,6 +87,8 @@ class _SettingsPageState extends State<SettingsPage> {
   Future<void> _importData() async {
     final messenger = ScaffoldMessenger.of(context);
     final service = context.read<SerializationService>();
+    final weightManager = context.read<WeightManager>();
+    final biteManager = context.read<BiteManager>();
     var progressShown = false;
 
     try {
@@ -101,6 +105,11 @@ class _SettingsPageState extends State<SettingsPage> {
       // removing unconditionally would cut short whatever else is on screen.
       if (progressShown) messenger.removeCurrentSnackBar();
       if (imported) {
+        // A restore writes through the repositories, leaving both managers on
+        // what they loaded before it. Re-read here rather than leaning on a tab
+        // refreshing when it becomes visible.
+        await weightManager.refresh();
+        await biteManager.refresh();
         messenger.showSnackBar(
           const SnackBar(content: Text('Data imported successfully')),
         );

--- a/test/features/bite/data/bite_manager_pacing_test.dart
+++ b/test/features/bite/data/bite_manager_pacing_test.dart
@@ -184,6 +184,27 @@ void main() {
       manager.dispose();
     });
   });
+
+  test('refresh adopts thresholds that were replaced in the store', () {
+    fakeAsync((async) {
+      final repo = _FakeBiteRepository(config: config);
+      final manager = BiteManager(repo, onReachedClear: () async {});
+
+      manager.initialize();
+      async.flushMicrotasks();
+      expect(manager.b2, const Duration(seconds: 30));
+
+      // What a restore does: the config history is replaced underneath the
+      // manager.
+      repo.config = const PacingConfig(id: 2, effectiveMs: 0, b1S: 40, b2S: 90);
+      manager.refresh();
+      async.flushMicrotasks();
+
+      expect(manager.b2, const Duration(seconds: 90));
+
+      manager.dispose();
+    });
+  });
 }
 
 /// An in-memory [BiteRepository] with synchronous-ish futures so the pacing
@@ -192,7 +213,7 @@ class _FakeBiteRepository implements BiteRepository {
   _FakeBiteRepository({this.config, List<DateTime>? bites})
       : _bites = [...?bites];
 
-  final PacingConfig? config;
+  PacingConfig? config;
   final List<DateTime> _bites;
 
   @override

--- a/test/features/weight/weight_manager_test.dart
+++ b/test/features/weight/weight_manager_test.dart
@@ -249,4 +249,44 @@ void main() {
       });
     });
   });
+
+  group('WeightManager refresh', () {
+    test('picks up entries written straight to the repository', () async {
+      final repository = InMemoryWeightRepository();
+      final manager = WeightManager(repository);
+      await manager.initialize();
+
+      // What a restore does: writes through the repository, never through the
+      // manager.
+      await repository.saveWeight(Weight(date: DateTime.now(), value: 71.5));
+      expect(manager.history, isEmpty);
+
+      await manager.refresh();
+
+      expect(manager.history.single.value, 71.5);
+    });
+
+    test('drops entries the repository no longer holds', () async {
+      final repository = InMemoryWeightRepository();
+      final manager = WeightManager(repository);
+      await manager.addWeight(DateTime.now(), 80.0);
+      expect(manager.history, hasLength(1));
+
+      await repository.clear();
+      await manager.refresh();
+
+      expect(manager.history, isEmpty);
+    });
+
+    test('notifies listeners so the tab rebuilds', () async {
+      final repository = InMemoryWeightRepository();
+      final manager = WeightManager(repository);
+      var notifications = 0;
+      manager.addListener(() => notifications++);
+
+      await manager.refresh();
+
+      expect(notifications, 1);
+    });
+  });
 }

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -2,18 +2,39 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/bite/data/bite_analytics.dart';
+import 'package:food_locker/features/bite/data/bite_database.dart';
+import 'package:food_locker/features/bite/data/bite_manager.dart';
+import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/pages/settings_page.dart';
 import 'package:provider/provider.dart';
 
-/// Backup feedback on [SettingsPage]: work in flight says so, and only work
-/// that actually moved data reports success.
+/// Backup feedback on [SettingsPage]: work in flight says so, only work
+/// that actually moved data reports success, and a restore leaves no manager
+/// holding what it read before the import.
 void main() {
-  Future<void> pumpPage(WidgetTester tester, SerializationService service) {
+  Future<void> pumpPage(
+    WidgetTester tester,
+    SerializationService service, {
+    WeightManager? weightManager,
+    BiteManager? biteManager,
+  }) {
     return tester.pumpWidget(
       MaterialApp(
-        home: Provider<SerializationService>.value(
-          value: service,
+        home: MultiProvider(
+          providers: [
+            Provider<SerializationService>.value(value: service),
+            ChangeNotifierProvider<WeightManager>.value(
+              value: weightManager ?? WeightManager(InMemoryWeightRepository()),
+            ),
+            ChangeNotifierProvider<BiteManager>.value(
+              value: biteManager ?? _biteManager(_FakeBiteRepository()),
+            ),
+          ],
           child: const SettingsPage(),
         ),
       ),
@@ -94,6 +115,44 @@ void main() {
       expect(find.text('Data imported successfully'), findsNothing);
     });
 
+    testWidgets('leaves no manager holding pre-import data', (tester) async {
+      final weightRepo = InMemoryWeightRepository();
+      final biteRepo = _FakeBiteRepository(
+        config: const PacingConfig(id: 1, effectiveMs: 0, b1S: 12, b2S: 25),
+      );
+      final weightManager = WeightManager(weightRepo);
+      final biteManager = _biteManager(biteRepo);
+      await weightManager.initialize();
+      await biteManager.initialize();
+
+      final restored = Weight(date: DateTime.now(), value: 71.5);
+      final service = _FakeSerializationService(
+        // Stands in for the restore: replaces what is stored without going
+        // through either manager.
+        onRestore: () async {
+          await weightRepo.saveWeight(restored);
+          biteRepo.config =
+              const PacingConfig(id: 2, effectiveMs: 0, b1S: 40, b2S: 90);
+        },
+      );
+      await pumpPage(
+        tester,
+        service,
+        weightManager: weightManager,
+        biteManager: biteManager,
+      );
+
+      expect(weightManager.history, isEmpty);
+      expect(biteManager.b2, const Duration(seconds: 25));
+
+      await tapImport(tester, confirm: true);
+      service.finish();
+      await pumpToast(tester);
+
+      expect(weightManager.history.single.value, restored.value);
+      expect(biteManager.b2, const Duration(seconds: 90));
+    });
+
     testWidgets('replaces the progress toast with the failure toast',
         (tester) async {
       final service = _FakeSerializationService();
@@ -147,7 +206,14 @@ void main() {
 /// Replaces the file picker, the restore, and the share sheet, holding the work
 /// open until [finish] or [fail] ends it.
 class _FakeSerializationService extends SerializationService {
-  _FakeSerializationService({this.cancelled = false, this.empty = false});
+  _FakeSerializationService({
+    this.cancelled = false,
+    this.empty = false,
+    this.onRestore,
+  });
+
+  /// Import only: what the restore writes to the stores once it is let through.
+  final Future<void> Function()? onRestore;
 
   /// Import only: the user dismissed the file picker.
   final bool cancelled;
@@ -173,6 +239,7 @@ class _FakeSerializationService extends SerializationService {
     if (onConfirm != null && !await onConfirm(fileName)) return false;
     onRestoreStart?.call();
     await _work.future;
+    await onRestore?.call();
     return true;
   }
 
@@ -183,4 +250,58 @@ class _FakeSerializationService extends SerializationService {
     onShareReady?.call();
     return true;
   }
+}
+
+/// A [BiteManager] over [repo] with the device haptic stubbed out.
+BiteManager _biteManager(BiteRepository repo) =>
+    BiteManager(repo, onReachedClear: () async {});
+
+/// An in-memory [BiteRepository] whose [config] a test can swap, the way a
+/// restore replaces the stored threshold history.
+class _FakeBiteRepository implements BiteRepository {
+  _FakeBiteRepository({this.config});
+
+  PacingConfig? config;
+
+  final List<DateTime> _bites = [];
+
+  @override
+  Future<void> logBite(DateTime at) async => _bites.add(at);
+
+  @override
+  Future<Bite?> lastBite() async => _bites.isEmpty
+      ? null
+      : Bite(id: _bites.length, atMs: _bites.last.millisecondsSinceEpoch);
+
+  @override
+  Future<List<Bite>> bitesInRange(DateTime from, DateTime to) async {
+    var id = 0;
+    return [
+      for (final at in _bites)
+        if (!at.isBefore(from) && at.isBefore(to))
+          Bite(id: ++id, atMs: at.millisecondsSinceEpoch),
+    ];
+  }
+
+  @override
+  Future<int> biteCount(DateTime from, DateTime to) async =>
+      _bites.where((at) => !at.isBefore(from) && at.isBefore(to)).length;
+
+  @override
+  Future<List<DailyBiteCount>> dailyBiteCounts(DateTime from, DateTime to) async => [];
+
+  @override
+  Future<void> setPacingConfig(PacingConfig cfg) async => config = cfg;
+
+  @override
+  Future<PacingConfig?> pacingConfigAt(DateTime instant) async => config;
+
+  @override
+  Future<List<PacingConfig>> allPacingConfigs() async => [?config];
+
+  @override
+  Future<void> clearBites() async => _bites.clear();
+
+  @override
+  Future<void> clearPacingConfigs() async => config = null;
 }


### PR DESCRIPTION
## What changed

`SerializationService.restoreFromBackup` writes straight through the repositories, so `WeightManager._weights` kept serving whatever it had loaded before the import. The Weight tab listed weigh-ins the import had deleted and hid restored ones, next to stat tiles that were already correct (they read the repository at access time).

- **`lib/ui/pages/settings_page.dart`** — `_importData` now reads `WeightManager` and `BiteManager` out of the context (before the first `await`, alongside `messenger`/`service`) and refreshes both once the import reports success, just before the success snackbar.
- **`lib/features/weight/data/weight_manager.dart`** — new `refresh()`, the public name for the existing `_reloadHistory()` reload path.
- **`lib/features/bite/data/bite_manager.dart`** — `refresh()` re-reads the pacing config instead of keeping any version it already held (`_pacingConfig ??=` → re-read, falling back to the held value if the store has none).

## How the issue's asks are met

- **The Weight tab reflects the restored store without a restart** — the restore path itself refreshes the manager, so it no longer depends on a later add/edit/delete or an app restart.
- **"The Bite tab looks less exposed — worth confirming rather than assuming."** Confirmed: `BitePage` refreshes on lifecycle resume *and* on becoming the visible tab (`didUpdateWidget`, `bite_page.dart:56-63`), and `AppShell` keeps every tab in an `IndexedStack`, so reaching the Bite tab after an import always re-reads today's count and the last bite. That masks the staleness rather than removing it, so the restore path now refreshes `BiteManager` too — correctness no longer rests on which tab you happen to arrive from.
- **A test that a restore makes the manager reflect the new store contents** — see below.

## Decisions made along the way

- **Refresh from the page, not from `SerializationService`.** The issue offered both; the page is the smaller change and keeps the service's dependencies as they are (it takes repositories, not managers), leaving `restoreFromBackup` unit-testable on its own.
- **A new `WeightManager.refresh()` rather than calling `initialize()` post-startup.** One extra three-line method, but it mirrors the `BiteManager.refresh()` that already exists for exactly this, and stops `initialize()` from acquiring a second meaning that a later reader would reasonably "clean up".
- **Refreshing runs inside the existing `try`.** A failing reload therefore surfaces as the "Import failed" toast even though the stores were replaced. Both reloads are repository reads that shouldn't throw in practice, and the alternative — swallowing the error and reporting success — hides a genuinely broken state.
- **The pacing-config re-read is included.** Strictly it's a second staleness bug in the same restore path (a restore replaces the config history, but `refresh()` kept the thresholds it already had until the next app start). It's one line and squarely the issue's subject — stale in-memory state after a restore — so fixing it here rather than leaving a known hole in the fix. Flagging it explicitly since it's the one part not named in the issue body. The re-read falls back to the held config when the store has none, so it never regresses to the hardcoded fallback thresholds.
- **Both managers are read before the first `await`**, matching how the method already captures `messenger` and `service`, so nothing reads from a `BuildContext` across an async gap.

## Tests

- `test/features/weight/weight_manager_test.dart` — new `WeightManager refresh` group: picks up an entry written straight to the repository, drops one the repository no longer holds, and notifies listeners so the tab rebuilds.
- `test/ui/pages/settings_page_test.dart` — new `leaves no manager holding pre-import data`: drives the real `SettingsPage` through a confirmed import whose fake restore replaces the stores behind both managers' backs, then asserts `WeightManager.history` carries the restored weigh-in and `BiteManager.b2` carries the restored threshold. `pumpPage` now supplies both managers (defaulting to an `InMemoryWeightRepository` and an in-memory fake `BiteRepository`), so the existing import/export tests cover the new code path too.
- `test/features/bite/data/bite_manager_pacing_test.dart` — new `refresh adopts thresholds that were replaced in the store`.

## Verification

Flutter is not installed in this environment and `CLAUDE.md` says not to install it here, so `flutter analyze` and `flutter test` were **not** run locally — the `flutter_ci.yml` checks on this PR are the verification. The diff was kept small and self-reviewed for unused imports and dead code.

Closes #98


---
_Generated by [Claude Code](https://claude.ai/code/session_01EACQpaencGUh158V6XDxKA)_