### PR TITLE
chore: merge the green release-please PR every Sunday

### DIFF
--- a/.github/workflows/sunday-release-merge.yml
+++ b/.github/workflows/sunday-release-merge.yml
@@ -80,7 +80,9 @@ jobs:
 
         # GitHub reports UNKNOWN while it recomputes mergeability after a push.
         for _ in 1 2 3 4 5; do
-          [ "$mergeable" != "UNKNOWN" ] && break
+          if [ "$mergeable" != "UNKNOWN" ]; then
+            break
+          fi
           sleep 10
           mergeable=$(gh pr view "$number" --repo "$REPO" --json mergeable --jq '.mergeable')
         done
@@ -101,7 +103,7 @@ jobs:
         fi
 
         blocking=""
-        while IFS="$(printf '\t')" read -r name status conclusion; do
+        while IFS=$'\t' read -r name status conclusion; do
           if [ "$status" != "completed" ]; then
             blocking="$blocking- \`$name\`: $status"$'\n'
           else

--- a/.github/workflows/sunday-release-merge.yml
+++ b/.github/workflows/sunday-release-merge.yml
@@ -7,9 +7,9 @@ name: Sunday Release Merge
 
 on:
   schedule:
-    # 01:00 UTC Sunday - 04:00 in Israel during IDT, 03:00 during IST. Actions
-    # evaluates cron in UTC with no DST handling, and delays scheduled runs
-    # anyway, so the winter hour of drift is accepted.
+    # Early Sunday. Actions evaluates cron in UTC with no DST handling, so the
+    # local hour this lands on drifts by one across the year; scheduled runs are
+    # queued and delayed anyway, so the drift is accepted.
     - cron: '0 1 * * 0'
   workflow_dispatch:
 

--- a/.github/workflows/sunday-release-merge.yml
+++ b/.github/workflows/sunday-release-merge.yml
@@ -122,7 +122,15 @@ jobs:
         fi
 
         # The squash subject has to stay `chore(main): release X.Y.Z` so
-        # release-please recognises its own release commit on `main`.
-        gh pr merge "$number" --repo "$REPO" --squash --subject "$title" --body ""
+        # release-please recognises its own release commit on `main`, and
+        # --match-head-commit refuses the merge if release-please force-pushed
+        # after the checks above were read - otherwise the green checks that
+        # let the merge through could belong to a commit that is no longer the
+        # one being merged.
+        if ! gh pr merge "$number" --repo "$REPO" --squash \
+          --match-head-commit "$sha" --subject "$title" --body ""; then
+          note "Not merged: the merge call failed - see the step log. The head commit may have moved since its checks were read."
+          exit 1
+        fi
 
-        note "Merged. release-please will tag the release, and build_release.yml will attach the APK to it."
+        note "Merged \`${sha:0:7}\`. release-please will tag the release, and build_release.yml will attach the APK to it."

