### PR TITLE
feat: add a 52-week weight-change heatmap to Home

### DIFF
--- a/lib/features/weight/data/weekly_weight_change.dart
+++ b/lib/features/weight/data/weekly_weight_change.dart
@@ -1,0 +1,53 @@
+import 'package:food_locker/features/weight/data/weight.dart';
+
+/// One calendar week's weight change, as the Home heatmap reads it.
+///
+/// Intra-week only: [delta] is the week's last weigh-in minus its first, so
+/// nothing carries across a week boundary and every week stands on its own. A
+/// week under [minEntries] weigh-ins reports no [delta] at all.
+class WeeklyWeightChange {
+  const WeeklyWeightChange({required this.weekStart, this.delta, this.unit});
+
+  /// Weigh-ins a week needs before it reports a [delta].
+  static const int minEntries = 4;
+
+  /// The Sunday opening the week, at local midnight.
+  final DateTime weekStart;
+
+  /// Last weigh-in of the week minus its first, or null under [minEntries].
+  final double? delta;
+
+  /// The unit [delta] is expressed in; null exactly when [delta] is.
+  final WeightUnit? unit;
+
+  bool get hasData => delta != null;
+
+  /// Whether the week ended heavier. A flat week counts as not gained.
+  bool get isGain => (delta ?? 0) > 0;
+
+  /// Magnitude bucket, 1 (faintest) to 4 (strongest), or null without a
+  /// [delta]. The pound bounds are the kilogram ones doubled.
+  int? get level {
+    final magnitude = delta?.abs();
+    if (magnitude == null) return null;
+    final scale = unit == WeightUnit.pounds ? 2.0 : 1.0;
+    if (magnitude < 0.25 * scale) return 1;
+    if (magnitude < 0.5 * scale) return 2;
+    if (magnitude < 1.0 * scale) return 3;
+    return 4;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is WeeklyWeightChange &&
+      other.weekStart == weekStart &&
+      other.delta == delta &&
+      other.unit == unit;
+
+  @override
+  int get hashCode => Object.hash(weekStart, delta, unit);
+
+  @override
+  String toString() =>
+      'WeeklyWeightChange(weekStart: $weekStart, delta: $delta, unit: $unit)';
+}

--- a/lib/features/weight/data/weight_analytics.dart
+++ b/lib/features/weight/data/weight_analytics.dart
@@ -1,9 +1,14 @@
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
 
 class WeightAnalytics {
   final WeightRepository _weightRepository;
 
   WeightAnalytics(this._weightRepository);
+
+  /// Weeks the Home heatmap draws.
+  static const int heatmapWeeks = 52;
 
   double? get lowestAllTime => _weightRepository.getLowestWeight();
 
@@ -14,4 +19,61 @@ class WeightAnalytics {
   double? get lowestLast7Days => _weightRepository.getLowestWeight(
     since: DateTime.now().subtract(const Duration(days: 7)),
   );
+
+  /// The last [weeks] Sunday-to-Saturday weeks of weight change, oldest first
+  /// and ending with the week holding [asOf] — the week still in progress.
+  ///
+  /// Always [weeks] long: a week the store has too little for is present with
+  /// no delta rather than missing, so callers can index it as a fixed grid.
+  List<WeeklyWeightChange> weeklyChanges({
+    int weeks = heatmapWeeks,
+    DateTime? asOf,
+  }) {
+    final weekStarts = _weekStartsEndingAt(asOf ?? DateTime.now(), weeks);
+    final entriesByWeek = <DateTime, List<Weight>>{};
+
+    for (final weight in _weightRepository.getWeightsSince(weekStarts.first)) {
+      final start = _weekStart(weight.date);
+      // getWeightsSince is unbounded above, so future-dated weigh-ins arrive
+      // with no cell to sit in.
+      if (start.isAfter(weekStarts.last)) continue;
+      entriesByWeek.putIfAbsent(start, () => []).add(weight);
+    }
+
+    return [
+      for (final start in weekStarts) _change(start, entriesByWeek[start]),
+    ];
+  }
+
+  static WeeklyWeightChange _change(DateTime weekStart, List<Weight>? entries) {
+    if (entries == null || entries.length < WeeklyWeightChange.minEntries) {
+      return WeeklyWeightChange(weekStart: weekStart);
+    }
+
+    entries.sort((a, b) => a.date.compareTo(b.date));
+    final first = entries.first;
+    final last = entries.last;
+    return WeeklyWeightChange(
+      weekStart: weekStart,
+      delta: last.value - first.value,
+      unit: last.unit,
+    );
+  }
+
+  /// The Sunday opening [date]'s week, at local midnight. Dart counts Mon=1…
+  /// Sun=7, so `% 7` maps Sunday to a zero offset.
+  static DateTime _weekStart(DateTime date) =>
+      DateTime(date.year, date.month, date.day - (date.weekday % 7));
+
+  /// [weeks] consecutive week starts, oldest first, the last being [asOf]'s.
+  ///
+  /// Stepping by calendar components rather than `Duration(days: 7)` keeps the
+  /// walk on Sundays across a daylight-saving shift.
+  static List<DateTime> _weekStartsEndingAt(DateTime asOf, int weeks) {
+    final current = _weekStart(asOf);
+    return [
+      for (var back = weeks - 1; back >= 0; back--)
+        DateTime(current.year, current.month, current.day - 7 * back),
+    ];
+  }
 }

--- a/lib/features/weight/data/weight_analytics.dart
+++ b/lib/features/weight/data/weight_analytics.dart
@@ -29,6 +29,7 @@ class WeightAnalytics {
     int weeks = heatmapWeeks,
     DateTime? asOf,
   }) {
+    assert(weeks > 0);
     final weekStarts = _weekStartsEndingAt(asOf ?? DateTime.now(), weeks);
     final entriesByWeek = <DateTime, List<Weight>>{};
 

--- a/lib/features/weight/data/weight_manager.dart
+++ b/lib/features/weight/data/weight_manager.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:food_locker/core/date_range.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_analytics.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
@@ -95,4 +96,7 @@ class WeightManager extends ChangeNotifier {
   double? get lowestAllTime => _analytics.lowestAllTime;
   double? get lowestLast30Days => _analytics.lowestLast30Days;
   double? get lowestLast7Days => _analytics.lowestLast7Days;
+
+  /// The last year of weekly weight change, oldest first, for the Home heatmap.
+  List<WeeklyWeightChange> get weeklyChanges => _analytics.weeklyChanges();
 }

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -5,6 +5,7 @@ import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/widgets/add_weight_dialog.dart';
 import 'package:food_locker/ui/widgets/app_version_label.dart';
 import 'package:food_locker/ui/widgets/history_range_selector.dart';
+import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
 import 'package:food_locker/ui/widgets/weight_history_tile.dart';
 import 'package:provider/provider.dart';
 
@@ -17,6 +18,7 @@ class HomePage extends StatelessWidget {
     final weightManager = context.watch<WeightManager>();
     final history = weightManager.history;
     final range = weightManager.historyRange;
+    final weeklyChanges = weightManager.weeklyChanges;
 
     return Scaffold(
       body: CustomScrollView(
@@ -44,6 +46,13 @@ class HomePage extends StatelessWidget {
               ),
             ),
           ),
+          if (weeklyChanges.any((week) => week.hasData))
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: WeeklyChangeHeatmap(weeks: weeklyChanges),
+              ),
+            ),
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),

