### PR TITLE
feat: explain the Home heatmap cells and gate weeks on span

### DIFF
--- a/lib/features/weight/data/weekly_weight_change.dart
+++ b/lib/features/weight/data/weekly_weight_change.dart
@@ -13,6 +13,11 @@ class WeeklyWeightChange {
     required DateTime weekStart,
     List<Weight> entries = const [],
   }) {
+    assert(
+      entries.every((entry) => _fallsInWeek(entry, weekStart)),
+      'every weigh-in must fall in the week weekStart opens',
+    );
+
     if (entries.isEmpty) return WeeklyWeightChange._(weekStart: weekStart);
 
     var first = entries.first;
@@ -40,6 +45,9 @@ class WeeklyWeightChange {
   static const int minSpanDays = 3;
 
   /// The Sunday opening the week, at local midnight.
+  ///
+  /// The week's own identity, not something [entries] could supply: a week
+  /// nothing was logged in still has a cell to fill and a period to name.
   final DateTime weekStart;
 
   /// The week's earliest and latest weigh-in, null only for a week that holds
@@ -100,6 +108,17 @@ class WeeklyWeightChange {
   /// `Weight` compares by identity, so weigh-ins are matched on what they say.
   static bool _sameWeighIn(Weight? a, Weight? b) =>
       a?.date == b?.date && a?.value == b?.value && a?.unit == b?.unit;
+
+  /// Whether [entry] falls in the seven days [weekStart] opens.
+  static bool _fallsInWeek(Weight entry, DateTime weekStart) {
+    final day = DateTime(entry.date.year, entry.date.month, entry.date.day);
+    final weekAfter = DateTime(
+      weekStart.year,
+      weekStart.month,
+      weekStart.day + 7,
+    );
+    return !day.isBefore(weekStart) && day.isBefore(weekAfter);
+  }
 
   @override
   String toString() =>

--- a/lib/features/weight/data/weekly_weight_change.dart
+++ b/lib/features/weight/data/weekly_weight_change.dart
@@ -4,21 +4,44 @@ import 'package:food_locker/features/weight/data/weight.dart';
 ///
 /// Intra-week only: [delta] is the week's last weigh-in minus its first, so
 /// nothing carries across a week boundary and every week stands on its own. A
-/// week under [minEntries] weigh-ins reports no [delta] at all.
+/// week whose weigh-ins span fewer than [minSpanDays] days reports no [delta]
+/// at all.
 class WeeklyWeightChange {
-  const WeeklyWeightChange({required this.weekStart, this.delta, this.unit});
+  const WeeklyWeightChange({
+    required this.weekStart,
+    this.delta,
+    this.unit,
+    this.firstDate,
+    this.firstValue,
+    this.lastDate,
+    this.lastValue,
+  });
 
-  /// Weigh-ins a week needs before it reports a [delta].
-  static const int minEntries = 4;
+  /// Days a week's first and last weigh-in must lie apart before it reports a
+  /// [delta].
+  ///
+  /// The span states directly what a delta has to measure — the week, not a
+  /// two-day blip: a Sunday and a Saturday qualify on two weigh-ins, a Monday
+  /// and Tuesday never do. A lone weigh-in spans zero days, so its
+  /// `last - first == 0` cannot render as a faint loss.
+  static const int minSpanDays = 3;
 
   /// The Sunday opening the week, at local midnight.
   final DateTime weekStart;
 
-  /// Last weigh-in of the week minus its first, or null under [minEntries].
+  /// Last weigh-in of the week minus its first, or null under [minSpanDays].
   final double? delta;
 
   /// The unit [delta] is expressed in; null exactly when [delta] is.
   final WeightUnit? unit;
+
+  /// The week's first weigh-in, [delta]'s baseline; null when [delta] is.
+  final DateTime? firstDate;
+  final double? firstValue;
+
+  /// The week's last weigh-in, [delta]'s far end; null when [delta] is.
+  final DateTime? lastDate;
+  final double? lastValue;
 
   bool get hasData => delta != null;
 
@@ -42,12 +65,25 @@ class WeeklyWeightChange {
       other is WeeklyWeightChange &&
       other.weekStart == weekStart &&
       other.delta == delta &&
-      other.unit == unit;
+      other.unit == unit &&
+      other.firstDate == firstDate &&
+      other.firstValue == firstValue &&
+      other.lastDate == lastDate &&
+      other.lastValue == lastValue;
 
   @override
-  int get hashCode => Object.hash(weekStart, delta, unit);
+  int get hashCode => Object.hash(
+    weekStart,
+    delta,
+    unit,
+    firstDate,
+    firstValue,
+    lastDate,
+    lastValue,
+  );
 
   @override
   String toString() =>
-      'WeeklyWeightChange(weekStart: $weekStart, delta: $delta, unit: $unit)';
+      'WeeklyWeightChange(weekStart: $weekStart, delta: $delta, unit: $unit, '
+      'first: $firstValue on $firstDate, last: $lastValue on $lastDate)';
 }

--- a/lib/features/weight/data/weekly_weight_change.dart
+++ b/lib/features/weight/data/weekly_weight_change.dart
@@ -15,7 +15,21 @@ class WeeklyWeightChange {
     this.firstValue,
     this.lastDate,
     this.lastValue,
-  });
+  }) : assert(
+         delta == null
+             ? unit == null &&
+                   firstDate == null &&
+                   firstValue == null &&
+                   lastDate == null &&
+                   lastValue == null
+             : unit != null &&
+                   firstDate != null &&
+                   firstValue != null &&
+                   lastDate != null &&
+                   lastValue != null,
+         'a week reports its delta together with the two weigh-ins and the '
+         'unit behind it, or reports nothing at all',
+       );
 
   /// Days a week's first and last weigh-in must lie apart before it reports a
   /// [delta].

--- a/lib/features/weight/data/weekly_weight_change.dart
+++ b/lib/features/weight/data/weekly_weight_change.dart
@@ -2,34 +2,33 @@ import 'package:food_locker/features/weight/data/weight.dart';
 
 /// One calendar week's weight change, as the Home heatmap reads it.
 ///
-/// Intra-week only: [delta] is the week's last weigh-in minus its first, so
-/// nothing carries across a week boundary and every week stands on its own. A
-/// week whose weigh-ins span fewer than [minSpanDays] days reports no [delta]
-/// at all.
+/// Built from the week's own weigh-ins and derives everything from them:
+/// intra-week only, so nothing carries across a week boundary and every week
+/// stands on its own. A week whose weigh-ins span fewer than [minSpanDays]
+/// days reports no [delta] at all.
 class WeeklyWeightChange {
-  const WeeklyWeightChange({
-    required this.weekStart,
-    this.delta,
-    this.unit,
-    this.firstDate,
-    this.firstValue,
-    this.lastDate,
-    this.lastValue,
-  }) : assert(
-         delta == null
-             ? unit == null &&
-                   firstDate == null &&
-                   firstValue == null &&
-                   lastDate == null &&
-                   lastValue == null
-             : unit != null &&
-                   firstDate != null &&
-                   firstValue != null &&
-                   lastDate != null &&
-                   lastValue != null,
-         'a week reports its delta together with the two weigh-ins and the '
-         'unit behind it, or reports nothing at all',
-       );
+  /// The week [weekStart] opens, measured across [entries] — the week's
+  /// weigh-ins, in any order. An empty list is a week nothing was logged in.
+  factory WeeklyWeightChange({
+    required DateTime weekStart,
+    List<Weight> entries = const [],
+  }) {
+    if (entries.isEmpty) return WeeklyWeightChange._(weekStart: weekStart);
+
+    var first = entries.first;
+    var last = entries.first;
+    for (final entry in entries) {
+      if (entry.date.isBefore(first.date)) first = entry;
+      if (entry.date.isAfter(last.date)) last = entry;
+    }
+    return WeeklyWeightChange._(
+      weekStart: weekStart,
+      first: first,
+      last: last,
+    );
+  }
+
+  const WeeklyWeightChange._({required this.weekStart, this.first, this.last});
 
   /// Days a week's first and last weigh-in must lie apart before it reports a
   /// [delta].
@@ -43,21 +42,18 @@ class WeeklyWeightChange {
   /// The Sunday opening the week, at local midnight.
   final DateTime weekStart;
 
+  /// The week's earliest and latest weigh-in, null only for a week that holds
+  /// none. They are the same weigh-in when the week holds exactly one.
+  final Weight? first;
+  final Weight? last;
+
   /// Last weigh-in of the week minus its first, or null under [minSpanDays].
-  final double? delta;
+  double? get delta => hasData ? last!.value - first!.value : null;
 
   /// The unit [delta] is expressed in; null exactly when [delta] is.
-  final WeightUnit? unit;
+  WeightUnit? get unit => hasData ? last!.unit : null;
 
-  /// The week's first weigh-in, [delta]'s baseline; null when [delta] is.
-  final DateTime? firstDate;
-  final double? firstValue;
-
-  /// The week's last weigh-in, [delta]'s far end; null when [delta] is.
-  final DateTime? lastDate;
-  final double? lastValue;
-
-  bool get hasData => delta != null;
+  bool get hasData => _spanInDays >= minSpanDays;
 
   /// Whether the week ended heavier. A flat week counts as not gained.
   bool get isGain => (delta ?? 0) > 0;
@@ -74,30 +70,40 @@ class WeeklyWeightChange {
     return 4;
   }
 
+  /// Calendar days from the first weigh-in to the last, counted on UTC
+  /// midnights so a daylight-saving shift inside the week cannot shorten it.
+  int get _spanInDays {
+    final from = first?.date;
+    final to = last?.date;
+    if (from == null || to == null) return 0;
+    return DateTime.utc(to.year, to.month, to.day)
+        .difference(DateTime.utc(from.year, from.month, from.day))
+        .inDays;
+  }
+
   @override
   bool operator ==(Object other) =>
       other is WeeklyWeightChange &&
       other.weekStart == weekStart &&
-      other.delta == delta &&
-      other.unit == unit &&
-      other.firstDate == firstDate &&
-      other.firstValue == firstValue &&
-      other.lastDate == lastDate &&
-      other.lastValue == lastValue;
+      _sameWeighIn(other.first, first) &&
+      _sameWeighIn(other.last, last);
 
   @override
   int get hashCode => Object.hash(
     weekStart,
-    delta,
-    unit,
-    firstDate,
-    firstValue,
-    lastDate,
-    lastValue,
+    first?.date,
+    first?.value,
+    last?.date,
+    last?.value,
   );
+
+  /// `Weight` compares by identity, so weigh-ins are matched on what they say.
+  static bool _sameWeighIn(Weight? a, Weight? b) =>
+      a?.date == b?.date && a?.value == b?.value && a?.unit == b?.unit;
 
   @override
   String toString() =>
       'WeeklyWeightChange(weekStart: $weekStart, delta: $delta, unit: $unit, '
-      'first: $firstValue on $firstDate, last: $lastValue on $lastDate)';
+      'first: ${first?.value} on ${first?.date}, '
+      'last: ${last?.value} on ${last?.date})';
 }

--- a/lib/features/weight/data/weight_analytics.dart
+++ b/lib/features/weight/data/weight_analytics.dart
@@ -47,19 +47,34 @@ class WeightAnalytics {
   }
 
   static WeeklyWeightChange _change(DateTime weekStart, List<Weight>? entries) {
-    if (entries == null || entries.length < WeeklyWeightChange.minEntries) {
+    if (entries == null || entries.isEmpty) {
       return WeeklyWeightChange(weekStart: weekStart);
     }
 
     entries.sort((a, b) => a.date.compareTo(b.date));
     final first = entries.first;
     final last = entries.last;
+    if (_daysBetween(first.date, last.date) < WeeklyWeightChange.minSpanDays) {
+      return WeeklyWeightChange(weekStart: weekStart);
+    }
+
     return WeeklyWeightChange(
       weekStart: weekStart,
       delta: last.value - first.value,
       unit: last.unit,
+      firstDate: first.date,
+      firstValue: first.value,
+      lastDate: last.date,
+      lastValue: last.value,
     );
   }
+
+  /// Calendar days from [from] to [to], counted on UTC midnights so a
+  /// daylight-saving shift inside the week cannot shorten the span.
+  static int _daysBetween(DateTime from, DateTime to) =>
+      DateTime.utc(to.year, to.month, to.day)
+          .difference(DateTime.utc(from.year, from.month, from.day))
+          .inDays;
 
   /// The Sunday opening [date]'s week, at local midnight. Dart counts Mon=1…
   /// Sun=7, so `% 7` maps Sunday to a zero offset.

--- a/lib/features/weight/data/weight_analytics.dart
+++ b/lib/features/weight/data/weight_analytics.dart
@@ -42,39 +42,13 @@ class WeightAnalytics {
     }
 
     return [
-      for (final start in weekStarts) _change(start, entriesByWeek[start]),
+      for (final start in weekStarts)
+        WeeklyWeightChange(
+          weekStart: start,
+          entries: entriesByWeek[start] ?? const [],
+        ),
     ];
   }
-
-  static WeeklyWeightChange _change(DateTime weekStart, List<Weight>? entries) {
-    if (entries == null || entries.isEmpty) {
-      return WeeklyWeightChange(weekStart: weekStart);
-    }
-
-    entries.sort((a, b) => a.date.compareTo(b.date));
-    final first = entries.first;
-    final last = entries.last;
-    if (_daysBetween(first.date, last.date) < WeeklyWeightChange.minSpanDays) {
-      return WeeklyWeightChange(weekStart: weekStart);
-    }
-
-    return WeeklyWeightChange(
-      weekStart: weekStart,
-      delta: last.value - first.value,
-      unit: last.unit,
-      firstDate: first.date,
-      firstValue: first.value,
-      lastDate: last.date,
-      lastValue: last.value,
-    );
-  }
-
-  /// Calendar days from [from] to [to], counted on UTC midnights so a
-  /// daylight-saving shift inside the week cannot shorten the span.
-  static int _daysBetween(DateTime from, DateTime to) =>
-      DateTime.utc(to.year, to.month, to.day)
-          .difference(DateTime.utc(from.year, from.month, from.day))
-          .inDays;
 
   /// The Sunday opening [date]'s week, at local midnight. Dart counts Mon=1…
   /// Sun=7, so `% 7` maps Sunday to a zero offset.

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
 import 'package:food_locker/ui/widgets/weekly_change_color.dart';
+import 'package:food_locker/ui/widgets/weekly_change_summary.dart';
 
 /// A year of weekly weight change as a grid of coloured cells.
 ///
 /// Fills row by row, oldest top-left to newest bottom-right, so the last cell
-/// is the week in progress. Unlabelled and non-interactive by design.
+/// is the week in progress. Holding a cell names the week it covers and the
+/// weigh-ins its colour came from.
 class WeeklyChangeHeatmap extends StatelessWidget {
   const WeeklyChangeHeatmap({super.key, required this.weeks});
 
@@ -24,33 +26,65 @@ class WeeklyChangeHeatmap extends StatelessWidget {
           Row(
             children: [
               for (var column = 0; column < columns; column++)
-                Expanded(child: _Cell(color: _colorAt(row * columns + column))),
+                Expanded(child: _Cell(week: _weekAt(row * columns + column))),
             ],
           ),
       ],
     );
   }
 
-  Color _colorAt(int index) => index < weeks.length
-      ? weeklyChangeColor(weeks[index])
-      : weeklyChangeNoDataColor;
+  WeeklyWeightChange? _weekAt(int index) =>
+      index < weeks.length ? weeks[index] : null;
 }
 