--- a/.github/workflows/sunday-release-merge.yml
+++ b/.github/workflows/sunday-release-merge.yml
@@ -1,0 +1,126 @@
+name: Sunday Release Merge
+
+# Merges the open release-please PR on Sunday mornings once its checks are
+# green, so the release and its APK are cut without anyone at a keyboard.
+# Everything downstream is already automatic: the merge pushes to `main`,
+# release-please.yml tags the release, build_release.yml attaches the APK.
+
+on:
+  schedule:
+    # 01:00 UTC Sunday - 04:00 in Israel during IDT, 03:00 during IST. Actions
+    # evaluates cron in UTC with no DST handling, and delays scheduled runs
+    # anyway, so the winter hour of drift is accepted.
+    - cron: '0 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    # Every call below authenticates with RELEASE_PLEASE_TOKEN, so GITHUB_TOKEN
+    # needs no scopes of its own.
+    permissions: {}
+
+    steps:
+    - name: Merge the release PR when it is green
+      env:
+        # A merge performed with GITHUB_TOKEN pushes to `main` without
+        # triggering release-please.yml, which would leave no release and no
+        # APK - the same PAT that opens the release PR has to close it.
+        GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        note() { printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"; }
+
+        if [ -z "${GH_TOKEN:-}" ]; then
+          note "### Release merge failed"
+          note ""
+          note "\`RELEASE_PLEASE_TOKEN\` is not set, and merging with \`GITHUB_TOKEN\` would push to \`main\` without cutting a release. Nothing was merged."
+          exit 1
+        fi
+
+        prs=$(gh pr list --repo "$REPO" --state open --base main \
+          --label 'autorelease: pending' --limit 20 \
+          --json number,title,url,isDraft,mergeable,headRefOid)
+        count=$(jq 'length' <<<"$prs")
+
+        if [ "$count" -eq 0 ]; then
+          note "### Nothing to release"
+          note ""
+          note "No open PR labelled \`autorelease: pending\` targets \`main\`."
+          exit 0
+        fi
+
+        if [ "$count" -gt 1 ]; then
+          note "### Skipped: $count release PRs"
+          note ""
+          note "More than one open PR carries \`autorelease: pending\`, so there is no way to tell which one is the release. Merge one by hand:"
+          note ""
+          jq -r '.[] | "- \(.url) - \(.title)"' <<<"$prs" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        number=$(jq -r '.[0].number' <<<"$prs")
+        title=$(jq -r '.[0].title' <<<"$prs")
+        url=$(jq -r '.[0].url' <<<"$prs")
+        draft=$(jq -r '.[0].isDraft' <<<"$prs")
+        sha=$(jq -r '.[0].headRefOid' <<<"$prs")
+        mergeable=$(jq -r '.[0].mergeable' <<<"$prs")
+
+        note "### Release PR #$number"
+        note ""
+        note "[$title]($url)"
+        note ""
+
+        if [ "$draft" = "true" ]; then
+          note "Not merged: the PR is a draft."
+          exit 0
+        fi
+
+        # GitHub reports UNKNOWN while it recomputes mergeability after a push.
+        for _ in 1 2 3 4 5; do
+          [ "$mergeable" != "UNKNOWN" ] && break
+          sleep 10
+          mergeable=$(gh pr view "$number" --repo "$REPO" --json mergeable --jq '.mergeable')
+        done
+
+        if [ "$mergeable" != "MERGEABLE" ]; then
+          note "Not merged: GitHub reports the PR as \`$mergeable\`."
+          exit 0
+        fi
+
+        checks=$(gh api --paginate "repos/$REPO/commits/$sha/check-runs?per_page=100" \
+          --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion // "")"')
+
+        # No checks at all is not a pass: it means CI stopped running on the
+        # release PR, which would make an "everything green" gate vacuous.
+        if [ -z "$checks" ]; then
+          note "Not merged: the head commit \`${sha:0:7}\` has no check runs at all."
+          exit 0
+        fi
+
+        blocking=""
+        while IFS="$(printf '\t')" read -r name status conclusion; do
+          if [ "$status" != "completed" ]; then
+            blocking="$blocking- \`$name\`: $status"$'\n'
+          else
+            case "$conclusion" in
+              success|neutral|skipped) ;;
+              *) blocking="$blocking- \`$name\`: $conclusion"$'\n' ;;
+            esac
+          fi
+        done <<<"$checks"
+
+        if [ -n "$blocking" ]; then
+          note "Not merged: these checks are not green."
+          note ""
+          printf '%s' "$blocking" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        # The squash subject has to stay `chore(main): release X.Y.Z` so
+        # release-please recognises its own release commit on `main`.
+        gh pr merge "$number" --repo "$REPO" --squash --subject "$title" --body ""
+
+        note "Merged. release-please will tag the release, and build_release.yml will attach the APK to it."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,6 +37,14 @@ When the team decides it is time to cut a release:
 3. The creation of that GitHub Release then triggers our `build_release.yml` workflow.
 4. `build_release.yml` builds a production-signed Android APK securely on CI, names it with the new version and build number, and uploads it to the action artifacts.
 
+### Merging the Release PR automatically
+
+Step 1 also happens on its own. `sunday-release-merge.yml` runs at 01:00 UTC every Sunday (04:00 in Israel during IDT) and squash-merges the open release PR, so a week's worth of merged features ships without anyone doing anything. The same workflow has a **Run workflow** button for shipping immediately, which works from the GitHub mobile app.
+
+It fails closed and merges nothing if the release PR is red, still running, has no checks at all, or cannot be merged — and if more than one PR carries the `autorelease: pending` label, since there is then no way to tell which one is the release. Every run writes what it did, or why it did nothing, to its job summary.
+
+The merge is performed with `RELEASE_PLEASE_TOKEN` rather than the default `GITHUB_TOKEN`: a push made with `GITHUB_TOKEN` does not trigger other workflows, so the release-please run that cuts the release and tag would never fire.
+
 ## 4. Setting up Release Signing
 
 To build a production release, you need a Keystore to cryptographically sign the Android APK.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,7 +39,7 @@ When the team decides it is time to cut a release:
 
 ### Merging the Release PR automatically
 
-Step 1 also happens on its own. `sunday-release-merge.yml` runs at 01:00 UTC every Sunday (04:00 in Israel during IDT) and squash-merges the open release PR, so a week's worth of merged features ships without anyone doing anything. The same workflow has a **Run workflow** button for shipping immediately, which works from the GitHub mobile app.
+Step 1 also happens on its own. `sunday-release-merge.yml` runs at 01:00 UTC every Sunday and squash-merges the open release PR, so a week's worth of merged features ships without anyone doing anything. The same workflow has a **Run workflow** button for shipping immediately, which works from the GitHub mobile app.
 
 It fails closed and merges nothing if the release PR is red, still running, has no checks at all, or cannot be merged — and if more than one PR carries the `autorelease: pending` label, since there is then no way to tell which one is the release. Every run writes what it did, or why it did nothing, to its job summary.
 