--- a/lib/ui/widgets/weekly_change_color.dart
+++ b/lib/ui/widgets/weekly_change_color.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+
+/// The heatmap's colour for a week that reported no change.
+const Color weeklyChangeNoDataColor = Color(0xFFEEEEEE);
+
+/// The single point where a week's change becomes a heatmap colour.
+///
+/// Loss is green and gain is red, matching the app's loss-oriented framing; a
+/// later "goal direction" setting swaps the two ramps here, leaving the grid
+/// untouched. The shades are fixed rather than theme-derived, so a cell keeps
+/// its meaning whatever the palette does.
+Color weeklyChangeColor(WeeklyWeightChange week) {
+  final level = week.level;
+  if (level == null) return weeklyChangeNoDataColor;
+  return (week.isGain ? _gainRamp : _lossRamp)[level - 1];
+}
+
+const List<Color> _lossRamp = [
+  Color(0xFFC8E6C9),
+  Color(0xFF81C784),
+  Color(0xFF43A047),
+  Color(0xFF1B5E20),
+];
+
+const List<Color> _gainRamp = [
+  Color(0xFFFFCDD2),
+  Color(0xFFE57373),
+  Color(0xFFE53935),
+  Color(0xFFB71C1C),
+];

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/ui/widgets/weekly_change_color.dart';
+
+/// A year of weekly weight change as a grid of coloured cells.
+///
+/// Fills row by row, oldest top-left to newest bottom-right, so the last cell
+/// is the week in progress. Unlabelled and non-interactive by design.
+class WeeklyChangeHeatmap extends StatelessWidget {
+  const WeeklyChangeHeatmap({super.key, required this.weeks});
+
+  static const int rows = 4;
+  static const int columns = 13;
+
+  /// The weeks to draw, oldest first. Cells past the end of the list are drawn
+  /// as no-data.
+  final List<WeeklyWeightChange> weeks;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (var row = 0; row < rows; row++)
+          Row(
+            children: [
+              for (var column = 0; column < columns; column++)
+                Expanded(child: _Cell(color: _colorAt(row * columns + column))),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Color _colorAt(int index) => index < weeks.length
+      ? weeklyChangeColor(weeks[index])
+      : weeklyChangeNoDataColor;
+}
+
+class _Cell extends StatelessWidget {
+  const _Cell({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(2),
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(3),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/features/weight/data/weight_analytics.dart';
+
+void main() {
+  // A Saturday: the week it closes opens on Sunday the 9th.
+  final asOf = DateTime(2026, 8, 15);
+
+  late InMemoryWeightRepository repository;
+  late WeightAnalytics analytics;
+
+  setUp(() {
+    repository = InMemoryWeightRepository();
+    analytics = WeightAnalytics(repository);
+  });
+
+  Future<void> log(DateTime date, double value, {WeightUnit? unit}) =>
+      repository.saveWeight(
+        Weight(
+          date: date,
+          value: value,
+          unit: unit ?? WeightUnit.kilograms,
+        ),
+      );
+
+  /// Logs [values] on consecutive days, one per day, beginning at [start].
+  Future<void> logRun(DateTime start, List<double> values, {WeightUnit? unit}) async {
+    for (var offset = 0; offset < values.length; offset++) {
+      await log(
+        DateTime(start.year, start.month, start.day + offset),
+        values[offset],
+        unit: unit,
+      );
+    }
+  }
+
+  group('week grid', () {
+    test('returns 52 weeks, oldest first, ending with the current week', () {
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+
+      expect(weeks, hasLength(52));
+      expect(weeks.last.weekStart, DateTime(2026, 8, 9));
+      expect(weeks.first.weekStart, DateTime(2025, 8, 17));
+
+      for (var i = 1; i < weeks.length; i++) {
+        expect(weeks[i].weekStart.isAfter(weeks[i - 1].weekStart), isTrue);
+      }
+    });
+
+    test('every week start is a Sunday', () {
+      for (final week in analytics.weeklyChanges(asOf: asOf)) {
+        expect(week.weekStart.weekday, DateTime.sunday);
+      }
+    });
+
+    test('honours a shorter grid', () {
+      final weeks = analytics.weeklyChanges(weeks: 4, asOf: asOf);
+
+      expect(weeks, hasLength(4));
+      expect(weeks.last.weekStart, DateTime(2026, 8, 9));
+      expect(weeks.first.weekStart, DateTime(2026, 7, 19));
+    });
+
+    test('a store with no weigh-ins yields 52 empty weeks', () {
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+
+      expect(weeks.every((week) => !week.hasData), isTrue);
+      expect(weeks.every((week) => week.delta == null), isTrue);
+    });
+  });
+
+  group('week delta', () {
+    test('is the last weigh-in of the week minus its first', () async {
+      await logRun(DateTime(2026, 8, 9), [80.0, 79.5, 79.0, 78.4]);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.delta, closeTo(-1.6, 1e-9));
+      expect(current.isGain, isFalse);
+    });
+
+    test('reads chronologically, not in insertion order', () async {
+      await log(DateTime(2026, 8, 12), 79.0);
+      await log(DateTime(2026, 8, 9), 80.0);
+      await log(DateTime(2026, 8, 14), 81.0);
+      await log(DateTime(2026, 8, 10), 78.0);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.delta, closeTo(1.0, 1e-9));
+      expect(current.isGain, isTrue);
+    });
+
+    test('needs at least four weigh-ins in the week', () async {
+      await logRun(DateTime(2026, 8, 9), [80.0, 79.0, 78.0]);
+
+      expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isFalse);
+    });
+
+    test('four weigh-ins is enough', () async {
+      await logRun(DateTime(2026, 8, 9), [80.0, 79.0, 78.0, 77.0]);
+
+      expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isTrue);
+    });
+
+    test('never carries across a week boundary', () async {
+      // Saturday closes one week, Sunday opens the next: four each side.
+      await logRun(DateTime(2026, 8, 2), [90.0, 89.0, 88.0, 87.0]);
+      await logRun(DateTime(2026, 8, 9), [70.0, 71.0, 72.0, 73.0]);
+
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+      final previous = weeks[weeks.length - 2];
+      final current = weeks.last;
+
+      expect(previous.weekStart, DateTime(2026, 8, 2));
+      expect(previous.delta, closeTo(-3.0, 1e-9));
+      expect(current.weekStart, DateTime(2026, 8, 9));
+      expect(current.delta, closeTo(3.0, 1e-9));
+    });
+
+    test('splits a Saturday-to-Sunday run at the boundary', () async {
+      // Thursday the 6th through Tuesday the 11th splits three days either
+      // side of the boundary, so neither week reaches four.
+      await logRun(DateTime(2026, 8, 6), [90.0, 89.0, 88.0, 87.0, 86.0, 85.0]);
+
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+
+      expect(weeks[weeks.length - 2].hasData, isFalse);
+      expect(weeks.last.hasData, isFalse);
+    });
+
+    test('ignores weigh-ins dated past the current week', () async {
+      await logRun(DateTime(2026, 8, 16), [70.0, 71.0, 72.0, 73.0]);
+
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+
+      expect(weeks.every((week) => !week.hasData), isTrue);
+    });
+
+    test('ignores weigh-ins older than the grid', () async {
+      await logRun(DateTime(2025, 8, 10), [70.0, 71.0, 72.0, 73.0]);
+
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+
+      expect(weeks.every((week) => !week.hasData), isTrue);
+    });
+
+    test('fills the right cell for an older week', () async {
+      await logRun(DateTime(2026, 6, 7), [70.0, 70.5, 71.0, 71.5]);
+
+      final weeks = analytics.weeklyChanges(asOf: asOf);
+      final filled = weeks.where((week) => week.hasData).toList();
+
+      expect(filled, hasLength(1));
+      expect(filled.single.weekStart, DateTime(2026, 6, 7));
+      expect(filled.single.delta, closeTo(1.5, 1e-9));
+    });
+
+    test('takes its unit from the week\'s last weigh-in', () async {
+      await logRun(
+        DateTime(2026, 8, 9),
+        [180.0, 179.0, 178.0, 177.0],
+        unit: WeightUnit.pounds,
+      );
+
+      expect(analytics.weeklyChanges(asOf: asOf).last.unit, WeightUnit.pounds);
+    });
+  });
+
+  group('intensity levels', () {
+    WeeklyWeightChange change(double? delta, [WeightUnit? unit]) =>
+        WeeklyWeightChange(
+          weekStart: DateTime(2026, 8, 9),
+          delta: delta,
+          unit: delta == null ? null : unit ?? WeightUnit.kilograms,
+        );
+
+    test('a week with no delta has no level', () {
+      expect(change(null).level, isNull);
+      expect(change(null).hasData, isFalse);
+    });
+
+    test('kilogram buckets run 0.25 / 0.5 / 1.0', () {
+      expect(change(0.24).level, 1);
+      expect(change(0.25).level, 2);
+      expect(change(0.49).level, 2);
+      expect(change(0.5).level, 3);
+      expect(change(0.99).level, 3);
+      expect(change(1.0).level, 4);
+      expect(change(4.2).level, 4);
+    });
+
+    test('pound buckets are the kilogram ones doubled', () {
+      const lb = WeightUnit.pounds;
+      expect(change(0.49, lb).level, 1);
+      expect(change(0.5, lb).level, 2);
+      expect(change(0.99, lb).level, 2);
+      expect(change(1.0, lb).level, 3);
+      expect(change(1.99, lb).level, 3);
+      expect(change(2.0, lb).level, 4);
+    });
+
+    test('a loss buckets on its magnitude, not its sign', () {
+      expect(change(-1.2).level, 4);
+      expect(change(-0.3).level, 2);
+      expect(change(-1.2).isGain, isFalse);
+    });
+
+    test('an exact zero is the faintest loss, never a gain', () {
+      expect(change(0.0).hasData, isTrue);
+      expect(change(0.0).isGain, isFalse);
+      expect(change(0.0).level, 1);
+    });
+  });
+}

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -63,6 +63,13 @@ void main() {
       expect(weeks.first.weekStart, DateTime(2026, 7, 19));
     });
 
