### PR TITLE
fix: name the selected history range on Home (#99)

### DIFF
--- a/lib/features/weight/data/in_memory_weight_repository.dart
+++ b/lib/features/weight/data/in_memory_weight_repository.dart
@@ -31,4 +31,7 @@ class InMemoryWeightRepository with WeightRepositoryHelper implements WeightRepo
     invalidateCache();
     _weights.clear();
   }
+
+  @override
+  bool get isEmpty => _weights.isEmpty;
 }

--- a/lib/features/weight/data/persistent_weight_repository.dart
+++ b/lib/features/weight/data/persistent_weight_repository.dart
@@ -34,4 +34,7 @@ class PersistentWeightRepository with WeightRepositoryHelper implements WeightRe
     invalidateCache();
     await _box.clear();
   }
+
+  @override
+  bool get isEmpty => _box.isEmpty;
 }

--- a/lib/features/weight/data/weight_manager.dart
+++ b/lib/features/weight/data/weight_manager.dart
@@ -42,7 +42,7 @@ class WeightManager extends ChangeNotifier {
       .toList(growable: false);
 
   /// Whether the store holds any weigh-in at all, in or out of [historyRange].
-  bool get hasAnyWeights => _weightRepository.getAllWeights().isNotEmpty;
+  bool get hasAnyWeights => !_weightRepository.isEmpty;
 
   void selectHistoryRange(DateRange range) {
     if (range == _historyRange) return;

--- a/lib/features/weight/data/weight_manager.dart
+++ b/lib/features/weight/data/weight_manager.dart
@@ -41,6 +41,9 @@ class WeightManager extends ChangeNotifier {
       .where((weight) => _historyRange.contains(weight.date))
       .toList(growable: false);
 
+  /// Whether the store holds any weigh-in at all, in or out of [historyRange].
+  bool get hasAnyWeights => _weightRepository.getAllWeights().isNotEmpty;
+
   void selectHistoryRange(DateRange range) {
     if (range == _historyRange) return;
     _historyRange = range;

--- a/lib/features/weight/data/weight_repository.dart
+++ b/lib/features/weight/data/weight_repository.dart
@@ -16,6 +16,10 @@ abstract class WeightRepository {
 
   Future<void> deleteWeight(DateTime date);
   Future<void> clear();
+
+  /// Whether the store holds no weigh-in. Implementations answer from the
+  /// store's own bookkeeping rather than by reading the entries.
+  bool get isEmpty;
   
   /// Returns the lowest weight recorded since [since] (inclusive).
   /// If [since] is null, returns the all-time lowest weight.

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -62,7 +62,7 @@ class HomePage extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(
-                    'Latest ${range.headingSpan} of Weight',
+                    'Latest ${range.span} of Weight',
                     style: theme.textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
@@ -118,7 +118,7 @@ class HomePage extends StatelessWidget {
             child: Text(
               storeIsEmpty
                   ? 'No weight entries yet.\nTap "Log Weight" above to get started!'
-                  : 'No weight entries in the ${range.label.toLowerCase()}.\n'
+                  : 'No weight entries in the last ${range.span.toLowerCase()}.\n'
                         'Tap "Log Weight" above to add one.',
               textAlign: TextAlign.center,
               style: const TextStyle(color: Colors.grey, height: 1.5),

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_range.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/widgets/add_weight_dialog.dart';
 import 'package:food_locker/ui/widgets/app_version_label.dart';
+import 'package:food_locker/ui/widgets/history_range_selector.dart';
 import 'package:food_locker/ui/widgets/longest_streak_banner.dart';
 import 'package:food_locker/ui/widgets/streak_banner.dart';
 import 'package:food_locker/ui/widgets/weight_history_tile.dart';
@@ -17,7 +19,7 @@ class HomePage extends StatelessWidget {
     final weightManager = context.watch<WeightManager>();
     final stats = weightManager.overeatingStats;
     final history = weightManager.history;
-    final latest7 = history.take(7).toList();
+    final range = weightManager.historyRange;
 
     return Scaffold(
       body: CustomScrollView(
@@ -60,7 +62,7 @@ class HomePage extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(
-                    'Latest 7 Days of Weight',
+                    'Latest ${range.headingSpan} of Weight',
                     style: theme.textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
@@ -74,7 +76,11 @@ class HomePage extends StatelessWidget {
               ),
             ),
           ),
-          _buildHistorySection(latest7, history),
+          _buildHistorySection(
+            history,
+            range: range,
+            storeIsEmpty: !weightManager.hasAnyWeights,
+          ),
           const SliverToBoxAdapter(
             child: AppVersionLabel(),
           ),
@@ -99,16 +105,23 @@ class HomePage extends StatelessWidget {
     }
   }
 
-  Widget _buildHistorySection(List<Weight> latest7, List<Weight> history) {
-    if (latest7.isEmpty) {
-      return const SliverToBoxAdapter(
+  Widget _buildHistorySection(
+    List<Weight> history, {
+    required DateRange range,
+    required bool storeIsEmpty,
+  }) {
+    if (history.isEmpty) {
+      return SliverToBoxAdapter(
         child: Padding(
-          padding: EdgeInsets.symmetric(vertical: 40.0, horizontal: 16.0),
+          padding: const EdgeInsets.symmetric(vertical: 40.0, horizontal: 16.0),
           child: Center(
             child: Text(
-              'No weight entries yet.\nTap "Log Weight" above to get started!',
+              storeIsEmpty
+                  ? 'No weight entries yet.\nTap "Log Weight" above to get started!'
+                  : 'No weight entries in the ${range.label.toLowerCase()}.\n'
+                        'Tap "Log Weight" above to add one.',
               textAlign: TextAlign.center,
-              style: TextStyle(color: Colors.grey, height: 1.5),
+              style: const TextStyle(color: Colors.grey, height: 1.5),
             ),
           ),
         ),
@@ -118,7 +131,7 @@ class HomePage extends StatelessWidget {
     return SliverList(
       delegate: SliverChildBuilderDelegate(
         (context, index) {
-          final item = latest7[index];
+          final item = history[index];
           // Compute difference with previous day (which is at index + 1 in sorted descending list)
           double? diff;
           if (index + 1 < history.length) {
@@ -130,7 +143,7 @@ class HomePage extends StatelessWidget {
             diff: diff,
           );
         },
-        childCount: latest7.length,
+        childCount: history.length,
       ),
     );
   }

--- a/lib/ui/pages/weight_page.dart
+++ b/lib/ui/pages/weight_page.dart
@@ -77,7 +77,7 @@ class WeightPage extends StatelessWidget {
                     padding: const EdgeInsets.all(32.0),
                     child: Center(
                       child: Text(
-                        'No weight entries in the ${range.label.toLowerCase()}. '
+                        'No weight entries in the last ${range.span.toLowerCase()}. '
                         'Tap + to log your weight.',
                       ),
                     ),

--- a/lib/ui/widgets/history_range_selector.dart
+++ b/lib/ui/widgets/history_range_selector.dart
@@ -10,16 +10,11 @@ const historyRangePresets = <DateRange>[
   DateRange.lastDays(365),
 ];
 
-extension HistoryRangeLabel on DateRange {
-  /// Rounded to the unit the span is closest to, so 180 days reads as months.
-  String get label => switch (days) {
-    180 => 'Last 6 months',
-    365 => 'Last year',
-    _ => 'Last $days days',
-  };
-
-  /// The span title-cased for a heading, as in 'Latest 30 Days of Weight'.
-  String get headingSpan => switch (days) {
+extension HistoryRangeSpan on DateRange {
+  /// Title-cased for headings ('Latest 30 Days of Weight'); lowercase it for
+  /// prose ('the last 30 days'). Rounded to the unit the span is closest to,
+  /// so 180 days reads as months.
+  String get span => switch (days) {
     180 => '6 Months',
     365 => 'Year',
     _ => '$days Days',
@@ -47,7 +42,10 @@ class HistoryRangeSelector extends StatelessWidget {
       onSelected: onSelected,
       itemBuilder: (context) => [
         for (final range in historyRangePresets)
-          PopupMenuItem(value: range, child: Text(range.label)),
+          PopupMenuItem(
+            value: range,
+            child: Text('Last ${range.span.toLowerCase()}'),
+          ),
       ],
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -55,7 +53,7 @@ class HistoryRangeSelector extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              selected.label,
+              'Last ${selected.span.toLowerCase()}',
               style: theme.textTheme.labelLarge?.copyWith(
                 color: theme.colorScheme.primary,
               ),

--- a/lib/ui/widgets/history_range_selector.dart
+++ b/lib/ui/widgets/history_range_selector.dart
@@ -17,6 +17,13 @@ extension HistoryRangeLabel on DateRange {
     365 => 'Last year',
     _ => 'Last $days days',
   };
+
+  /// The span title-cased for a heading, as in 'Latest 30 Days of Weight'.
+  String get headingSpan => switch (days) {
+    180 => '6 Months',
+    365 => 'Year',
+    _ => '$days Days',
+  };
 }
 
 /// Picks how far back the weight history reaches.

--- a/test/features/weight/weight_repository_test.dart
+++ b/test/features/weight/weight_repository_test.dart
@@ -157,5 +157,19 @@ void main() {
 
       expect(repository.getOldestWeightDate(), date2);
     });
+
+    test('isEmpty tracks whether the store holds anything', () async {
+      expect(repository.isEmpty, isTrue);
+
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 1), value: 70.0));
+      expect(repository.isEmpty, isFalse);
+
+      await repository.deleteWeight(DateTime(2023, 5, 1));
+      expect(repository.isEmpty, isTrue);
+
+      await repository.saveWeight(Weight(date: DateTime(2023, 5, 2), value: 71.0));
+      await repository.clear();
+      expect(repository.isEmpty, isTrue);
+    });
   });
 }

--- a/test/ui/pages/home_page_test.dart
+++ b/test/ui/pages/home_page_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_range.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weight_manager.dart';
+import 'package:food_locker/ui/pages/home_page.dart';
+import 'package:food_locker/ui/theme.dart';
+import 'package:food_locker/ui/widgets/weight_history_tile.dart';
+import 'package:provider/provider.dart';
+
+String _dateLabel(DateTime date) =>
+    '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+
+void main() {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  DateTime daysAgo(int days) =>
+      DateTime(today.year, today.month, today.day - days);
+
+  Future<void> pumpPage(WidgetTester tester, WeightManager manager) async {
+    // The header and the two banners push the history list below the fold on
+    // the default 800x600 surface, so its tiles never get built.
+    tester.view.physicalSize = const Size(800, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme,
+        home: ChangeNotifierProvider<WeightManager>.value(
+          value: manager,
+          child: const HomePage(),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('the heading names the selected range', (tester) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+    await manager.addWeight(today, 72.0);
+
+    await pumpPage(tester, manager);
+
+    Future<void> expectHeadingFor(DateRange range, String heading) async {
+      manager.selectHistoryRange(range);
+      await tester.pump();
+      expect(find.text(heading), findsOneWidget);
+    }
+
+    expect(find.text('Latest 7 Days of Weight'), findsOneWidget);
+    await expectHeadingFor(
+      const DateRange.lastDays(30),
+      'Latest 30 Days of Weight',
+    );
+    await expectHeadingFor(
+      const DateRange.lastDays(90),
+      'Latest 90 Days of Weight',
+    );
+    await expectHeadingFor(
+      const DateRange.lastDays(180),
+      'Latest 6 Months of Weight',
+    );
+    await expectHeadingFor(
+      const DateRange.lastDays(365),
+      'Latest Year of Weight',
+    );
+  });
+
+  testWidgets('an empty store keeps the onboarding prompt', (tester) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+
+    await pumpPage(tester, manager);
+
+    expect(
+      find.text(
+        'No weight entries yet.\nTap "Log Weight" above to get started!',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('an empty range names the range instead of claiming no entries', (
+    tester,
+  ) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+    await manager.addWeight(daysAgo(20), 73.0);
+
+    await pumpPage(tester, manager);
+
+    expect(
+      find.text(
+        'No weight entries in the last 7 days.\n'
+        'Tap "Log Weight" above to add one.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'No weight entries yet.\nTap "Log Weight" above to get started!',
+      ),
+      findsNothing,
+    );
+
+    manager.selectHistoryRange(const DateRange.lastDays(30));
+    await tester.pump();
+
+    expect(find.text(_dateLabel(daysAgo(20))), findsOneWidget);
+  });
+
+  testWidgets('the history lists every entry in the selected range', (
+    tester,
+  ) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+    for (var day = 0; day < 10; day++) {
+      await manager.addWeight(daysAgo(day), 70.0 + day);
+    }
+
+    await pumpPage(tester, manager);
+
+    expect(find.byType(WeightHistoryTile), findsNWidgets(7));
+
+    manager.selectHistoryRange(const DateRange.lastDays(30));
+    await tester.pump();
+
+    expect(find.byType(WeightHistoryTile), findsNWidgets(10));
+    expect(find.text(_dateLabel(daysAgo(9))), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What changed

The Home tab hardcoded `'Latest 7 Days of Weight'` and an empty state that claimed there were no entries at all, so after #97 gave the history a selectable range both strings could misdescribe what Home was showing.

- **`lib/ui/widgets/history_range_selector.dart`** — one `span` getter on the `HistoryRangeSpan` extension (`7 Days`, `30 Days`, `90 Days`, `6 Months`, `Year`), title-cased and without a baked-in "Last". Call sites frame it: `'Last ${range.span.toLowerCase()}'` for prose, `'Latest ${range.span} of Weight'` for the Home heading.
- **`lib/ui/pages/home_page.dart`** — the heading follows the selected range; the empty state names the active range when the store holds entries outside the window, and keeps the onboarding prompt when the store is genuinely empty; `history.take(7)` is gone.
- **`lib/features/weight/data/weight_manager.dart`** — `hasAnyWeights`, so the page can tell "nothing logged ever" from "nothing in this window" without reaching past the repository interface.
- **`lib/features/weight/data/weight_repository.dart`** (+ both implementations) — `isEmpty` on the interface, answered from the store's own bookkeeping: the Hive box's key count, the in-memory repository's map. Home asks on every rebuild, so it must not deserialize the box.
- **`lib/ui/pages/weight_page.dart`** — its empty state supplies its own "last", following the getter change. No rendered string changes.

## How the issue's asks are met

- **Heading follows the selected range** — `'Latest 30 Days of Weight'`, `'Latest 6 Months of Weight'`, `'Latest Year of Weight'`. With the default 7-day range the string is byte-identical to before.
- **Empty state no longer claims there are no entries at all** — with entries outside the window it reads `No weight entries in the last 30 days.` / `Tap "Log Weight" above to add one.`, phrased to match the Weight tab's equivalent. An empty store still gets `No weight entries yet.` / `Tap "Log Weight" above to get started!`.

## Decisions the issue left open

- **The 7-entry cap → dropped.** The alternative was wording the heading around the cap, but "Latest 30 Days of Weight" above at most 7 rows is the same class of lie the issue is about. Dropping `take(7)` is a one-line deletion and a no-op under the default 7-day range (one entry per day is the store's invariant), so behaviour only changes for someone who has deliberately widened the range. Home now lists the window, like the Weight tab does.
- **Home gets no range control.** The issue notes the honest fixes are a Home-side control or a return to "the 7 most recent entries" — both Home-redesign calls. This PR does only what the issue asks for: name the range rather than misreport it.
- **Distinguishing the two empty cases through the repository interface**, via the new `isEmpty`, rather than `getOldestWeightDate()`, which #103 proposes deleting.
- Scope kept off #103's toes: the two streak banners are untouched here.

## Verification

Flutter is not installed in this environment and CLAUDE.md says not to install it, so `flutter analyze` / `flutter test` were **not** run locally — the `flutter_ci.yml` checks on this PR are the verification.

New tests in `test/ui/pages/home_page_test.dart` (in-memory repository, mirroring `weight_page_test.dart`) cover: the heading for each preset range, the onboarding prompt on an empty store, the range-named empty state when entries sit outside the window, and the history listing every entry in the selected range once the cap is gone. `weight_repository_test.dart` covers `isEmpty` across save, delete and `clear()`. Together with the existing `weight_page_test.dart` expectations, they pin every user-visible string across the getter consolidation.

Closes #99