### PR TITLE
refactor: route every displayed date through core/date_format.dart

### DIFF
--- a/lib/core/date_format.dart
+++ b/lib/core/date_format.dart
@@ -2,10 +2,11 @@ import 'dart:ui';
 
 import 'package:intl/intl.dart';
 
-/// Locale-aware numeric date formatting for every date the app displays.
+/// Locale-aware date and time formatting for everything the app displays.
 ///
 /// Dates are drawn in the device locale's field order — `7/14` under `en_US`,
-/// `14/7` under `en_GB` — as numbers, never month names. Both helpers default to
+/// `14/7` under `en_GB` — as numbers, never month names, and times follow the
+/// locale's clock convention. Every helper defaults to
 /// [PlatformDispatcher.instance.locale]; an explicit [locale] override keeps them
 /// deterministic under test. Non-`en_US` locales need `initializeDateFormatting()`
 /// (called once at startup in `main.dart`).
@@ -17,5 +18,9 @@ String shortDate(DateTime date, [String? locale]) =>
 /// Numeric year/month/day in [locale] order, the default where space allows.
 String fullDate(DateTime date, [String? locale]) =>
     DateFormat.yMd(locale ?? _deviceLocale).format(date);
+
+/// The clock time, 12- or 24-hour as [locale] dictates.
+String shortTime(DateTime at, [String? locale]) =>
+    DateFormat.jm(locale ?? _deviceLocale).format(at);
 
 String get _deviceLocale => PlatformDispatcher.instance.locale.toString();

--- a/lib/core/date_format.dart
+++ b/lib/core/date_format.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:intl/intl.dart';
 
-/// Locale-aware numeric date formatting for charts and stat tiles.
+/// Locale-aware numeric date formatting for every date the app displays.
 ///
 /// Dates are drawn in the device locale's field order — `7/14` under `en_US`,
 /// `14/7` under `en_GB` — as numbers, never month names. Both helpers default to
@@ -14,7 +14,7 @@ import 'package:intl/intl.dart';
 String shortDate(DateTime date, [String? locale]) =>
     DateFormat.Md(locale ?? _deviceLocale).format(date);
 
-/// Numeric year/month/day in [locale] order, for chart tooltips.
+/// Numeric year/month/day in [locale] order, the default where space allows.
 String fullDate(DateTime date, [String? locale]) =>
     DateFormat.yMd(locale ?? _deviceLocale).format(date);
 

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -284,7 +284,7 @@ class _MealBreakdownCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final title = isToday ? 'Today\'s meals' : shortDate(breakdown.day);
+    final title = isToday ? 'Today\'s meals' : fullDate(breakdown.day);
     return Card(
       elevation: 0,
       margin: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 16.0),

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -182,7 +182,7 @@ class _StatTilesRow extends StatelessWidget {
               child: StatTile(
                 label: '30-day max',
                 value: max == null ? '—' : max.count.toString(),
-                subLabel: max == null ? null : _formatDay(max.day),
+                subLabel: max == null ? null : shortDate(max.day),
               ),
             ),
           ],
@@ -194,10 +194,6 @@ class _StatTilesRow extends StatelessWidget {
   /// A whole-bite figure, with `—` for the no-qualifying-day case (average 0).
   static String _formatAverage(double average) =>
       average == 0 ? '—' : average.toStringAsFixed(0);
-
-  /// A day in the device locale's numeric order, matching the daily-bites
-  /// chart's axis labels.
-  static String _formatDay(DateTime day) => shortDate(day);
 }
 
 /// A meals summary: today's meal count, the 30-day average meals per day, and

--- a/lib/ui/pages/weight_page.dart
+++ b/lib/ui/pages/weight_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/ui/widgets/add_weight_dialog.dart';
@@ -88,8 +89,7 @@ class WeightPage extends StatelessWidget {
                   delegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final item = history[index];
-                      // Format date nicely
-                      final dateStr = '${item.date.year}-${item.date.month.toString().padLeft(2, '0')}-${item.date.day.toString().padLeft(2, '0')}';
+                      final dateStr = fullDate(item.date);
 
                       return Dismissible(
                         key: ValueKey(item.date),

--- a/lib/ui/widgets/add_weight_dialog.dart
+++ b/lib/ui/widgets/add_weight_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 
 class AddWeightDialog extends StatefulWidget {
@@ -71,7 +72,7 @@ class _AddWeightDialogState extends State<AddWeightDialog> {
                     });
                   }
                 },