### PR DESCRIPTION
## What changed

A new `.github/workflows/sunday-release-merge.yml` closes the last manual link in the release chain. It runs on `schedule` (`0 1 * * 0`) and on `workflow_dispatch`, finds the open PR labelled `autorelease: pending` targeting `main`, and squash-merges it once it is mergeable and every check run on its head commit is green. Everything after that is already automatic: the push to `main` triggers `release-please.yml`, which cuts the release and tag, which triggers `build_release.yml`, which attaches the APK.

The merge authenticates with `RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN` — a push made with `GITHUB_TOKEN` does not trigger other workflows, so a merge performed with it would silently produce no release and no APK. The workflow also fails with a loud job summary if that secret is missing, rather than falling back to a token that would break the chain.

`RELEASING.md` §3 said "merge the bot's PR" as a manual step, so it now carries a short subsection describing the automatic merge, its manual **Run workflow** button, and the token requirement.

### Every path writes a job summary

| Situation | Outcome |
|---|---|
| No `autorelease: pending` PR | Clean no-op, "Nothing to release" |
| More than one such PR | Merges nothing, lists both, asks for a hand merge |
| PR is a draft | Skipped, reason recorded |
| PR is `CONFLICTING` (or still `UNKNOWN` after 5 retries) | Skipped, the reported state named |
| Head commit has **zero** check runs | Skipped — a vacuous "all green" is not a pass |
| Any check pending / failed / cancelled / timed out | Skipped, with each blocking check and its state listed |
| All green | Squash-merged, keeping the `chore(main): release X.Y.Z` subject |

## How each acceptance criterion is met

| From #118 | Where |
|---|---|
| Both `schedule` (`0 1 * * 0`) and `workflow_dispatch` triggers | `on:` block |
| Merge uses `RELEASE_PLEASE_TOKEN` | `GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}`, the only credential in the job; `permissions: {}` leaves `GITHUB_TOKEN` with no scopes so it cannot be used by accident |
| Red / pending / unmergeable / check-less PR left untouched, reason in the summary | the guards above, each `exit 0` after a `note` |
| More than one `autorelease: pending` PR merges nothing, with the reason | `count -gt 1` branch, which lists the candidates |
| No open release PR is a clean no-op | `count -eq 0` branch, exit 0 |
| Verified end to end via `workflow_dispatch` | **Not done here** — see below |

## Decisions made along the way

- **`gh` CLI over the raw API**, matching `build_release.yml` and `build_test.yml`, which already shell out to `gh` on the runner.
- **Passing conclusions are an allowlist, not a denylist.** The issue names `pending`, `failure`, `cancelled` and `timed_out` as blocking; the script instead treats only `success`, `neutral` and `skipped` as passing, so a conclusion nobody anticipated (`action_required`, `stale`) blocks rather than slips through. Same intent, one fewer way to be wrong later.
- **Mergeability is retried before it is believed.** GitHub reports `UNKNOWN` while it recomputes the merge commit after a push, so the script polls five times at 10s before treating an unresolved state as a skip — fail-closed, without skipping a perfectly mergeable PR just because the API had not caught up.
- **The squash body is set to empty** (`--body ""`). `gh`'s default body is the PR's commit messages, and the release PR's changelog can legitimately contain a `BREAKING CHANGE:` line; leaving it in the squash commit on `main` risks release-please reading it as a footer and mis-bumping the *next* version.
- **The branch is not deleted** after merging. release-please force-pushes the same branch name for the next release, and deleting it here would add a race for no gain.
- **The winter DST hour of drift is accepted**, as the issue proposes — no second cron entry and no `TZ` guard step.

## Verification

This change is a workflow file, so there is nothing for `flutter analyze` or `flutter test` to cover, and no Dart test can exercise it. In this session neither local shell execution nor Python was available to lint the YAML or dry-run the script against a stubbed `gh`, so **the script was verified by review only** — read line by line against the `gh`/`jq` behaviours it depends on, and against the two existing workflows that already use `gh` on the runner.

Which leaves the issue's last acceptance criterion — *verified end to end at least once via `workflow_dispatch`: release PR merged → release tagged → APK attached* — deliberately **not** met by this PR. Doing it means merging the real open release PR (#113) and cutting a real release, which is not something to do unattended. Once this is on `main`, running **Sunday Release Merge → Run workflow** performs exactly that end-to-end check; #113 being green makes it a good first subject.

Worth knowing before that first run: `schedule` triggers only fire from the default branch, so nothing happens on any Sunday until this is merged.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7zZsPKbq5RebVocjJX18s

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7zZsPKbq5RebVocjJX18s)_