### PR TITLE
feat: show the weekday alongside every displayed date

### DIFF
--- a/lib/core/date_format.dart
+++ b/lib/core/date_format.dart
@@ -5,19 +5,31 @@ import 'package:intl/intl.dart';
 /// Locale-aware date and time formatting for everything the app displays.
 ///
 /// Dates are drawn in the device locale's field order — `7/14` under `en_US`,
-/// `14/7` under `en_GB` — as numbers, never month names, and times follow the
-/// locale's clock convention. Every helper defaults to
-/// [PlatformDispatcher.instance.locale]; an explicit [locale] override keeps them
-/// deterministic under test. Non-`en_US` locales need `initializeDateFormatting()`
-/// (called once at startup in `main.dart`).
+/// `14/7` under `en_GB` — with numeric months, never month names, and times
+/// follow the locale's clock convention. The `WithWeekday` variants add the
+/// abbreviated weekday name, placed where the locale puts it. Every helper
+/// defaults to [PlatformDispatcher.instance.locale]; an explicit [locale]
+/// override keeps them deterministic under test. Non-`en_US` locales need
+/// `initializeDateFormatting()` (called once at startup in `main.dart`).
 
-/// Numeric month/day in [locale] order, for axis labels and stat tiles.
+/// Numeric month/day in [locale] order, for chart axis labels.
 String shortDate(DateTime date, [String? locale]) =>
     DateFormat.Md(locale ?? _deviceLocale).format(date);
 
-/// Numeric year/month/day in [locale] order, the default where space allows.
+/// Numeric year/month/day in [locale] order, without the weekday.
 String fullDate(DateTime date, [String? locale]) =>
     DateFormat.yMd(locale ?? _deviceLocale).format(date);
+
+/// [shortDate] carrying the abbreviated weekday, e.g. `Tue, 7/14`.
+String shortDateWithWeekday(DateTime date, [String? locale]) =>
+    DateFormat.MEd(locale ?? _deviceLocale).format(date);
+
+/// [fullDate] carrying the abbreviated weekday, e.g. `Tue, 7/14/2026`.
+///
+/// The default where a date is read; [shortDate] and [fullDate] stay for chart
+/// axes and anywhere else too tight for the weekday.
+String fullDateWithWeekday(DateTime date, [String? locale]) =>
+    DateFormat.yMEd(locale ?? _deviceLocale).format(date);
 
 /// The clock time, 12- or 24-hour as [locale] dictates.
 String shortTime(DateTime at, [String? locale]) =>

--- a/lib/ui/pages/bite_analytics_page.dart
+++ b/lib/ui/pages/bite_analytics_page.dart
@@ -182,7 +182,7 @@ class _StatTilesRow extends StatelessWidget {
               child: StatTile(
                 label: '30-day max',
                 value: max == null ? '—' : max.count.toString(),
-                subLabel: max == null ? null : shortDate(max.day),
+                subLabel: max == null ? null : shortDateWithWeekday(max.day),
               ),
             ),
           ],
@@ -280,7 +280,9 @@ class _MealBreakdownCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final title = isToday ? 'Today\'s meals' : fullDate(breakdown.day);
+    final title = isToday
+        ? 'Today\'s meals'
+        : fullDateWithWeekday(breakdown.day);
     return Card(
       elevation: 0,
       margin: const EdgeInsets.fromLTRB(16.0, 0, 16.0, 16.0),

--- a/lib/ui/pages/weight_page.dart
+++ b/lib/ui/pages/weight_page.dart
@@ -89,7 +89,7 @@ class WeightPage extends StatelessWidget {
                   delegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final item = history[index];
-                      final dateStr = fullDate(item.date);
+                      final dateStr = fullDateWithWeekday(item.date);
 
                       return Dismissible(
                         key: ValueKey(item.date),

--- a/lib/ui/widgets/add_weight_dialog.dart
+++ b/lib/ui/widgets/add_weight_dialog.dart
@@ -72,7 +72,7 @@ class _AddWeightDialogState extends State<AddWeightDialog> {
                     });
                   }
                 },