-                child: Text('${_selectedDate.year}-${_selectedDate.month.toString().padLeft(2, '0')}-${_selectedDate.day.toString().padLeft(2, '0')}'),
+                child: Text(fullDate(_selectedDate)),
               ),
             ],
           ),

--- a/lib/ui/widgets/meal_breakdown_list.dart
+++ b/lib/ui/widgets/meal_breakdown_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 
 /// The meal-by-meal breakdown of a single day: one row per meal with its bite
@@ -68,7 +69,7 @@ class _MealRow extends StatelessWidget {
                   Text('Meal $index', style: theme.textTheme.titleSmall),
                   const SizedBox(height: 2),
                   Text(
-                    '${_formatTime(meal.start)} – ${_formatTime(meal.end)}',
+                    '${shortTime(meal.start)} – ${shortTime(meal.end)}',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
@@ -155,12 +156,4 @@ class _TotalRow extends StatelessWidget {
       ),
     );
   }
-}
-
-/// A local time as `h:mm AM/PM`, 12-hour with no leading zero on the hour.
-String _formatTime(DateTime at) {
-  final hour12 = at.hour % 12 == 0 ? 12 : at.hour % 12;
-  final minute = at.minute.toString().padLeft(2, '0');
-  final period = at.hour < 12 ? 'AM' : 'PM';
-  return '$hour12:$minute $period';
 }

--- a/lib/ui/widgets/weight_history_tile.dart
+++ b/lib/ui/widgets/weight_history_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/ui/widgets/weight_change_indicator.dart';
 
@@ -15,7 +16,7 @@ class WeightHistoryTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final dateStr = '${item.date.year}-${item.date.month.toString().padLeft(2, '0')}-${item.date.day.toString().padLeft(2, '0')}';
+    final dateStr = fullDate(item.date);
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),

--- a/test/core/date_format_test.dart
+++ b/test/core/date_format_test.dart
@@ -25,4 +25,15 @@ void main() {
     expect(_fields(fullDate(date, 'en_US')), [7, 14, 2026]); // 7/14/2026
     expect(_fields(fullDate(date, 'en_GB')), [14, 7, 2026]); // 14/7/2026
   });