-class _Cell extends StatelessWidget {
-  const _Cell({required this.color});
+class _Cell extends StatefulWidget {
+  const _Cell({required this.week});
 
-  final Color color;
+  /// The week this cell draws, or null past the end of the grid.
+  final WeeklyWeightChange? week;
+
+  @override
+  State<_Cell> createState() => _CellState();
+}
+
+class _CellState extends State<_Cell> {
+  final GlobalKey<TooltipState> _tooltip = GlobalKey<TooltipState>();
 
   @override
   Widget build(BuildContext context) {
+    final week = widget.week;
+    final summary = weeklyChangeSummary(week);
+
     return Padding(
       padding: const EdgeInsets.all(2),
       child: AspectRatio(
         aspectRatio: 1,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: color,
-            borderRadius: BorderRadius.circular(3),
+        child: Semantics(
+          label: summary.join('. '),
+          excludeSemantics: true,
+          child: Tooltip(
+            key: _tooltip,
+            message: summary.join('\n'),
+            // Shown and hidden below, so the week reads for exactly as long
+            // as the finger is down.
+            triggerMode: TooltipTriggerMode.manual,
+            enableTapToDismiss: false,
+            excludeFromSemantics: true,
+            child: Listener(
+              behavior: HitTestBehavior.opaque,
+              onPointerDown: (_) =>
+                  _tooltip.currentState?.ensureTooltipVisible(),
+              onPointerUp: (_) => Tooltip.dismissAllToolTips(),
+              onPointerCancel: (_) => Tooltip.dismissAllToolTips(),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: week == null
+                      ? weeklyChangeNoDataColor
+                      : weeklyChangeColor(week),
+                  borderRadius: BorderRadius.circular(3),
+                ),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -91,6 +91,12 @@ class _CellState extends State<_Cell> {
             triggerMode: TooltipTriggerMode.manual,
             enableTapToDismiss: false,
             excludeFromSemantics: true,
+            // Above the cell and clear of the fingertip holding it: the
+            // offset is measured from the cell's centre, and a cell is a few
+            // millimetres across. Flutter drops it below for a cell too near
+            // the top to fit.
+            preferBelow: false,
+            verticalOffset: 36,
             child: Listener(
               behavior: HitTestBehavior.opaque,
               onPointerDown: _showTooltip,

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
 import 'package:food_locker/ui/widgets/weekly_change_color.dart';
@@ -8,8 +7,9 @@ import 'package:food_locker/ui/widgets/weekly_change_summary.dart';
 ///
 /// Fills row by row, oldest top-left to newest bottom-right, so the last cell
 /// is the week in progress. Holding a cell names the week it covers and the
-/// weigh-ins its colour came from.
-class WeeklyChangeHeatmap extends StatelessWidget {
+/// weigh-ins its colour came from; dragging carries that readout from cell to
+/// cell, and lifting ends it.
+class WeeklyChangeHeatmap extends StatefulWidget {
   const WeeklyChangeHeatmap({super.key, required this.weeks});
 
   static const int rows = 4;
@@ -20,99 +20,203 @@ class WeeklyChangeHeatmap extends StatelessWidget {
   final List<WeeklyWeightChange> weeks;
 
   @override
+  State<WeeklyChangeHeatmap> createState() => _WeeklyChangeHeatmapState();
+}
+
+class _WeeklyChangeHeatmapState extends State<WeeklyChangeHeatmap> {
+  /// How far above the held cell's centre the readout sits. A cell is a few
+  /// millimetres across, so anything less opens under the fingertip.
+  static const double _readoutOffset = 36;
+
+  OverlayEntry? _readout;
+  int? _held;
+  Offset _target = Offset.zero;
+
+  @override
+  void dispose() {
+    _hide();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        for (var row = 0; row < rows; row++)
-          Row(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Each cell is a square of one column's width: the row's Expanded sets
+        // the width and the AspectRatio inside follows it.
+        final cellSize = constraints.maxWidth / WeeklyChangeHeatmap.columns;
+
+        return Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: (event) => _holdAt(event.position, cellSize),
+          onPointerMove: (event) => _holdAt(event.position, cellSize),
+          onPointerUp: (_) => _hide(),
+          onPointerCancel: (_) => _hide(),
+          child: Column(
             children: [
-              for (var column = 0; column < columns; column++)
-                Expanded(child: _Cell(week: _weekAt(row * columns + column))),
+              for (var row = 0; row < WeeklyChangeHeatmap.rows; row++)
+                Row(
+                  children: [
+                    for (
+                      var column = 0;
+                      column < WeeklyChangeHeatmap.columns;
+                      column++
+                    )
+                      Expanded(child: _Cell(week: _weekAt(_index(row, column)))),
+                  ],
+                ),
             ],
           ),
-      ],
+        );
+      },
     );
   }
 
+  int _index(int row, int column) => row * WeeklyChangeHeatmap.columns + column;
+
   WeeklyWeightChange? _weekAt(int index) =>
-      index < weeks.length ? weeks[index] : null;
+      index < widget.weeks.length ? widget.weeks[index] : null;
+
+  /// Moves the readout to whichever cell [globalPosition] falls in, or hides it
+  /// once the finger leaves the grid.
+  void _holdAt(Offset globalPosition, double cellSize) {
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null) return;
+
+    final local = box.globalToLocal(globalPosition);
+    final column = local.dx ~/ cellSize;
+    final row = local.dy ~/ cellSize;
+    if (local.dx < 0 ||
+        local.dy < 0 ||
+        column >= WeeklyChangeHeatmap.columns ||
+        row >= WeeklyChangeHeatmap.rows) {
+      _hide();
+      return;
+    }
+
+    // Re-read the centre every move, so the readout stays on its cell even
+    // while the page scrolls under the finger.
+    _held = _index(row, column);
+    _target = box.localToGlobal(
+      Offset((column + 0.5) * cellSize, (row + 0.5) * cellSize),
+    );
+
+    if (_readout == null) {
+      _readout = OverlayEntry(builder: _buildReadout);
+      Overlay.of(context, debugRequiredFor: widget).insert(_readout!);
+    } else {
+      _readout!.markNeedsBuild();
+    }
+  }
+
+  Widget _buildReadout(BuildContext context) {
+    final held = _held;
+    if (held == null) return const SizedBox.shrink();
+
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: CustomSingleChildLayout(
+          delegate: _AboveCell(target: _target, verticalOffset: _readoutOffset),
+          child: _Readout(lines: weeklyChangeSummary(_weekAt(held))),
+        ),
+      ),
+    );
+  }
+
+  void _hide() {
+    _readout?.remove();
+    _readout = null;
+    _held = null;
+  }
 }
 
-class _Cell extends StatefulWidget {
+/// Places the readout above [target], dropping below it when the cell sits too
+/// near the top of the screen to fit, and keeping clear of the screen edges.
+class _AboveCell extends SingleChildLayoutDelegate {
+  const _AboveCell({required this.target, required this.verticalOffset});
+
+  static const double _margin = 8;
+
+  final Offset target;
+  final double verticalOffset;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
+      BoxConstraints.loose(
+        Size(constraints.maxWidth - 2 * _margin, constraints.maxHeight),
+      );
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final above = target.dy - verticalOffset - childSize.height;
+    final furthestDown = size.height - childSize.height;
+    final y = above >= _margin
+        ? above
+        : (furthestDown <= _margin
+              ? _margin
+              : (target.dy + verticalOffset).clamp(_margin, furthestDown));
+
+    final furthestLeft = size.width - childSize.width - _margin;
+    final x = furthestLeft <= _margin
+        ? (size.width - childSize.width) / 2
+        : (target.dx - childSize.width / 2).clamp(_margin, furthestLeft);
+
+    return Offset(x, y);
+  }
+
+  @override
+  bool shouldRelayout(_AboveCell oldDelegate) => target != oldDelegate.target;
+}
+
+class _Readout extends StatelessWidget {
+  const _Readout({required this.lines});
+
+  final List<String> lines;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.inverseSurface.withValues(alpha: 0.92),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Text(
+          lines.join('\n'),
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onInverseSurface,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Cell extends StatelessWidget {
   const _Cell({required this.week});
 
   /// The week this cell draws, or null past the end of the grid.
   final WeeklyWeightChange? week;
 
   @override
-  State<_Cell> createState() => _CellState();
-}
-
-class _CellState extends State<_Cell> {
-  /// Reaches the [Tooltip]'s own state to show it on demand, which is the only
-  /// way in: the widget exposes no "shown" flag to rebuild with.
-  final GlobalKey<TooltipState> _tooltip = GlobalKey<TooltipState>();
-  Offset? _pressOrigin;
-
-  void _showTooltip(PointerDownEvent event) {
-    _pressOrigin = event.position;
-    _tooltip.currentState?.ensureTooltipVisible();
-  }
-
-  /// A finger that travels is scrolling Home, not reading a cell, and the
-  /// overlay stays where it opened rather than following the page.
-  void _dismissIfDragged(PointerMoveEvent event) {
-    final origin = _pressOrigin;
-    if (origin != null && (event.position - origin).distance > kTouchSlop) {
-      _dismissTooltip();
-    }
-  }
-
-  void _dismissTooltip([PointerEvent? event]) {
-    _pressOrigin = null;
-    Tooltip.dismissAllToolTips();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final week = widget.week;
-    final summary = weeklyChangeSummary(week);
-
     return Padding(
       padding: const EdgeInsets.all(2),
       child: AspectRatio(
         aspectRatio: 1,
         child: Semantics(
-          label: summary.join('. '),
+          label: weeklyChangeSummary(week).join('. '),
           excludeSemantics: true,
-          child: Tooltip(
-            key: _tooltip,
-            message: summary.join('\n'),
-            // Shown and hidden below, so the week reads for exactly as long
-            // as the finger is down.
-            triggerMode: TooltipTriggerMode.manual,
-            enableTapToDismiss: false,
-            excludeFromSemantics: true,
-            // Above the cell and clear of the fingertip holding it: the
-            // offset is measured from the cell's centre, and a cell is a few
-            // millimetres across. Flutter drops it below for a cell too near
-            // the top to fit.
-            preferBelow: false,
-            verticalOffset: 36,
-            child: Listener(
-              behavior: HitTestBehavior.opaque,
-              onPointerDown: _showTooltip,
-              onPointerMove: _dismissIfDragged,
-              onPointerUp: _dismissTooltip,
-              onPointerCancel: _dismissTooltip,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: week == null
-                      ? weeklyChangeNoDataColor
-                      : weeklyChangeColor(week),
-                  borderRadius: BorderRadius.circular(3),
-                ),
-              ),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: week == null
+                  ? weeklyChangeNoDataColor
+                  : weeklyChangeColor(week!),
+              borderRadius: BorderRadius.circular(3),
             ),
           ),
         ),

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -49,6 +49,26 @@ class _Cell extends StatefulWidget {
 
 class _CellState extends State<_Cell> {
   final GlobalKey<TooltipState> _tooltip = GlobalKey<TooltipState>();
+  Offset? _pressOrigin;
+
+  void _showTooltip(PointerDownEvent event) {
+    _pressOrigin = event.position;
+    _tooltip.currentState?.ensureTooltipVisible();
+  }
+
+  /// A finger that travels is scrolling Home, not reading a cell, and the
+  /// overlay stays where it opened rather than following the page.
+  void _dismissIfDragged(PointerMoveEvent event) {
+    final origin = _pressOrigin;
+    if (origin != null && (event.position - origin).distance > kTouchSlop) {
+      _dismissTooltip();
+    }
+  }
+
+  void _dismissTooltip([PointerEvent? event]) {
+    _pressOrigin = null;
+    Tooltip.dismissAllToolTips();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -72,10 +92,10 @@ class _CellState extends State<_Cell> {
             excludeFromSemantics: true,
             child: Listener(
               behavior: HitTestBehavior.opaque,
-              onPointerDown: (_) =>
-                  _tooltip.currentState?.ensureTooltipVisible(),
-              onPointerUp: (_) => Tooltip.dismissAllToolTips(),
-              onPointerCancel: (_) => Tooltip.dismissAllToolTips(),
+              onPointerDown: _showTooltip,
+              onPointerMove: _dismissIfDragged,
+              onPointerUp: _dismissTooltip,
+              onPointerCancel: _dismissTooltip,
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: week == null

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
 import 'package:food_locker/ui/widgets/weekly_change_color.dart';

--- a/lib/ui/widgets/weekly_change_heatmap.dart
+++ b/lib/ui/widgets/weekly_change_heatmap.dart
@@ -49,6 +49,8 @@ class _Cell extends StatefulWidget {
 }
 
 class _CellState extends State<_Cell> {
+  /// Reaches the [Tooltip]'s own state to show it on demand, which is the only
+  /// way in: the widget exposes no "shown" flag to rebuild with.
   final GlobalKey<TooltipState> _tooltip = GlobalKey<TooltipState>();
   Offset? _pressOrigin;
 

--- a/lib/ui/widgets/weekly_change_summary.dart
+++ b/lib/ui/widgets/weekly_change_summary.dart
@@ -16,11 +16,10 @@ List<String> weeklyChangeSummary(WeeklyWeightChange? week, [String? locale]) {
   final period =
       '${shortDateWithWeekday(week.weekStart, locale)} – '
       '${shortDateWithWeekday(_weekEnd(week.weekStart), locale)}';
+  // True of a week with nothing logged as much as one whose weigh-ins sat
+  // too close together.
   if (!week.hasData) {
-    return [
-      period,
-      'No weigh-ins at least ${WeeklyWeightChange.minSpanDays} days apart',
-    ];
+    return [period, 'No weigh-ins far enough apart to compare'];
   }
 
   final unit = week.unit!;

--- a/lib/ui/widgets/weekly_change_summary.dart
+++ b/lib/ui/widgets/weekly_change_summary.dart
@@ -16,19 +16,24 @@ List<String> weeklyChangeSummary(WeeklyWeightChange? week, [String? locale]) {
   final period =
       '${shortDateWithWeekday(week.weekStart, locale)} – '
       '${shortDateWithWeekday(_weekEnd(week.weekStart), locale)}';
-  // True of a week with nothing logged as much as one whose weigh-ins sat
-  // too close together.
+  // Naming the rule covers both ways a week fails it: nothing logged at all,
+  // and weigh-ins that sat too close together.
   if (!week.hasData) {
-    return [period, 'No weigh-ins far enough apart to compare'];
+    return [
+      period,
+      'No two weigh-ins ${WeeklyWeightChange.minSpanDays} days apart',
+    ];
   }
 
+  final first = week.first!;
+  final last = week.last!;
   final unit = week.unit!;
   return [
     period,
-    '${shortDateWithWeekday(week.firstDate!, locale)}: '
-        '${_measurement(week.firstValue!, unit)} → '
-        '${shortDateWithWeekday(week.lastDate!, locale)}: '
-        '${_measurement(week.lastValue!, unit)}',
+    '${shortDateWithWeekday(first.date, locale)}: '
+        '${_measurement(first.value, unit)} → '
+        '${shortDateWithWeekday(last.date, locale)}: '
+        '${_measurement(last.value, unit)}',
     _signedChange(week.delta!, unit),
   ];
 }

--- a/lib/ui/widgets/weekly_change_summary.dart
+++ b/lib/ui/widgets/weekly_change_summary.dart
@@ -1,0 +1,48 @@
+import 'package:food_locker/core/date_format.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+
+/// What a heatmap cell says about its week, one line at a time.
+///
+/// The period the cell covers, the two weigh-ins its delta was measured across
+/// — the pair is what makes red or green make sense — and the signed delta. A
+/// week that failed the span gate says so, so grey never reads as "nothing
+/// happened".
+///
+/// [week] is null for a cell past the end of the grid.
+List<String> weeklyChangeSummary(WeeklyWeightChange? week, [String? locale]) {
+  if (week == null) return const ['No data'];
+
+  final period =
+      '${shortDateWithWeekday(week.weekStart, locale)} – '
+      '${shortDateWithWeekday(_weekEnd(week.weekStart), locale)}';
+  if (!week.hasData) {
+    return [
+      period,
+      'No weigh-ins at least ${WeeklyWeightChange.minSpanDays} days apart',
+    ];
+  }
+
+  final unit = week.unit!;
+  return [
+    period,
+    '${shortDateWithWeekday(week.firstDate!, locale)}: '
+        '${_measurement(week.firstValue!, unit)} → '
+        '${shortDateWithWeekday(week.lastDate!, locale)}: '
+        '${_measurement(week.lastValue!, unit)}',
+    _signedChange(week.delta!, unit),
+  ];
+}
+
+/// The Saturday closing the week [weekStart] opens.
+DateTime _weekEnd(DateTime weekStart) =>
+    DateTime(weekStart.year, weekStart.month, weekStart.day + 6);
+
+String _measurement(double value, WeightUnit unit) =>
+    '${value.toStringAsFixed(1)} ${unit.symbol}';
+
+/// The delta with its sign, matching how a history row states a change.
+String _signedChange(double delta, WeightUnit unit) {
+  final change = _measurement(delta, unit);
+  return delta > 0 ? '+$change' : change;
+}

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -100,16 +100,46 @@ void main() {
       expect(current.isGain, isTrue);
     });
 
-    test('needs at least four weigh-ins in the week', () async {
-      await logRun(DateTime(2026, 8, 9), [80.0, 79.0, 78.0]);
+    test('needs the week\'s weigh-ins three days apart', () async {
+      // Sunday and Monday: a two-day blip, not a week.
+      await logRun(DateTime(2026, 8, 9), [80.0, 79.0]);
 
       expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isFalse);
     });
 
-    test('four weigh-ins is enough', () async {
-      await logRun(DateTime(2026, 8, 9), [80.0, 79.0, 78.0, 77.0]);
+    test('a three-day span is enough', () async {
+      await log(DateTime(2026, 8, 9), 80.0);
+      await log(DateTime(2026, 8, 12), 79.0);
 
       expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isTrue);
+    });
+
+    test('a Sunday and a Saturday alone span the whole week', () async {
+      await log(DateTime(2026, 8, 9), 80.0);
+      await log(DateTime(2026, 8, 15), 79.0);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.hasData, isTrue);
+      expect(current.delta, closeTo(-1.0, 1e-9));
+    });
+
+    test('three consecutive days fall short of the span', () async {
+      // The store keeps one entry per day, so it takes four consecutive
+      // entries to span three days.
+      await logRun(DateTime(2026, 8, 10), [80.0, 79.0, 78.0]);
+
+      expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isFalse);
+    });
+
+    test('a lone weigh-in reports nothing rather than a flat week', () async {
+      await log(DateTime(2026, 8, 12), 80.0);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.hasData, isFalse);
+      expect(current.delta, isNull);
+      expect(current.level, isNull);
     });
 
     test('never carries across a week boundary', () async {
@@ -129,7 +159,7 @@ void main() {
 
     test('splits a Saturday-to-Sunday run at the boundary', () async {
       // Thursday the 6th through Tuesday the 11th splits three days either
-      // side of the boundary, so neither week reaches four.
+      // side of the boundary, so neither week spans three days.
       await logRun(DateTime(2026, 8, 6), [90.0, 89.0, 88.0, 87.0, 86.0, 85.0]);
 
       final weeks = analytics.weeklyChanges(asOf: asOf);
@@ -163,6 +193,35 @@ void main() {
       expect(filled, hasLength(1));
       expect(filled.single.weekStart, DateTime(2026, 6, 7));
       expect(filled.single.delta, closeTo(1.5, 1e-9));
+    });
+
+    test('carries the two weigh-ins it compared', () async {
+      await log(DateTime(2026, 8, 9), 80.0);
+      await log(DateTime(2026, 8, 11), 79.5);
+      await log(DateTime(2026, 8, 14), 78.4);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.firstDate, DateTime(2026, 8, 9));
+      expect(current.firstValue, 80.0);
+      expect(current.lastDate, DateTime(2026, 8, 14));
+      expect(current.lastValue, 78.4);
+      expect(
+        current.delta,
+        closeTo(current.lastValue! - current.firstValue!, 1e-9),
+      );
+    });
+
+    test('a week under the gate carries no weigh-ins either', () async {
+      await logRun(DateTime(2026, 8, 9), [80.0, 79.0]);
+
+      final current = analytics.weeklyChanges(asOf: asOf).last;
+
+      expect(current.firstDate, isNull);
+      expect(current.firstValue, isNull);
+      expect(current.lastDate, isNull);
+      expect(current.lastValue, isNull);
+      expect(current.unit, isNull);
     });
 
     test('takes its unit from the week\'s last weigh-in', () async {

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -236,12 +236,19 @@ void main() {
   });
 
   group('intensity levels', () {
-    WeeklyWeightChange change(double? delta, [WeightUnit? unit]) =>
-        WeeklyWeightChange(
-          weekStart: DateTime(2026, 8, 9),
-          delta: delta,
-          unit: delta == null ? null : unit ?? WeightUnit.kilograms,
-        );
+    WeeklyWeightChange change(double? delta, [WeightUnit? unit]) {
+      final weekStart = DateTime(2026, 8, 9);
+      if (delta == null) return WeeklyWeightChange(weekStart: weekStart);
+      return WeeklyWeightChange(
+        weekStart: weekStart,
+        delta: delta,
+        unit: unit ?? WeightUnit.kilograms,
+        firstDate: weekStart,
+        firstValue: 80.0,
+        lastDate: DateTime(2026, 8, 14),
+        lastValue: 80.0 + delta,
+      );
+    }
 
     test('a week with no delta has no level', () {
       expect(change(null).level, isNull);

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -132,6 +132,16 @@ void main() {
       expect(analytics.weeklyChanges(asOf: asOf).last.hasData, isFalse);
     });
 
+    test('rejects a weigh-in from outside the week', () {
+      expect(
+        () => WeeklyWeightChange(
+          weekStart: DateTime(2026, 8, 9),
+          entries: [Weight(date: DateTime(2026, 8, 16), value: 80.0)],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('a lone weigh-in reports nothing rather than a flat week', () async {
       await log(DateTime(2026, 8, 12), 80.0);
 

--- a/test/features/weight/weekly_weight_change_test.dart
+++ b/test/features/weight/weekly_weight_change_test.dart
@@ -202,26 +202,26 @@ void main() {
 
       final current = analytics.weeklyChanges(asOf: asOf).last;
 
-      expect(current.firstDate, DateTime(2026, 8, 9));
-      expect(current.firstValue, 80.0);
-      expect(current.lastDate, DateTime(2026, 8, 14));
-      expect(current.lastValue, 78.4);
+      expect(current.first!.date, DateTime(2026, 8, 9));
+      expect(current.first!.value, 80.0);
+      expect(current.last!.date, DateTime(2026, 8, 14));
+      expect(current.last!.value, 78.4);
       expect(
         current.delta,
-        closeTo(current.lastValue! - current.firstValue!, 1e-9),
+        closeTo(current.last!.value - current.first!.value, 1e-9),
       );
     });
 
-    test('a week under the gate carries no weigh-ins either', () async {
+    test('a week under the gate reports no delta or unit', () async {
       await logRun(DateTime(2026, 8, 9), [80.0, 79.0]);
 
       final current = analytics.weeklyChanges(asOf: asOf).last;
 
-      expect(current.firstDate, isNull);
-      expect(current.firstValue, isNull);
-      expect(current.lastDate, isNull);
-      expect(current.lastValue, isNull);
+      expect(current.delta, isNull);
       expect(current.unit, isNull);
+      // The weigh-ins are still there — they just don't span the week.
+      expect(current.first!.date, DateTime(2026, 8, 9));
+      expect(current.last!.date, DateTime(2026, 8, 10));
     });
 
     test('takes its unit from the week\'s last weigh-in', () async {
@@ -236,17 +236,25 @@ void main() {
   });
 
   group('intensity levels', () {
+    /// A week opening on Sunday the 9th, weighed that day and again on the
+    /// Friday — far enough apart to clear the span gate.
     WeeklyWeightChange change(double? delta, [WeightUnit? unit]) {
       final weekStart = DateTime(2026, 8, 9);
       if (delta == null) return WeeklyWeightChange(weekStart: weekStart);
       return WeeklyWeightChange(
         weekStart: weekStart,
-        delta: delta,
-        unit: unit ?? WeightUnit.kilograms,
-        firstDate: weekStart,
-        firstValue: 80.0,
-        lastDate: DateTime(2026, 8, 14),
-        lastValue: 80.0 + delta,
+        entries: [
+          Weight(
+            date: weekStart,
+            value: 80.0,
+            unit: unit ?? WeightUnit.kilograms,
+          ),
+          Weight(
+            date: DateTime(2026, 8, 14),
+            value: 80.0 + delta,
+            unit: unit ?? WeightUnit.kilograms,
+          ),
+        ],
       );
     }
 

--- a/test/ui/pages/home_page_test.dart
+++ b/test/ui/pages/home_page_test.dart
@@ -131,8 +131,8 @@ void main() {
     tester,
   ) async {
     final manager = WeightManager(InMemoryWeightRepository());
-    // Four weeks of daily weigh-ins, so a full week clears the four-entry
-    // threshold whatever weekday the test runs on.
+    // Four weeks of daily weigh-ins, so a full week clears the span gate
+    // whatever weekday the test runs on.
     for (var day = 0; day < 28; day++) {
       await manager.addWeight(daysAgo(day), 70.0 + day);
     }

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -5,6 +5,7 @@ import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_analytics.dart';
 import 'package:food_locker/ui/widgets/weekly_change_color.dart';
 import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
+import 'package:food_locker/ui/widgets/weekly_change_summary.dart';
 
 void main() {
   WeeklyWeightChange week(int index, {double? delta, WeightUnit? unit}) =>
@@ -35,6 +36,14 @@ void main() {
       .widgetList<DecoratedBox>(cells())
       .map((box) => (box.decoration as BoxDecoration).color)
       .toList();
+
+  Finder tooltips() => find.descendant(
+    of: find.byType(WeeklyChangeHeatmap),
+    matching: find.byType(Tooltip),
+  );
+
+  String tooltipAt(WidgetTester tester, int index) =>
+      tester.widgetList<Tooltip>(tooltips()).elementAt(index).message!;
 
   testWidgets('draws 52 cells in 4 rows of 13', (tester) async {
     await pump(tester, emptyYear());
@@ -118,5 +127,85 @@ void main() {
       colors.skip(1).every((color) => color == weeklyChangeNoDataColor),
       isTrue,
     );
+  });
+
+  group('cell summaries', () {
+    // A week that gained: Tuesday's weigh-in through Saturday's.
+    final gainingWeek = WeeklyWeightChange(
+      weekStart: DateTime(2026, 3, 8),
+      delta: 0.6,
+      unit: WeightUnit.kilograms,
+      firstDate: DateTime(2026, 3, 10),
+      firstValue: 82.4,
+      lastDate: DateTime(2026, 3, 14),
+      lastValue: 83.0,
+    );
+    final losingWeek = WeeklyWeightChange(
+      weekStart: DateTime(2026, 3, 15),
+      delta: -1.2,
+      unit: WeightUnit.kilograms,
+      firstDate: DateTime(2026, 3, 15),
+      firstValue: 83.0,
+      lastDate: DateTime(2026, 3, 21),
+      lastValue: 81.8,
+    );
+
+    List<WeeklyWeightChange> yearOpeningWith(List<WeeklyWeightChange> first) =>
+        [...first, ...emptyYear().skip(first.length)];
+
+    testWidgets('every cell carries its week as a tooltip', (tester) async {
+      await pump(tester, yearOpeningWith([gainingWeek, losingWeek]));
+
+      expect(tooltips(), findsNWidgets(52));
+      expect(tooltipAt(tester, 0), weeklyChangeSummary(gainingWeek).join('\n'));
+      expect(tooltipAt(tester, 1), weeklyChangeSummary(losingWeek).join('\n'));
+    });
+
+    testWidgets('a week under the gate says so rather than staying blank', (
+      tester,
+    ) async {
+      await pump(tester, emptyYear());
+
+      final summary = tooltipAt(tester, 0);
+      expect(summary, weeklyChangeSummary(emptyYear().first).join('\n'));
+      expect(summary, contains('No weigh-ins'));
+    });
+
+    testWidgets('a cell past the end of the list reads as no data', (
+      tester,
+    ) async {
+      await pump(tester, [gainingWeek]);
+
+      expect(tooltipAt(tester, 1), weeklyChangeSummary(null).join('\n'));
+    });
+
+    testWidgets('the tooltip lasts as long as the cell is held', (
+      tester,
+    ) async {
+      await pump(tester, yearOpeningWith([gainingWeek]));
+      final summary = tooltipAt(tester, 0);
+
+      final gesture = await tester.startGesture(tester.getCenter(cells().at(0)));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text(summary), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text(summary), findsNothing);
+    });
+
+    testWidgets('each cell is readable without holding it', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pump(tester, yearOpeningWith([gainingWeek]));
+
+      expect(
+        find.bySemanticsLabel(weeklyChangeSummary(gainingWeek).join('. ')),
+        findsOneWidget,
+      );
+
+      handle.dispose();
+    });
   });
 }

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -48,13 +48,8 @@ void main() {
       .map((box) => (box.decoration as BoxDecoration).color)
       .toList();
 
-  Finder tooltips() => find.descendant(
-    of: find.byType(WeeklyChangeHeatmap),
-    matching: find.byType(Tooltip),
-  );
-
-  String tooltipAt(WidgetTester tester, int index) =>
-      tester.widgetList<Tooltip>(tooltips()).elementAt(index).message!;
+  String readoutFor(WeeklyWeightChange? week) =>
+      weeklyChangeSummary(week).join('\n');
 
   testWidgets('draws 52 cells in 4 rows of 13', (tester) async {
     await pump(tester, emptyYear());
@@ -140,7 +135,7 @@ void main() {
     );
   });
 
-  group('cell summaries', () {
+  group('cell readout', () {
     // A week that gained: Tuesday's weigh-in through Saturday's.
     final gainingWeek = WeeklyWeightChange(
       weekStart: DateTime(2026, 3, 8),
@@ -160,12 +155,59 @@ void main() {
     List<WeeklyWeightChange> yearOpeningWith(List<WeeklyWeightChange> first) =>
         [...first, ...emptyYear().skip(first.length)];
 
-    testWidgets('every cell carries its week as a tooltip', (tester) async {
+    testWidgets('holding a cell names its week and the weigh-ins behind it', (
+      tester,
+    ) async {
+      await pump(tester, yearOpeningWith([gainingWeek]));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(cells().first),
+      );
+      await tester.pump();
+
+      expect(find.text(readoutFor(gainingWeek)), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text(readoutFor(gainingWeek)), findsNothing);
+    });
+
+    testWidgets('dragging carries the readout to the next cell', (
+      tester,
+    ) async {
       await pump(tester, yearOpeningWith([gainingWeek, losingWeek]));
 
-      expect(tooltips(), findsNWidgets(52));
-      expect(tooltipAt(tester, 0), weeklyChangeSummary(gainingWeek).join('\n'));
-      expect(tooltipAt(tester, 1), weeklyChangeSummary(losingWeek).join('\n'));
+      final gesture = await tester.startGesture(
+        tester.getCenter(cells().first),
+      );
+      await tester.pump();
+      await gesture.moveTo(tester.getCenter(cells().at(1)));
+      await tester.pump();
+
+      expect(find.text(readoutFor(losingWeek)), findsOneWidget);
+      expect(find.text(readoutFor(gainingWeek)), findsNothing);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('dragging off the grid ends the readout', (tester) async {
+      await pump(tester, yearOpeningWith([gainingWeek]));
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(cells().first),
+      );
+      await tester.pump();
+      expect(find.text(readoutFor(gainingWeek)), findsOneWidget);
+
+      await gesture.moveTo(const Offset(400, 560));
+      await tester.pump();
+
+      expect(find.text(readoutFor(gainingWeek)), findsNothing);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('a week under the gate says so rather than staying blank', (
@@ -173,12 +215,18 @@ void main() {
     ) async {
       await pump(tester, emptyYear());
 
-      final summary = tooltipAt(tester, 0);
-      expect(summary, weeklyChangeSummary(emptyYear().first).join('\n'));
-      expect(
-        summary,
-        contains('${WeeklyWeightChange.minSpanDays} days apart'),
+      final gesture = await tester.startGesture(
+        tester.getCenter(cells().first),
       );
+      await tester.pump();
+
+      expect(
+        find.textContaining('${WeeklyWeightChange.minSpanDays} days apart'),
+        findsOneWidget,
+      );
+
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
 
     testWidgets('a cell past the end of the list reads as no data', (
@@ -186,27 +234,16 @@ void main() {
     ) async {
       await pump(tester, [gainingWeek]);
 
-      expect(tooltipAt(tester, 1), weeklyChangeSummary(null).join('\n'));
-    });
+      final gesture = await tester.startGesture(tester.getCenter(cells().at(1)));
+      await tester.pump();
 
-    testWidgets('the tooltip lasts as long as the cell is held', (
-      tester,
-    ) async {
-      await pump(tester, yearOpeningWith([gainingWeek]));
-      final summary = tooltipAt(tester, 0);
-
-      final gesture = await tester.startGesture(tester.getCenter(cells().at(0)));
-      await tester.pump(const Duration(milliseconds: 300));
-
-      expect(find.text(summary), findsOneWidget);
+      expect(find.text(readoutFor(null)), findsOneWidget);
 
       await gesture.up();
       await tester.pumpAndSettle();
-
-      expect(find.text(summary), findsNothing);
     });
 
-    testWidgets('the tooltip opens clear of the finger holding the cell', (
+    testWidgets('the readout opens clear of the finger holding the cell', (
       tester,
     ) async {
       // A cell in the last row, so there is room above it to open into.
@@ -214,34 +251,17 @@ void main() {
       weeks[51] = week(0, delta: 0.6);
       await pump(tester, weeks);
 
-      final summary = tooltipAt(tester, 51);
       final cell = tester.getRect(cells().at(51));
-
       final gesture = await tester.startGesture(cell.center);
-      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump();
 
-      expect(tester.getRect(find.text(summary)).bottom, lessThan(cell.top));
+      expect(
+        tester.getRect(find.text(readoutFor(weeks[51]))).bottom,
+        lessThan(cell.top),
+      );
 
       await gesture.up();
       await tester.pumpAndSettle();
-    });
-
-    testWidgets('a press that turns into a scroll drops the tooltip', (
-      tester,
-    ) async {
-      await pump(tester, yearOpeningWith([gainingWeek]));
-      final summary = tooltipAt(tester, 0);
-
-      final gesture = await tester.startGesture(tester.getCenter(cells().at(0)));
-      await tester.pump(const Duration(milliseconds: 300));
-      expect(find.text(summary), findsOneWidget);
-
-      await gesture.moveBy(const Offset(0, -60));
-      await tester.pumpAndSettle();
-
-      expect(find.text(summary), findsNothing);
-
-      await gesture.up();
     });
 
     testWidgets('each cell is readable without holding it', (tester) async {

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -205,6 +205,26 @@ void main() {
       expect(find.text(summary), findsNothing);
     });
 
+    testWidgets('the tooltip opens clear of the finger holding the cell', (
+      tester,
+    ) async {
+      // A cell in the last row, so there is room above it to open into.
+      final weeks = emptyYear();
+      weeks[51] = week(0, delta: 0.6);
+      await pump(tester, weeks);
+
+      final summary = tooltipAt(tester, 51);
+      final cell = tester.getRect(cells().at(51));
+
+      final gesture = await tester.startGesture(cell.center);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(tester.getRect(find.text(summary)).bottom, lessThan(cell.top));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('a press that turns into a scroll drops the tooltip', (
       tester,
     ) async {

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -205,6 +205,24 @@ void main() {
       expect(find.text(summary), findsNothing);
     });
 
+    testWidgets('a press that turns into a scroll drops the tooltip', (
+      tester,
+    ) async {
+      await pump(tester, yearOpeningWith([gainingWeek]));
+      final summary = tooltipAt(tester, 0);
+
+      final gesture = await tester.startGesture(tester.getCenter(cells().at(0)));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text(summary), findsOneWidget);
+
+      await gesture.moveBy(const Offset(0, -60));
+      await tester.pumpAndSettle();
+
+      expect(find.text(summary), findsNothing);
+
+      await gesture.up();
+    });
+
     testWidgets('each cell is readable without holding it', (tester) async {
       final handle = tester.ensureSemantics();
       await pump(tester, yearOpeningWith([gainingWeek]));

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -15,12 +15,14 @@ void main() {
     if (delta == null) return WeeklyWeightChange(weekStart: start);
     return WeeklyWeightChange(
       weekStart: start,
-      delta: delta,
-      unit: unit ?? WeightUnit.kilograms,
-      firstDate: start,
-      firstValue: 80.0,
-      lastDate: DateTime(start.year, start.month, start.day + 5),
-      lastValue: 80.0 + delta,
+      entries: [
+        Weight(date: start, value: 80.0, unit: unit ?? WeightUnit.kilograms),
+        Weight(
+          date: DateTime(start.year, start.month, start.day + 5),
+          value: 80.0 + delta,
+          unit: unit ?? WeightUnit.kilograms,
+        ),
+      ],
     );
   }
 
@@ -142,21 +144,17 @@ void main() {
     // A week that gained: Tuesday's weigh-in through Saturday's.
     final gainingWeek = WeeklyWeightChange(
       weekStart: DateTime(2026, 3, 8),
-      delta: 0.6,
-      unit: WeightUnit.kilograms,
-      firstDate: DateTime(2026, 3, 10),
-      firstValue: 82.4,
-      lastDate: DateTime(2026, 3, 14),
-      lastValue: 83.0,
+      entries: [
+        Weight(date: DateTime(2026, 3, 10), value: 82.4),
+        Weight(date: DateTime(2026, 3, 14), value: 83.0),
+      ],
     );
     final losingWeek = WeeklyWeightChange(
       weekStart: DateTime(2026, 3, 15),
-      delta: -1.2,
-      unit: WeightUnit.kilograms,
-      firstDate: DateTime(2026, 3, 15),
-      firstValue: 83.0,
-      lastDate: DateTime(2026, 3, 21),
-      lastValue: 81.8,
+      entries: [
+        Weight(date: DateTime(2026, 3, 15), value: 83.0),
+        Weight(date: DateTime(2026, 3, 21), value: 81.8),
+      ],
     );
 
     List<WeeklyWeightChange> yearOpeningWith(List<WeeklyWeightChange> first) =>
@@ -177,7 +175,10 @@ void main() {
 
       final summary = tooltipAt(tester, 0);
       expect(summary, weeklyChangeSummary(emptyYear().first).join('\n'));
-      expect(summary, contains('No weigh-ins'));
+      expect(
+        summary,
+        contains('${WeeklyWeightChange.minSpanDays} days apart'),
+      );
     });
 
     testWidgets('a cell past the end of the list reads as no data', (

--- a/test/ui/widgets/weekly_change_heatmap_test.dart
+++ b/test/ui/widgets/weekly_change_heatmap_test.dart
@@ -8,12 +8,21 @@ import 'package:food_locker/ui/widgets/weekly_change_heatmap.dart';
 import 'package:food_locker/ui/widgets/weekly_change_summary.dart';
 
 void main() {
-  WeeklyWeightChange week(int index, {double? delta, WeightUnit? unit}) =>
-      WeeklyWeightChange(
-        weekStart: DateTime(2026, 8, 9 - 7 * index),
-        delta: delta,
-        unit: delta == null ? null : unit ?? WeightUnit.kilograms,
-      );
+  /// The week [index] grids back from the 9th of August, gaining or losing
+  /// [delta] between a Sunday and a Friday weigh-in.
+  WeeklyWeightChange week(int index, {double? delta, WeightUnit? unit}) {
+    final start = DateTime(2026, 8, 9 - 7 * index);
+    if (delta == null) return WeeklyWeightChange(weekStart: start);
+    return WeeklyWeightChange(
+      weekStart: start,
+      delta: delta,
+      unit: unit ?? WeightUnit.kilograms,
+      firstDate: start,
+      firstValue: 80.0,
+      lastDate: DateTime(start.year, start.month, start.day + 5),
+      lastValue: 80.0 + delta,
+    );
+  }
 
   List<WeeklyWeightChange> emptyYear() =>
       [for (var i = 51; i >= 0; i--) week(i)];

--- a/test/ui/widgets/weekly_change_summary_test.dart
+++ b/test/ui/widgets/weekly_change_summary_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/weight/data/weekly_weight_change.dart';
+import 'package:food_locker/features/weight/data/weight.dart';
+import 'package:food_locker/ui/widgets/weekly_change_summary.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+void main() {
+  setUpAll(initializeDateFormatting);
+
+  // Sunday the 8th of March through Saturday the 14th.
+  final weekStart = DateTime(2026, 3, 8);
+
+  WeeklyWeightChange week({
+    required double delta,
+    WeightUnit unit = WeightUnit.kilograms,
+  }) => WeeklyWeightChange(
+    weekStart: weekStart,
+    delta: delta,
+    unit: unit,
+    firstDate: DateTime(2026, 3, 9),
+    firstValue: 82.4,
+    lastDate: DateTime(2026, 3, 13),
+    lastValue: 82.4 + delta,
+  );
+
+  test('a gaining week names its period, its weigh-ins and its change', () {
+    expect(weeklyChangeSummary(week(delta: 0.6), 'en_US'), [
+      'Sun, 3/8 – Sat, 3/14',
+      'Mon, 3/9: 82.4 kg → Fri, 3/13: 83.0 kg',
+      '+0.6 kg',
+    ]);
+  });
+
+  test('a losing week signs its change with a minus', () {
+    expect(weeklyChangeSummary(week(delta: -1.2), 'en_US'), [
+      'Sun, 3/8 – Sat, 3/14',
+      'Mon, 3/9: 82.4 kg → Fri, 3/13: 81.2 kg',
+      '-1.2 kg',
+    ]);
+  });
+
+  test('a flat week states zero rather than a sign', () {
+    expect(weeklyChangeSummary(week(delta: 0.0), 'en_US').last, '0.0 kg');
+  });
+
+  test('the weigh-ins carry the week\'s own unit', () {
+    final summary = weeklyChangeSummary(
+      week(delta: 1.4, unit: WeightUnit.pounds),
+      'en_US',
+    );
+
+    expect(summary[1], 'Mon, 3/9: 82.4 lbs → Fri, 3/13: 83.8 lbs');
+    expect(summary.last, '+1.4 lbs');
+  });
+
+  test('a week under the span gate says so instead of reading as flat', () {
+    final summary = weeklyChangeSummary(
+      WeeklyWeightChange(weekStart: weekStart),
+      'en_US',
+    );
+
+    expect(summary, [
+      'Sun, 3/8 – Sat, 3/14',
+      'No weigh-ins at least ${WeeklyWeightChange.minSpanDays} days apart',
+    ]);
+  });
+
+  test('a cell past the end of the grid has no week to name', () {
+    expect(weeklyChangeSummary(null, 'en_US'), ['No data']);
+  });
+
+  test('renders its dates in the locale field order', () {
+    // Day-before-month under en_GB, so the period cannot be the en_US string.
+    expect(
+      weeklyChangeSummary(week(delta: 0.6), 'en_GB').first,
+      isNot(weeklyChangeSummary(week(delta: 0.6), 'en_US').first),
+    );
+  });
+}

--- a/test/ui/widgets/weekly_change_summary_test.dart
+++ b/test/ui/widgets/weekly_change_summary_test.dart
@@ -15,12 +15,10 @@ void main() {
     WeightUnit unit = WeightUnit.kilograms,
   }) => WeeklyWeightChange(
     weekStart: weekStart,
-    delta: delta,
-    unit: unit,
-    firstDate: DateTime(2026, 3, 9),
-    firstValue: 82.4,
-    lastDate: DateTime(2026, 3, 13),
-    lastValue: 82.4 + delta,
+    entries: [
+      Weight(date: DateTime(2026, 3, 9), value: 82.4, unit: unit),
+      Weight(date: DateTime(2026, 3, 13), value: 82.4 + delta, unit: unit),
+    ],
   );
 
   test('a gaining week names its period, its weigh-ins and its change', () {
@@ -63,7 +61,7 @@ void main() {
     // weigh-ins sat too close together.
     expect(summary, [
       'Sun, 3/8 – Sat, 3/14',
-      'No weigh-ins far enough apart to compare',
+      'No two weigh-ins ${WeeklyWeightChange.minSpanDays} days apart',
     ]);
   });
 

--- a/test/ui/widgets/weekly_change_summary_test.dart
+++ b/test/ui/widgets/weekly_change_summary_test.dart
@@ -53,15 +53,17 @@ void main() {
     expect(summary.last, '+1.4 lbs');
   });
 
-  test('a week under the span gate says so instead of reading as flat', () {
+  test('a week without a delta says so instead of reading as flat', () {
     final summary = weeklyChangeSummary(
       WeeklyWeightChange(weekStart: weekStart),
       'en_US',
     );
 
+    // The same line serves a week nothing was logged in and one whose
+    // weigh-ins sat too close together.
     expect(summary, [
       'Sun, 3/8 – Sat, 3/14',
-      'No weigh-ins at least ${WeeklyWeightChange.minSpanDays} days apart',
+      'No weigh-ins far enough apart to compare',
     ]);
   });
 


### PR DESCRIPTION
## What changed

**Part 1 — reading a cell.** The grid handles its own touch and draws its own readout, the way the charts do. Press a cell and it names the week; drag and the readout follows your finger from cell to cell; lift, or leave the grid, and it ends.

```
Sun, 3/8 – Sat, 3/14
Tue, 3/10: 82.4 kg → Sat, 3/14: 83.0 kg
+0.6 kg
```

- the period the cell covers — the week's Sunday through its Saturday;
- the two weigh-ins that were compared, each with date and value, which is what makes the colour make sense;
- the resulting change, signed and with its unit;
- for a week with no delta, `No two weigh-ins 3 days apart` — true whether the week held nothing at all or two weigh-ins a day apart — and for a cell past the end of the list, `No data`. Grey no longer reads as "nothing happened".

The readout opens **above** the held cell (offset from the cell's centre, so it clears the fingertip), dropping below only when a cell sits too near the top of the screen to fit. Every cell also carries the same lines as a `Semantics` label, so the information is reachable without holding anything. Dates go through `lib/core/date_format.dart`, so they stay locale-aware and carry the weekday.

**Part 2 — the span gate.** `WeeklyWeightChange.minEntries = 4` is replaced by `minSpanDays = 3`: a week reports a delta only when its first and last weigh-in lie at least three days apart. A Sunday-and-Saturday pair (2 entries, 6-day span) now reports its change instead of drawing grey; a Monday-and-Tuesday pair still doesn't.

This also fixes the bug the old gate was masking: a single weigh-in made `last.value - first.value == 0.0`, which gave `level == 1` and `isGain == false` — the cell rendered as the faintest green, "you lost a tiny bit", from one data point. A lone weigh-in spans zero days, so it is now correctly no-data.

**Model.** `WeeklyWeightChange` takes the week's weigh-ins and derives everything from them:

```dart
factory WeeklyWeightChange({required DateTime weekStart, List<Weight> entries = const []})

double? get delta => hasData ? last!.value - first!.value : null;
bool get hasData => _spanInDays >= minSpanDays;
```

`weekStart` is the week's identity — an empty week still has a cell to fill and a period to name — and a constructor assert holds the entries to that week. `WeightAnalytics` is left with the job only it can do: reading the repository and working out which week each weigh-in belongs to. No Hive model, no `typeId`, no Drift table, no backup-codec impact.

## How each acceptance criterion is met

| From the issue | Where |
|---|---|
| Readout while the cell is held, gone on release | `_WeeklyChangeHeatmapState`; tests *holding a cell names its week and the weigh-ins behind it*, *dragging off the grid ends the readout* |
| Period the cell covers | `weeklyChangeSummary` first line; test *a gaining week names its period, its weigh-ins and its change* |
| The two weigh-ins compared, with dates and values | `first`/`last` on the model + summary second line; tests *carries the two weigh-ins it compared*, *the weigh-ins carry the week's own unit* |
| Resulting change, signed, with unit | summary last line; tests for `+0.6 kg`, `-1.2 kg`, `0.0 kg` |
| Clear no-data state, gated weeks and empty cells alike | tests *a week without a delta says so instead of reading as flat*, *a cell past the end of the grid has no week to name* |
| `minEntries` → minimum span | `WeeklyWeightChange.minSpanDays` |
| Sun+Sat two-entry week passes | test *a Sunday and a Saturday alone span the whole week* |
| Mon+Tue two-entry week still grey | test *needs the week's weigh-ins three days apart* |
| Single-entry week grey, not faint green | test *a lone weigh-in reports nothing rather than a flat week* |
| Dates via `core/date_format.dart`, with weekday | `weeklyChangeSummary` uses `shortDateWithWeekday` |
| `Semantics` label per cell | test *each cell is readable without holding it* |

Beyond the issue, from review: dragging moves the readout between cells (test *dragging carries the readout to the next cell*).

## Decisions made along the way

- **The grid owns the gesture, not the cells.** One `Listener` over the whole heatmap, with the cell under the finger computed from `LayoutBuilder`'s cell size rather than widget hit-testing. This is what makes drag-between-cells possible, and it removes the 52 `Tooltip`s and `GlobalKey`s an earlier revision needed.
- **The readout is recomputed from the finger's position on every move**, so a drag that also scrolls the page keeps it glued to the cell under the finger instead of stranding it — which is why there's no touch-slop dismissal any more.
- **Span counted on UTC midnights**, so a daylight-saving shift inside the week can't turn a 3-day span into 2 days 23 hours.
- **One no-data line for both cases.** A week with nothing logged and a week whose weigh-ins sat too close say the same thing, because the model distinguishes them only by absence; telling them apart would mean carrying an entry count, which is more than this issue asks for.
- **`Weight` keeps its identity equality.** The model's `==` compares weigh-ins on date, value and unit rather than changing how `Weight` itself compares — that's a Hive model used well outside this feature.
- **No colour legend**, per the issue — the delta and the two weigh-ins behind it explain red vs green.

## Verification

Flutter is not installed in this session and the repo's `CLAUDE.md` says not to install it, so `flutter analyze` and `flutter test` were **not** run locally — verification is deferred to the `flutter_ci.yml` checks on this PR. The change was also reviewed by a separate agent working only from the diff, and tried on a phone via the `test-builds` APK, which is where the tooltip-under-the-finger and drag behaviour were caught.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mtHR2XTR23mGAGsaNQZk5