+    test('rejects a grid with no weeks in it', () {
+      expect(
+        () => analytics.weeklyChanges(weeks: 0, asOf: asOf),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('a store with no weigh-ins yields 52 empty weeks', () {
       final weeks = analytics.weeklyChanges(asOf: asOf);
 

--- a/test/ui/pages/home_page_test.dart
+++ b/test/ui/pages/home_page_test.dart
@@ -5,6 +5,7 @@ import 'package:food_locker/features/weight/data/in_memory_weight_repository.dar
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/pages/home_page.dart';
 import 'package:food_locker/ui/theme.dart';
+import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
 import 'package:food_locker/ui/widgets/weight_history_tile.dart';
 import 'package:provider/provider.dart';
 
@@ -126,5 +127,39 @@ void main() {
 
     expect(find.byType(WeightHistoryTile), findsNWidgets(10));
     expect(find.text(_dateLabel(daysAgo(9))), findsOneWidget);
+  });
+
+  testWidgets('the heatmap sits under the title block once a week has data', (
+    tester,
+  ) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+    // Four weeks of daily weigh-ins, so a full week clears the four-entry
+    // threshold whatever weekday the test runs on.
+    for (var day = 0; day < 28; day++) {
+      await manager.addWeight(daysAgo(day), 70.0 + day);
+    }
+
+    await pumpPage(tester, manager);
+
+    expect(find.byType(WeeklyChangeHeatmap), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byType(WeeklyChangeHeatmap)).dy,
+      greaterThan(tester.getTopLeft(find.text('Weight Locker')).dy),
+    );
+    expect(
+      tester.getTopLeft(find.byType(WeeklyChangeHeatmap)).dy,
+      lessThan(tester.getTopLeft(find.text('Latest 7 Days of Weight')).dy),
+    );
+  });
+
+  testWidgets('the heatmap stays hidden while no week has data', (
+    tester,
+  ) async {
+    final manager = WeightManager(InMemoryWeightRepository());
+    await manager.addWeight(today, 72.0);
+
+    await pumpPage(tester, manager);
+
+    expect(find.byType(WeeklyChangeHeatmap), findsNothing);
   });
 }

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/features/weight/data/weight_analytics.dart';
 import 'package:food_locker/ui/widgets/weekly_change_color.dart';
 import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
 
@@ -46,7 +47,12 @@ void main() {
       findsNWidgets(WeeklyChangeHeatmap.rows),
     );
     expect(cellColors(tester), hasLength(52));
-    expect(WeeklyChangeHeatmap.rows * WeeklyChangeHeatmap.columns, 52);
+    // The grid must hold exactly the weeks analytics supplies: the list is
+    // oldest-first, so a grid too small would silently drop the newest weeks.
+    expect(
+      WeeklyChangeHeatmap.rows * WeeklyChangeHeatmap.columns,
+      WeightAnalytics.heatmapWeeks,
+    );
   });
 
   testWidgets('a week under the entry threshold is drawn as no data', (

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/ui/widgets/weekly_change_color.dart';
+import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
+
+void main() {
+  WeeklyWeightChange week(int index, {double? delta, WeightUnit? unit}) =>
+      WeeklyWeightChange(
+        weekStart: DateTime(2026, 8, 9 - 7 * index),
+        delta: delta,
+        unit: delta == null ? null : unit ?? WeightUnit.kilograms,
+      );
+
+  List<WeeklyWeightChange> emptyYear() =>
+      [for (var i = 51; i >= 0; i--) week(i)];
+
+  Future<void> pump(WidgetTester tester, List<WeeklyWeightChange> weeks) =>
+      tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: WeeklyChangeHeatmap(weeks: weeks)),
+        ),
+      );
+
+  // Nothing inside the heatmap but a cell decorates a box, so these are the
+  // cells, in row-major order.
+  Finder cells() => find.descendant(
+    of: find.byType(WeeklyChangeHeatmap),
+    matching: find.byType(DecoratedBox),
+  );
+
+  List<Color?> cellColors(WidgetTester tester) => tester
+      .widgetList<DecoratedBox>(cells())
+      .map((box) => (box.decoration as BoxDecoration).color)
+      .toList();
+
+  testWidgets('draws 52 cells in 4 rows of 13', (tester) async {
+    await pump(tester, emptyYear());
+
+    expect(
+      find.descendant(
+        of: find.byType(WeeklyChangeHeatmap),
+        matching: find.byType(Row),
+      ),
+      findsNWidgets(WeeklyChangeHeatmap.rows),
+    );
+    expect(cellColors(tester), hasLength(52));
+    expect(WeeklyChangeHeatmap.rows * WeeklyChangeHeatmap.columns, 52);
+  });
+
+  testWidgets('a week under the entry threshold is drawn as no data', (
+    tester,
+  ) async {
+    await pump(tester, emptyYear());
+
+    expect(
+      cellColors(tester).every((color) => color == weeklyChangeNoDataColor),
+      isTrue,
+    );
+  });
+
+  testWidgets('a gain and a loss of equal size get different colours', (
+    tester,
+  ) async {
+    final weeks = emptyYear();
+    weeks[0] = week(51, delta: 1.5);
+    weeks[1] = week(50, delta: -1.5);
+
+    await pump(tester, weeks);
+    final colors = cellColors(tester);
+
+    expect(colors[0], isNot(colors[1]));
+    expect(colors[0], isNot(weeklyChangeNoDataColor));
+    expect(colors[1], isNot(weeklyChangeNoDataColor));
+  });
+
+  testWidgets('a bigger change is drawn darker', (tester) async {
+    final weeks = emptyYear();
+    weeks[0] = week(51, delta: -0.1);
+    weeks[1] = week(50, delta: -1.5);
+
+    await pump(tester, weeks);
+    final colors = cellColors(tester);
+
+    expect(colors[1]!.computeLuminance(), lessThan(colors[0]!.computeLuminance()));
+  });
+
+  testWidgets('the current week takes the last cell', (tester) async {
+    final weeks = emptyYear();
+    weeks[51] = week(0, delta: 2.0);
+
+    await pump(tester, weeks);
+    final colors = cellColors(tester);
+
+    expect(colors.last, isNot(weeklyChangeNoDataColor));
+    expect(
+      colors.take(51).every((color) => color == weeklyChangeNoDataColor),
+      isTrue,
+    );
+  });
+
+  testWidgets('a short list leaves the trailing cells as no data', (
+    tester,
+  ) async {
+    await pump(tester, [week(51, delta: -1.0)]);
+    final colors = cellColors(tester);
+
+    expect(colors, hasLength(52));
+    expect(colors.first, isNot(weeklyChangeNoDataColor));
+    expect(
+      colors.skip(1).every((color) => color == weeklyChangeNoDataColor),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
A GitHub-contributions-style grid on Home: 52 cells, one per calendar week of the past year, coloured by that week's weight change.

## What changed

| File | Role |
|---|---|
| `lib/features/weight/data/weekly_weight_change.dart` | New `WeeklyWeightChange` value type — a week's `weekStart`, `delta`, `unit`, plus `hasData` / `isGain` / `level`. |
| `lib/features/weight/data/weight_analytics.dart` | New `weeklyChanges({weeks, asOf})` — pure computation over the repository. |
| `lib/features/weight/data/weight_manager.dart` | `weeklyChanges` getter delegating to analytics. |
| `lib/ui/widgets/weekly_change_color.dart` | The single delta-to-colour mapping function. |
| `lib/ui/widgets/weekly_change_heatmap.dart` | The 4 × 13 grid widget. |
| `lib/ui/pages/home_page.dart` | Places the grid under the title block. |

No model, Hive `typeId`, Drift schema or migration work — the grid is derived entirely from stored weights at read time, as the issue anticipated.

## How each resolved decision is met

**Week delta — intra-week, ≥ 4 entries.** `WeightAnalytics.weeklyChanges` buckets weigh-ins by their week and reports `last − first` within that bucket only; a bucket under `WeeklyWeightChange.minEntries` (4) reports `delta == null`. Nothing crosses a week boundary. Covered by `never carries across a week boundary` and `splits a Saturday-to-Sunday run at the boundary`.

**Gray means one thing.** `delta == null` — fewer than 4 entries — is the only path to `weeklyChangeNoDataColor`. The in-progress current week is therefore gray until it reaches 4.

**Exact 0.0 → faintest green.** `isGain` is `delta > 0`, so a flat week takes the loss ramp; `level` buckets on `abs(delta)`, putting 0.0 at level 1. Covered by `an exact zero is the faintest loss, never a gain`.

**Sunday → Saturday, 4 × 13, oldest top-left.** `_weekStart` uses the explicit `weekday % 7` offset the issue called for. The widget fills row-major from a list the analytics returns oldest-first, so the last cell is the current week. Covered by `every week start is a Sunday` and `the current week takes the last cell`.

**Fixed, unit-aware buckets.** `WeeklyWeightChange.level` returns 1–4 against `< 0.25 / 0.5 / 1.0` kg, doubled for `WeightUnit.pounds` (`< 0.5 / 1.0 / 2.0`). The bucket set comes from the week's last weigh-in's unit. Both columns of the issue's table are covered by `kilogram buckets run 0.25 / 0.5 / 1.0` and `pound buckets are the kilogram ones doubled`.

**Loss = green / gain = red through one function.** `weeklyChangeColor` is the only place the sign becomes a colour; swapping `_lossRamp` and `_gainRamp` there is the whole of a future goal-direction setting. The widget never sees a sign.

**Placement.** Top of Home, directly under the title block.

**No interaction, no legend, no month labels.** The grid is a plain `DecoratedBox` per cell.

**DST safety.** Both `_weekStart` and the walk back through the year use calendar-component arithmetic (`DateTime(y, m, d - n)`), never `Duration(days:)`, as the issue's implementation note asked.

## Decisions made along the way

- **The issue says "above the streak banners"; those are gone.** #112 removed them from Home before this landed. The grid goes directly under the title block, which is what that instruction resolves to now.
- **`DateTimeCalendar` no longer exists.** #112 removed it along with the overeating analytics. Rather than reviving an extension for two call sites, the date math is written inline as `DateTime(y, m, d - n)` — the same calendar-component form, matching what `DateRange` in `lib/core/` already does.
- **The grid hides itself while no week has data.** Unspecified in the issue. A wall of 52 gray cells above the "No weight entries yet" onboarding text reads as broken rather than empty, and Home already suppresses its history section the same way. One `if` in `HomePage`; the widget itself renders unconditionally. Easy to drop if you'd rather always show the frame.
- **A week's unit comes from its *last* weigh-in.** The issue says "the week's entry `WeightUnit`" without picking one for a mixed week. The last entry is the one the delta is measured to, and every stored entry is `kilograms` today regardless.
- **`weeklyChanges` takes an `asOf` parameter.** Injecting "now" is what makes the week-boundary and grid-extent tests deterministic; production callers use the default.
- **The widget tolerates a short list.** Cells past the end of `weeks` draw as no-data, so the 4 × 13 frame is never partially built.

## Verification

**Flutter is not installed in this environment, and per `CLAUDE.md` it was not installed** — so `flutter analyze` and `flutter test` were never run locally. The `flutter_ci.yml` check on this PR is the verification, and `analyze_and_test` is **green on `978ba24`**. The diff is additive (no existing behaviour altered) and was self-reviewed before each push.

Tests added:

- `test/features/weight/weekly_weight_change_test.dart` — 21 cases over `InMemoryWeightRepository`: grid extent and ordering, Sunday starts, the 4-entry threshold at 3 and at 4, boundary non-carry, out-of-grid and future-dated entries, chronological rather than insertion order, unit selection, and every bucket edge in both kg and lb.
- `test/ui/widgets/weekly_change_heatmap_test.dart` — 52 cells in 4 rows, no-data colouring, gain vs. loss distinguishable, magnitude darkening, current week last, short-list tolerance.
- `test/ui/pages/home_page_test.dart` — the grid appears under the title block and above the history header once a week has data, and stays hidden when none does.

A second commit (`978ba24`) responds to the independent review below: it pins the grid shape to `WeightAnalytics.heatmapWeeks` rather than a hardcoded 52, and asserts `weeks > 0`. See [that comment](https://github.com/igorbasko01/food-locker/pull/114#issuecomment-5465466003) for what was fixed and what was deliberately left as follow-up.

## Known gaps — follow-up material, not blockers

- **Accessibility, as the issue accepted.** Red/green is the only signal, with no legend, lightness ramp, or texture cue.
- **Mixed-unit weeks.** A week holding both kg and lb entries yields an unconverted delta. Latent only — `AddWeightDialog` hard-codes kilograms; a hand-edited backup is the sole route in.
- **`weeklyChanges` recomputes on every `HomePage` build.** Same shape as the pagination `TODO` already on `WeightManager._weights`.

Closes #105