+
+  test('shortTime follows the locale clock convention', () {
+    final afternoon = DateTime(2026, 7, 14, 13, 30);
+
+    // en_US is 12-hour with a day period; the separator before it is locale
+    // data (a narrow no-break space in current CLDR), so match on the parts.
+    expect(shortTime(afternoon, 'en_US'), startsWith('1:30'));
+    expect(shortTime(afternoon, 'en_US'), contains('PM'));
+
+    expect(shortTime(afternoon, 'en_GB'), '13:30');
+  });
 }

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -3,6 +3,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
@@ -317,11 +318,12 @@ void main() {
     expect(find.text('12 bites'), findsNWidgets(2));
 
     // Tap yesterday's bar → card follows it: back control appears, the today
-    // title is gone, and yesterday's 20-bite meal shows.
+    // title gives way to yesterday's date, and its 20-bite meal shows.
     tapBar(tester, 0);
     await tester.pumpAndSettle();
 
     expect(find.text('Today\'s meals'), findsNothing);
+    expect(find.text(fullDate(yesterday)), findsOneWidget);
     expect(find.text('Back to today'), findsOneWidget);
     expect(find.text('20 bites'), findsNWidgets(2));
 

--- a/test/ui/pages/home_page_test.dart
+++ b/test/ui/pages/home_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/core/date_range.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
@@ -8,9 +9,6 @@ import 'package:food_locker/ui/theme.dart';
 import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
 import 'package:food_locker/ui/widgets/weight_history_tile.dart';
 import 'package:provider/provider.dart';
-
-String _dateLabel(DateTime date) =>
-    '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
 
 void main() {
   final now = DateTime.now();
@@ -107,7 +105,7 @@ void main() {
     manager.selectHistoryRange(const DateRange.lastDays(30));
     await tester.pump();
 
-    expect(find.text(_dateLabel(daysAgo(20))), findsOneWidget);
+    expect(find.text(fullDate(daysAgo(20))), findsOneWidget);
   });
 
   testWidgets('the history lists every entry in the selected range', (
@@ -126,7 +124,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(WeightHistoryTile), findsNWidgets(10));
-    expect(find.text(_dateLabel(daysAgo(9))), findsOneWidget);
+    expect(find.text(fullDate(daysAgo(9))), findsOneWidget);
   });
 
   testWidgets('the heatmap sits under the title block once a week has data', (

--- a/test/ui/pages/weight_page_test.dart
+++ b/test/ui/pages/weight_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/core/date_range.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
@@ -8,9 +9,6 @@ import 'package:food_locker/ui/theme.dart';
 import 'package:food_locker/ui/widgets/history_range_selector.dart';
 import 'package:food_locker/ui/widgets/stat_tile.dart';
 import 'package:provider/provider.dart';
-
-String _dateLabel(DateTime date) =>
-    '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
 
 void main() {
   Future<void> pumpPage(WidgetTester tester, WeightManager manager) async {
@@ -71,9 +69,9 @@ void main() {
 
     await pumpPage(tester, manager);
 
-    expect(find.text(_dateLabel(recentDay)), findsOneWidget);
+    expect(find.text(fullDate(recentDay)), findsOneWidget);
     expect(find.text('71.0 kg'), findsOneWidget);
-    expect(find.text(_dateLabel(oldDay)), findsNothing);
+    expect(find.text(fullDate(oldDay)), findsNothing);
     expect(find.text('73.0 kg'), findsNothing);
   });
 
@@ -98,7 +96,7 @@ void main() {
     await tester.tap(find.text('Last 30 days').last);
     await tester.pumpAndSettle();
 
-    expect(find.text(_dateLabel(lastMonth)), findsOneWidget);
+    expect(find.text(fullDate(lastMonth)), findsOneWidget);
     expect(find.text('73.0 kg'), findsOneWidget);
     expect(manager.historyRange, const DateRange.lastDays(30));
   });

--- a/test/ui/widgets/add_weight_dialog_test.dart
+++ b/test/ui/widgets/add_weight_dialog_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
+import 'package:food_locker/ui/theme.dart';
+import 'package:food_locker/ui/widgets/add_weight_dialog.dart';
+
+void main() {
+  Future<void> pumpDialog(WidgetTester tester, DateTime initialDate) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: appTheme,
+        home: Scaffold(body: AddWeightDialog(initialDate: initialDate)),
+      ),
+    );
+  }
+
+  testWidgets('the date button renders the picked date locale-aware', (
+    tester,
+  ) async {
+    final date = DateTime(2026, 3, 8);
+
+    await pumpDialog(tester, date);
+
+    expect(find.text(fullDate(date)), findsOneWidget);
+  });
+}

--- a/test/ui/widgets/meal_breakdown_list_test.dart
+++ b/test/ui/widgets/meal_breakdown_list_test.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/date_format.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/ui/theme.dart';
 import 'package:food_locker/ui/widgets/meal_breakdown_list.dart';