-                child: Text(fullDate(_selectedDate)),
+                child: Text(fullDateWithWeekday(_selectedDate)),
               ),
             ],
           ),

--- a/lib/ui/widgets/daily_bites_chart.dart
+++ b/lib/ui/widgets/daily_bites_chart.dart
@@ -168,7 +168,7 @@ class DailyBitesChart extends StatelessWidget {
       );
     }
     if (selected != null) {
-      summary.write(' Selected day ${fullDate(selected)}.');
+      summary.write(' Selected day ${fullDateWithWeekday(selected)}.');
     }
     final semanticsLabel = summary.toString();
 
@@ -285,7 +285,7 @@ class DailyBitesChart extends StatelessWidget {
               final weightLine =
                   weight == null ? '' : '\n${weight.toStringAsFixed(1)} kg';
               return BarTooltipItem(
-                '${fullDate(day)}\n${rod.toY.toInt()} bites$weightLine',
+                '${fullDateWithWeekday(day)}\n${rod.toY.toInt()} bites$weightLine',
                 const TextStyle(
                   color: Colors.white,
                   fontWeight: FontWeight.bold,

--- a/lib/ui/widgets/weight_chart.dart
+++ b/lib/ui/widgets/weight_chart.dart
@@ -90,7 +90,7 @@ class WeightChart extends StatelessWidget {
                 return touchedSpots.map((spot) {
                   final date = DateTime.fromMillisecondsSinceEpoch(spot.x.toInt());
                   return LineTooltipItem(
-                    '${fullDate(date)}\n${spot.y} kg',
+                    '${fullDateWithWeekday(date)}\n${spot.y} kg',
                     const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
                   );
                 }).toList();

--- a/lib/ui/widgets/weight_history_tile.dart
+++ b/lib/ui/widgets/weight_history_tile.dart
@@ -16,7 +16,7 @@ class WeightHistoryTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final dateStr = fullDate(item.date);
+    final dateStr = fullDateWithWeekday(item.date);
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),

--- a/test/core/date_format_test.dart
+++ b/test/core/date_format_test.dart
@@ -26,6 +26,25 @@ void main() {
     expect(_fields(fullDate(date, 'en_GB')), [14, 7, 2026]); // 14/7/2026
   });
 
+  test('the WithWeekday variants keep the locale field order', () {
+    expect(_fields(shortDateWithWeekday(date, 'en_US')), [7, 14]);
+    expect(_fields(shortDateWithWeekday(date, 'en_GB')), [14, 7]);
+    expect(_fields(fullDateWithWeekday(date, 'en_US')), [7, 14, 2026]);
+    expect(_fields(fullDateWithWeekday(date, 'en_GB')), [14, 7, 2026]);
+  });
+
+  test('the WithWeekday variants name the weekday in three letters', () {
+    // Narrow weekday names collide (Sunday and Saturday are both `S`), so the
+    // abbreviated form is the point of these helpers.
+    expect(shortDateWithWeekday(date, 'en_US'), startsWith('Tue'));
+    expect(fullDateWithWeekday(date, 'en_US'), startsWith('Tue'));
+  });
+
+  test('the numeric variants stay free of the weekday, for chart axes', () {
+    expect(shortDate(date, 'en_US'), isNot(contains('Tue')));
+    expect(fullDate(date, 'en_US'), isNot(contains('Tue')));
+  });
+
   test('shortTime follows the locale clock convention', () {
     final afternoon = DateTime(2026, 7, 14, 13, 30);
 

--- a/test/ui/pages/bite_analytics_page_test.dart
+++ b/test/ui/pages/bite_analytics_page_test.dart
@@ -74,7 +74,7 @@ void main() {
 
   Future<void> pumpPage(WidgetTester tester) async {
     // Pin the locale so the 30-day-max tile's date renders deterministically
-    // (`shortDate` formats against the platform locale).
+    // (`shortDateWithWeekday` formats against the platform locale).
     tester.platformDispatcher.localeTestValue = const Locale('en', 'US');
     addTearDown(tester.platformDispatcher.clearLocaleTestValue);
     await tester.pumpWidget(
@@ -127,7 +127,7 @@ void main() {
     expect(
       find.descendant(
         of: maxTile,
-        matching: find.text('${yesterday.month}/${yesterday.day}'),
+        matching: find.text(shortDateWithWeekday(yesterday)),
       ),
       findsOneWidget,
     );
@@ -323,7 +323,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Today\'s meals'), findsNothing);
-    expect(find.text(fullDate(yesterday)), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(yesterday)), findsOneWidget);
     expect(find.text('Back to today'), findsOneWidget);
     expect(find.text('20 bites'), findsNWidgets(2));
 

--- a/test/ui/pages/home_page_test.dart
+++ b/test/ui/pages/home_page_test.dart
@@ -105,7 +105,7 @@ void main() {
     manager.selectHistoryRange(const DateRange.lastDays(30));
     await tester.pump();
 
-    expect(find.text(fullDate(daysAgo(20))), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(daysAgo(20))), findsOneWidget);
   });
 
   testWidgets('the history lists every entry in the selected range', (
@@ -124,7 +124,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(WeightHistoryTile), findsNWidgets(10));
-    expect(find.text(fullDate(daysAgo(9))), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(daysAgo(9))), findsOneWidget);
   });
 
   testWidgets('the heatmap sits under the title block once a week has data', (

--- a/test/ui/pages/weight_page_test.dart
+++ b/test/ui/pages/weight_page_test.dart
@@ -69,9 +69,9 @@ void main() {
 
     await pumpPage(tester, manager);
 
-    expect(find.text(fullDate(recentDay)), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(recentDay)), findsOneWidget);
     expect(find.text('71.0 kg'), findsOneWidget);
-    expect(find.text(fullDate(oldDay)), findsNothing);
+    expect(find.text(fullDateWithWeekday(oldDay)), findsNothing);
     expect(find.text('73.0 kg'), findsNothing);
   });
 
@@ -96,7 +96,7 @@ void main() {
     await tester.tap(find.text('Last 30 days').last);
     await tester.pumpAndSettle();
 
-    expect(find.text(fullDate(lastMonth)), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(lastMonth)), findsOneWidget);
     expect(find.text('73.0 kg'), findsOneWidget);
     expect(manager.historyRange, const DateRange.lastDays(30));
   });