+
+String _span(int fromHour, int fromMinute, int toHour, int toMinute) =>
+    '${shortTime(DateTime(2026, 7, 16, fromHour, fromMinute))} – '
+    '${shortTime(DateTime(2026, 7, 16, toHour, toMinute))}';
 
 void main() {
   Future<void> pumpList(WidgetTester tester, DayMealBreakdown breakdown) async {
@@ -47,9 +52,9 @@ void main() {
     expect(find.text('5 bites'), findsOneWidget);
     expect(find.text('Total'), findsOneWidget);
     expect(find.text('32 bites'), findsOneWidget);
-    // A morning and an afternoon meal read as 12-hour times.
-    expect(find.text('8:00 AM – 8:11 AM'), findsOneWidget);
-    expect(find.text('1:30 PM – 1:44 PM'), findsOneWidget);
+    // Each meal's span reads as a pair of locale-formatted clock times.
+    expect(find.text(_span(8, 0, 8, 11)), findsOneWidget);
+    expect(find.text(_span(13, 30, 13, 44)), findsOneWidget);
   });
 
   testWidgets('renders the snack total on an all-snack day with no meals', (


### PR DESCRIPTION
## What changed

Every date **and time** the app displays now goes through `lib/core/date_format.dart`, so the same day reads identically in a weight row and in the chart tooltip above it, and clock times follow the device locale.

The three hand-rolled `YYYY-MM-DD` sites named in the issue now call `fullDate`:

- `lib/ui/widgets/weight_history_tile.dart:19`
- `lib/ui/pages/weight_page.dart:91` (the stale `// Format date nicely` comment went with it)
- `lib/ui/widgets/add_weight_dialog.dart:75`

And the one site the issue asked to re-bucket:

- `lib/ui/pages/bite_analytics_page.dart:287` — the meal-breakdown card title moves `shortDate` → `fullDate`, since it has the room.

Left on `shortDate` per the rule (space is tight): the two chart axis labels (`weight_chart.dart:76`, `daily_bites_chart.dart:247`) and the `30-day max` stat tile sub-label. Tooltips and the bites accessibility summary were already on `fullDate` and are untouched.

The `date_format.dart` header and the `fullDate` doc comment said "for charts and stat tiles" / "for chart tooltips", which stopped being true with this change — both now state the app-wide rule instead.

### Follow-up commit — the two review items you asked for

- **Time locale (`meal_breakdown_list.dart:160-166`).** That file hand-rolled `h:mm AM/PM` — the last display formatter in `lib/` outside `date_format.dart`, and a real bug for anyone on a 24-hour locale, who still got `1:30 PM`. A new `shortTime` helper (`DateFormat.jm`) joins `shortDate`/`fullDate`, and the meal rows use it: `1:30 PM` under `en_US`, `13:30` under `en_GB`.
- **The date pass-through (`bite_analytics_page.dart:200`).** `_formatDay` was a single-caller alias for `shortDate`; the `30-day max` sub-label now calls the helper directly and the alias is gone.

`lib/` now contains no date or time formatting outside `core/date_format.dart`.

## How the issue is met

- **All three hand-rolled sites moved onto the shared helpers.** Done, as listed above — no `padLeft`-built date strings remain in `lib/`.
- **`shortDate` where space is tight, `fullDate` everywhere else.** Applied exactly as the issue specifies, including the meal-breakdown title's move to `fullDate`.
- **Existing widget tests assert on the `YYYY-MM-DD` strings and will need updating.** `test/ui/pages/weight_page_test.dart` and `test/ui/pages/home_page_test.dart` each carried a private `_dateLabel` helper that rebuilt the ISO string; both are deleted and the assertions now call `fullDate` directly, so the tests read the date through the same helper the widget does.

## Tests

- `test/ui/pages/weight_page_test.dart`, `test/ui/pages/home_page_test.dart` — updated to expect the locale-aware string.
- `test/ui/pages/bite_analytics_page_test.dart` — the day-selection test now asserts the non-today meal card is titled `fullDate(yesterday)`, which is the behaviour this PR changes; previously it only checked that the `Today's meals` title was gone.
- `test/ui/widgets/add_weight_dialog_test.dart` — new, covering the dialog's date button. It was the one changed site with no test at all.
- `test/core/date_format_test.dart` — `shortTime` is pinned against both conventions: 12-hour with a day period under `en_US`, `13:30` under `en_GB`.
- `test/ui/widgets/meal_breakdown_list_test.dart` — the two meal-span assertions were `'8:00 AM – 8:11 AM'` literals. They now build the expected span through `shortTime`, because current CLDR puts a narrow no-break space (U+202F) before `AM`/`PM`, so a plain-space literal no longer matches what `intl` renders.

## Decisions

- **Tests compute the expected string with `fullDate(date)` / `shortTime(at)` rather than pinned-locale literals.** Both the widget and the test then resolve the locale the same way, so the assertions hold on any runner. `test/core/date_format_test.dart` covers the format contracts themselves with explicit `en_US`/`en_GB` overrides.
- **No weekday added anywhere.** That is #116, which explicitly builds on this consolidation; this PR is the groundwork only.
- **Title still says `refactor:`, matching #117's own title** — flagged because the squashed subject is the only lever and `refactor:` is hidden from the release-please changelog, while this PR does change what users see (dates, and now times on 24-hour locales). Worth overriding to `fix:` at merge if you want it in the notes.

## Verification

Flutter is not installed in this session and `CLAUDE.md` says not to install it, so `flutter analyze` and `flutter test` were **not** run locally — verification is deferred to the `flutter_ci.yml` checks on this PR. `analyze_and_test` is green on both commits.

Closes #117