--- a/test/ui/widgets/add_weight_dialog_test.dart
+++ b/test/ui/widgets/add_weight_dialog_test.dart
@@ -21,6 +21,6 @@ void main() {
 
     await pumpDialog(tester, date);
 
-    expect(find.text(fullDate(date)), findsOneWidget);
+    expect(find.text(fullDateWithWeekday(date)), findsOneWidget);
   });
 }

--- a/test/ui/widgets/daily_bites_chart_test.dart
+++ b/test/ui/widgets/daily_bites_chart_test.dart
@@ -161,7 +161,7 @@ void main() {
     expect(
       find.bySemanticsLabel(
         'Daily bites bar chart, 2 days. Highest day 60 bites. '
-        'Selected day ${fullDate(DateTime(2026, 1, 2))}.',
+        'Selected day ${fullDateWithWeekday(DateTime(2026, 1, 2))}.',
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## What changed

`lib/core/date_format.dart` gains two weekday-carrying variants alongside the
existing helpers:

| Helper | `en_US` | `en_GB` |
|---|---|---|
| `shortDateWithWeekday` | `Tue, 7/14` | `Tue, 14/07` |
| `fullDateWithWeekday` | `Tue, 7/14/2026` | `Tue, 14/07/2026` |

Both are built on the ICU `MEd` / `yMEd` skeletons rather than concatenating a
weekday onto the existing output, so the weekday sits where the locale puts it
and the numeric field order is unchanged. `initializeDateFormatting()` is
already called in `main.dart`, so no startup change was needed.

Call sites moved to the weekday variants, exactly the list in the issue:

- `lib/ui/widgets/weight_history_tile.dart` and `lib/ui/pages/weight_page.dart` — the weight rows
- `lib/ui/widgets/add_weight_dialog.dart` — the picked date
- `lib/ui/widgets/weight_chart.dart` — tooltip only
- `lib/ui/widgets/daily_bites_chart.dart` — tooltip and accessibility summary only
- `lib/ui/pages/bite_analytics_page.dart` — the `30-day max` sub-label and the meal-breakdown card title for a non-today day

**Axes stay numeric.** `weight_chart.dart` and `daily_bites_chart.dart` keep
`shortDate` on their `bottomTitles`, and `test/core/date_format_test.dart` now
asserts the numeric helpers carry no weekday, so that guarantee is pinned rather
than left to convention.

`DateFormat.EEEEE` (narrow) is not used anywhere — a test comment records why,
since English narrow names make Sunday and Saturday both `S`.

## Acceptance criteria

- **Short weekday name (`DateFormat.E`), locale-aware numeric ordering kept** — `MEd`/`yMEd` are the `E` skeletons; `date_format_test.dart` asserts the field order is still `[7, 14, 2026]` under `en_US` and `[14, 7, 2026]` under `en_GB` for both new helpers.
- **Extend `date_format.dart`, then use the variants at the call sites** — no widget formats a date inline; every call site above goes through the shared helpers.
- **Charts get the weekday in tooltips only, never on axis labels** — done, and covered by the numeric-variant test above.
- **Update the affected widget tests, which assert numeric-only date strings** — `weight_page_test`, `home_page_test`, `bite_analytics_page_test`, `daily_bites_chart_test` and `add_weight_dialog_test` now assert through the weekday helpers. `bite_analytics_page_test` also had a hand-built `'${yesterday.month}/${yesterday.day}'` string for the 30-day max sub-label; that is now `shortDateWithWeekday(yesterday)` (the test already pins the locale to `en_US`).

## Decisions made along the way

- **Naming:** `shortDateWithWeekday` / `fullDateWithWeekday`, mirroring the existing `shortDate` / `fullDate` pair rather than introducing a different vocabulary.
- **`fullDate` is now unused in `lib/`** — it is still the right helper for anywhere the weekday will not fit, is still tested, and #115 and #119 both reference the numeric helpers, so it stays rather than being deleted as part of this issue's scope.
- **The `30-day max` sub-label got the weekday.** The issue flagged it as the tightest call site and asked for a visual check first. That check was not possible here (no Flutter toolchain or emulator in this session), so the reasoning is written down instead: the sub-label is a `bodySmall`, centre-aligned, unconstrained `Text` inside a third-width tile, and `Tue, 7/14` at 12sp is roughly 60dp against roughly 90dp of available text width. It is included as the issue specified; if it reads badly on a real device, reverting that one line to `shortDate` is the whole fix.
- Neighbouring doc comments in `date_format.dart` were refreshed so they no longer call `fullDate` "the default" — comments only, no behaviour change.

## Verification

Flutter is not installed in this session and `CLAUDE.md` says not to install it,
so `flutter analyze` and `flutter test` were **not** run locally — verification
is deferred to the `flutter_ci.yml` checks on this PR. The diff was
self-reviewed instead: no `*.g.dart` touched, no model, Hive `typeId`, Drift
schema or backup-codec change, and no new imports (every edited file already
imported `core/date_format.dart`).

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMhGMbfDtmsCNgSAoFr1LQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMhGMbfDtmsCNgSAoFr1LQ)_