### PR TITLE
feat: capture the user's height in Settings, in metric or imperial

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ Key layering for the weight feature:
 
 Dates are treated as day-granular throughout: repository keys and equality normalize to `(year, month, day)`, so "one entry per day" is the invariant. When adding mutation paths, follow the existing pattern (write through the repository, then refresh `_weights` from it).
 
+Settings preferences are a third store, on `shared_preferences` rather than Hive or Drift: `SettingsRepository` (interface, with `PreferencesSettingsRepository` and `InMemorySettingsRepository`) holds the single current values that are not a dated series — the height in centimetres and the `MeasurementSystem` heights are displayed in — and `SettingsManager` exposes them to the UI. Centimetres are the internal unit; imperial is converted at the input/display boundary through `lib/core/units.dart`. An unset height is `null`, never a default.
+
 The bite feature mirrors this shape (interface + manager) on Drift instead of Hive:
 
 - **`BiteDatabase`** (`bite_database.dart`) — two tables: `bites` (append-only `at_ms` epoch-millis log; only the raw timestamp is stored) and `pacing_config` (versioned `b1_s`/`b2_s` thresholds, a slowly-changing dimension seeded with a default on first run).
@@ -46,7 +48,7 @@ The bite feature mirrors this shape (interface + manager) on Drift instead of Hi
 
 ### Backup / restore
 
-`SerializationService` (Settings tab) exports/imports one zip spanning **both** stores. Each dataset owns a per-store codec — `WeightBackupCodec` (`weight.csv`), `BiteBackupCodec` (`bites.csv`, raw `at_ms`), and `PacingConfigBackupCodec` (`pacing_config.csv`, the threshold versions) — and `SerializationService` coordinates them into a single archive. `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable (`clearAllData` is the same clear with nothing restored after it, behind the Settings "Clear All Data" action); it always replaces weights, and replaces bites / pacing config only when the archive actually carries that entry (an older backup missing an entry leaves that store untouched), deduping on import (repeated instants for bites, repeated `effective_ms` for config). Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
+`SerializationService` (Settings tab) exports/imports one zip spanning **every** store. Each dataset owns a per-store codec — `WeightBackupCodec` (`weight.csv`), `BiteBackupCodec` (`bites.csv`, raw `at_ms`), `PacingConfigBackupCodec` (`pacing_config.csv`, the threshold versions), and `ProfileBackupCodec` (`profile.csv`, the stored height) — and `SerializationService` coordinates them into a single archive. `restoreFromBackup` is the destructive clear-then-restore core, kept separate from file-picker/IO so it stays unit-testable (`clearAllData` is the same clear with nothing restored after it, behind the Settings "Clear All Data" action); it always replaces weights, and replaces bites / pacing config / profile only when the archive actually carries that entry (an older backup missing an entry leaves that store untouched), deduping on import (repeated instants for bites, repeated `effective_ms` for config). Core CSV helpers live in `lib/core/` (`csv_serializer.dart`, `where.dart`).
 
 ## Testing
 

--- a/lib/core/units.dart
+++ b/lib/core/units.dart
@@ -1,0 +1,55 @@
+/// The system a figure is shown and typed in. Storage stays metric whatever
+/// this says — it is a display-and-input concern, converted at the boundary.
+enum MeasurementSystem { metric, imperial }
+
+/// Exact by definition, and the only place the inch is spelled out.
+const double centimetresPerInch = 2.54;
+
+const int inchesPerFoot = 12;
+
+double inchesToCentimetres(double inches) => inches * centimetresPerInch;
+
+double centimetresToInches(double centimetres) =>
+    centimetres / centimetresPerInch;
+
+/// A length the way a height is said out loud: whole feet plus the inches left
+/// over.
+class FeetInches {
+  final int feet;
+  final double inches;
+
+  const FeetInches(this.feet, this.inches);
+}
+
+FeetInches centimetresToFeetInches(double centimetres) {
+  final totalInches = centimetresToInches(centimetres);
+  final feet = totalInches ~/ inchesPerFoot;
+  return FeetInches(feet, totalInches - feet * inchesPerFoot);
+}
+
+double feetInchesToCentimetres(int feet, double inches) =>
+    inchesToCentimetres(feet * inchesPerFoot + inches);
+
+/// A bare number with at most one decimal and no trailing `.0`, so a whole
+/// height reads `178` rather than `178.0`.
+String formatLengthValue(double value) {
+  final text = value.toStringAsFixed(1);
+  return text.endsWith('.0') ? text.substring(0, text.length - 2) : text;
+}
+
+/// [centimetres] as it reads in [system]: `177.5 cm`, or `5' 10"`.
+String formatHeight(double centimetres, MeasurementSystem system) {
+  if (system == MeasurementSystem.metric) {
+    return '${formatLengthValue(centimetres)} cm';
+  }
+
+  final split = centimetresToFeetInches(centimetres);
+  var feet = split.feet;
+  var inches = split.inches.round();
+  // Rounding 11.6" up would otherwise print 12".
+  if (inches == inchesPerFoot) {
+    feet += 1;
+    inches = 0;
+  }
+  return "$feet' $inches\"";
+}

--- a/lib/core/units.dart
+++ b/lib/core/units.dart
@@ -30,6 +30,17 @@ FeetInches centimetresToFeetInches(double centimetres) {
 double feetInchesToCentimetres(int feet, double inches) =>
     inchesToCentimetres(feet * inchesPerFoot + inches);
 
+/// [centimetres] as feet and inches rounded to [decimals] places, carrying a
+/// rounded-up twelve into the next foot so no display or field ever reads
+/// `5' 12"`.
+FeetInches roundedFeetInches(double centimetres, int decimals) {
+  final split = centimetresToFeetInches(centimetres);
+  final inches = double.parse(split.inches.toStringAsFixed(decimals));
+  return inches >= inchesPerFoot
+      ? FeetInches(split.feet + 1, 0)
+      : FeetInches(split.feet, inches);
+}
+
 /// A bare number with at most one decimal and no trailing `.0`, so a whole
 /// height reads `178` rather than `178.0`.
 String formatLengthValue(double value) {
@@ -43,13 +54,6 @@ String formatHeight(double centimetres, MeasurementSystem system) {
     return '${formatLengthValue(centimetres)} cm';
   }
 
-  final split = centimetresToFeetInches(centimetres);
-  var feet = split.feet;
-  var inches = split.inches.round();
-  // Rounding 11.6" up would otherwise print 12".
-  if (inches == inchesPerFoot) {
-    feet += 1;
-    inches = 0;
-  }
-  return "$feet' $inches\"";
+  final split = roundedFeetInches(centimetres, 0);
+  return "${split.feet}' ${formatLengthValue(split.inches)}\"";
 }

--- a/lib/features/settings/data/in_memory_settings_repository.dart
+++ b/lib/features/settings/data/in_memory_settings_repository.dart
@@ -1,0 +1,29 @@
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
+
+class InMemorySettingsRepository implements SettingsRepository {
+  double? _heightCm;
+  MeasurementSystem _measurementSystem;
+
+  InMemorySettingsRepository({
+    double? heightCm,
+    MeasurementSystem measurementSystem = MeasurementSystem.metric,
+  })  : _heightCm = heightCm,
+        _measurementSystem = measurementSystem;
+
+  @override
+  double? get heightCm => _heightCm;
+
+  @override
+  Future<void> setHeightCm(double? centimetres) async {
+    _heightCm = centimetres;
+  }
+
+  @override
+  MeasurementSystem get measurementSystem => _measurementSystem;
+
+  @override
+  Future<void> setMeasurementSystem(MeasurementSystem system) async {
+    _measurementSystem = system;
+  }
+}

--- a/lib/features/settings/data/preferences_settings_repository.dart
+++ b/lib/features/settings/data/preferences_settings_repository.dart
@@ -1,0 +1,42 @@
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The production [SettingsRepository], on `shared_preferences`. The instance
+/// is loaded once at startup, which is what lets the getters stay synchronous.
+class PreferencesSettingsRepository implements SettingsRepository {
+  static const String heightKey = 'height_cm';
+  static const String measurementSystemKey = 'measurement_system';
+
+  final SharedPreferences _preferences;
+
+  PreferencesSettingsRepository(this._preferences);
+
+  @override
+  double? get heightCm => _preferences.getDouble(heightKey);
+
+  @override
+  Future<void> setHeightCm(double? centimetres) async {
+    if (centimetres == null) {
+      await _preferences.remove(heightKey);
+      return;
+    }
+    await _preferences.setDouble(heightKey, centimetres);
+  }
+
+  /// Anything unrecognised — nothing stored yet, or a name from a build that
+  /// knew more systems — reads as metric rather than throwing.
+  @override
+  MeasurementSystem get measurementSystem {
+    final stored = _preferences.getString(measurementSystemKey);
+    return MeasurementSystem.values.firstWhere(
+      (system) => system.name == stored,
+      orElse: () => MeasurementSystem.metric,
+    );
+  }
+
+  @override
+  Future<void> setMeasurementSystem(MeasurementSystem system) async {
+    await _preferences.setString(measurementSystemKey, system.name);
+  }
+}

--- a/lib/features/settings/data/profile_backup_codec.dart
+++ b/lib/features/settings/data/profile_backup_codec.dart
@@ -1,0 +1,82 @@
+import 'package:archive/archive.dart';
+import 'package:food_locker/core/csv_serializer.dart';
+
+/// The profile facts a backup carries. A type of its own rather than a bare
+/// `double?` so an import can tell an archive that says "no height recorded"
+/// from an archive that doesn't describe a profile at all.
+class ProfileBackup {
+  final double? heightCm;
+
+  const ProfileBackup({required this.heightCm});
+}
+
+/// CSV backup logic for the profile preferences.
+///
+/// The height lives in `shared_preferences` rather than in either data store,
+/// so without this entry it would survive a "Clear All Data" and vanish on a
+/// restore. This codec turns it into a `profile.csv` entry that
+/// `SerializationService` packs into the same zip as the other datasets.
+///
+/// Only the height is carried: the measurement system is how this device shows
+/// figures, not a fact about the user worth moving between installs.
+class ProfileBackupCodec {
+  /// The profile dataset's entry inside a backup zip.
+  static const String profileFileName = 'profile.csv';
+
+  static const String heightColumn = 'height_cm';
+
+  const ProfileBackupCodec();
+
+  /// The profile CSV packaged as a single [ArchiveFile], so it can be added to
+  /// a shared archive that also carries the weight, bite and pacing CSVs.
+  ArchiveFile toArchiveFile(double? heightCm) {
+    final csvContent = generateProfileCsv(heightCm);
+    return ArchiveFile(
+      profileFileName,
+      csvContent.length,
+      csvContent.codeUnits,
+    );
+  }
+
+  /// One row, exported whether or not a height was ever entered — an unset
+  /// height is an empty cell, so a restore reproduces "not answered" rather
+  /// than leaving whatever the device happened to hold.
+  String generateProfileCsv(double? heightCm) {
+    return CsvSerializer.toCSV([
+      {heightColumn: heightCm},
+    ]);
+  }
+
+  /// The profile carried by a decoded [archive], or null when the archive has
+  /// no profile entry at all.
+  ///
+  /// The null vs. empty distinction is load-bearing on import, as it is for the
+  /// bite and pacing entries: an older backup doesn't describe the profile and
+  /// must leave the stored height untouched, whereas a present entry is a full
+  /// snapshot and replaces it.
+  ProfileBackup? fromArchive(Archive archive) {
+    for (final file in archive) {
+      if (file.isFile && file.name == profileFileName) {
+        final content = String.fromCharCodes(file.content as List<int>);
+        return parseProfileCsv(content);
+      }
+    }
+    return null;
+  }
+
+  /// The first row's height, or a profile with no height when the entry holds
+  /// no row, an empty cell, or something unparseable — the entry is present
+  /// either way, and a present entry is a snapshot.
+  ProfileBackup parseProfileCsv(String csv) {
+    for (final item in CsvSerializer.fromCSV(csv)) {
+      final raw = item[heightColumn];
+      final height = raw is num
+          ? raw.toDouble()
+          : double.tryParse(raw?.toString() ?? '');
+      return ProfileBackup(
+        heightCm: height != null && height > 0 ? height : null,
+      );
+    }
+    return const ProfileBackup(heightCm: null);
+  }
+}

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -6,6 +6,8 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
 import 'package:food_locker/features/settings/data/pacing_config_backup_codec.dart';
+import 'package:food_locker/features/settings/data/profile_backup_codec.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
@@ -42,18 +44,22 @@ class SerializationService {
   Future<bool> exportData(BuildContext context, {VoidCallback? onShareReady}) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
+    final settingsRepo = context.read<SettingsRepository>();
 
     final weights = weightRepo.getAllWeights();
     final bites = await _allBites(biteRepo);
+    // A height is something the user entered, so it counts as data worth
+    // exporting on its own — unlike the pacing thresholds, which are seeded.
+    final heightCm = settingsRepo.heightCm;
 
-    if (weights.isEmpty && bites.isEmpty) return false;
+    if (weights.isEmpty && bites.isEmpty && heightCm == null) return false;
 
     // Pacing config rides along with real data rather than gating the export:
     // the default is always seeded, so it never on its own makes a backup
     // "non-empty".
     final configs = await biteRepo.allPacingConfigs();
 
-    final zipData = encodeBackup(weights, bites, configs);
+    final zipData = encodeBackup(weights, bites, configs, heightCm: heightCm);
 
     final tempDir = await getTemporaryDirectory();
     final zipFile = File('${tempDir.path}/${generateZipFileName()}');
@@ -66,20 +72,22 @@ class SerializationService {
     return true;
   }
 
-  /// Packs every dataset into a single backup zip — weights, bites, and the
-  /// pacing-config history. Each dataset owns its own codec; the coordination —
-  /// one archive, one file per dataset — lives here so a single export call
-  /// spans both stores.
+  /// Packs every dataset into a single backup zip — weights, bites, the
+  /// pacing-config history, and the profile. Each dataset owns its own codec;
+  /// the coordination — one archive, one file per dataset — lives here so a
+  /// single export call spans every store.
   @visibleForTesting
   List<int> encodeBackup(
     List<Weight> weights,
     List<Bite> bites,
-    List<PacingConfig> configs,
-  ) {
+    List<PacingConfig> configs, {
+    double? heightCm,
+  }) {
     final archive = Archive()
       ..addFile(const WeightBackupCodec().toArchiveFile(weights))
       ..addFile(const BiteBackupCodec().toArchiveFile(bites))
-      ..addFile(const PacingConfigBackupCodec().toArchiveFile(configs));
+      ..addFile(const PacingConfigBackupCodec().toArchiveFile(configs))
+      ..addFile(const ProfileBackupCodec().toArchiveFile(heightCm));
     return ZipEncoder().encode(archive);
   }
 
@@ -111,6 +119,7 @@ class SerializationService {
   }) async {
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
+    final settingsRepo = context.read<SettingsRepository>();
 
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -128,6 +137,7 @@ class SerializationService {
       weightRepo,
       biteRepo,
       bytes,
+      settingsRepo: settingsRepo,
       fileName: picked.name,
       onConfirm: onConfirm,
       onRestoreStart: onRestoreStart,
@@ -142,6 +152,7 @@ class SerializationService {
     WeightRepository weightRepo,
     BiteRepository biteRepo,
     List<int> zipBytes, {
+    SettingsRepository? settingsRepo,
     required String fileName,
     ConfirmRestore? onConfirm,
     VoidCallback? onRestoreStart,
@@ -150,7 +161,12 @@ class SerializationService {
 
     onRestoreStart?.call();
 
-    await restoreFromBackup(weightRepo, biteRepo, zipBytes);
+    await restoreFromBackup(
+      weightRepo,
+      biteRepo,
+      zipBytes,
+      settingsRepo: settingsRepo,
+    );
     return true;
   }
 
@@ -164,28 +180,36 @@ class SerializationService {
   /// config until the next app start.
   Future<void> clearAllData(
     WeightRepository weightRepo,
-    BiteRepository biteRepo,
-  ) async {
+    BiteRepository biteRepo, {
+    SettingsRepository? settingsRepo,
+  }) async {
     await weightRepo.clear();
     await biteRepo.clearBites();
     await biteRepo.clearPacingConfigs();
     await biteRepo.setPacingConfig(defaultPacingConfig);
+    // Back to unanswered rather than to a default body.
+    await settingsRepo?.setHeightCm(null);
   }
 
-  /// Replaces both stores' contents with a backup zip — the destructive core of
-  /// [importData], kept separate from the file-picker and file-I/O plumbing so
-  /// the clear-then-restore path stays unit-testable.
+  /// Replaces every store's contents with a backup zip — the destructive core
+  /// of [importData], kept separate from the file-picker and file-I/O plumbing
+  /// so the clear-then-restore path stays unit-testable.
   ///
-  /// The single decode is where the two stores are coordinated: weights and
-  /// bites are restored from the same archive. Weights are always
-  /// replaced; bites are replaced only when the archive actually carries a bite
-  /// entry, so restoring an older weight-only backup leaves existing bites
-  /// alone rather than wiping them.
+  /// The single decode is where the stores are coordinated: weights, bites and
+  /// the profile are restored from the same archive. Weights are always
+  /// replaced; bites, the pacing config and the profile are replaced only when
+  /// the archive actually carries their entry, so restoring an older
+  /// weight-only backup leaves them alone rather than wiping them.
+  ///
+  /// [settingsRepo] is optional only for tests that don't exercise the profile
+  /// entry; the app always passes one, and without it a backup's height is
+  /// decoded and dropped.
   Future<void> restoreFromBackup(
     WeightRepository weightRepo,
     BiteRepository biteRepo,
-    List<int> zipBytes,
-  ) async {
+    List<int> zipBytes, {
+    SettingsRepository? settingsRepo,
+  }) async {
     final archive = ZipDecoder().decodeBytes(zipBytes);
 
     final weights = const WeightBackupCodec().fromArchive(archive);
@@ -220,6 +244,14 @@ class SerializationService {
           await biteRepo.setPacingConfig(cfg);
         }
       }
+    }
+
+    final profile = const ProfileBackupCodec().fromArchive(archive);
+    if (profile != null && settingsRepo != null) {
+      // A present entry is a full snapshot, so a backup taken before a height
+      // was entered restores the unanswered state rather than keeping this
+      // device's.
+      await settingsRepo.setHeightCm(profile.heightCm);
     }
   }
 }

--- a/lib/features/settings/data/serialization_service.dart
+++ b/lib/features/settings/data/serialization_service.dart
@@ -152,7 +152,7 @@ class SerializationService {
     WeightRepository weightRepo,
     BiteRepository biteRepo,
     List<int> zipBytes, {
-    SettingsRepository? settingsRepo,
+    required SettingsRepository settingsRepo,
     required String fileName,
     ConfirmRestore? onConfirm,
     VoidCallback? onRestoreStart,
@@ -181,14 +181,14 @@ class SerializationService {
   Future<void> clearAllData(
     WeightRepository weightRepo,
     BiteRepository biteRepo, {
-    SettingsRepository? settingsRepo,
+    required SettingsRepository settingsRepo,
   }) async {
     await weightRepo.clear();
     await biteRepo.clearBites();
     await biteRepo.clearPacingConfigs();
     await biteRepo.setPacingConfig(defaultPacingConfig);
     // Back to unanswered rather than to a default body.
-    await settingsRepo?.setHeightCm(null);
+    await settingsRepo.setHeightCm(null);
   }
 
   /// Replaces every store's contents with a backup zip — the destructive core
@@ -200,15 +200,12 @@ class SerializationService {
   /// replaced; bites, the pacing config and the profile are replaced only when
   /// the archive actually carries their entry, so restoring an older
   /// weight-only backup leaves them alone rather than wiping them.
-  ///
-  /// [settingsRepo] is optional only for tests that don't exercise the profile
-  /// entry; the app always passes one, and without it a backup's height is
-  /// decoded and dropped.
+
   Future<void> restoreFromBackup(
     WeightRepository weightRepo,
     BiteRepository biteRepo,
     List<int> zipBytes, {
-    SettingsRepository? settingsRepo,
+    required SettingsRepository settingsRepo,
   }) async {
     final archive = ZipDecoder().decodeBytes(zipBytes);
 
@@ -247,7 +244,7 @@ class SerializationService {
     }
 
     final profile = const ProfileBackupCodec().fromArchive(archive);
-    if (profile != null && settingsRepo != null) {
+    if (profile != null) {
       // A present entry is a full snapshot, so a backup taken before a height
       // was entered restores the unanswered state rather than keeping this
       // device's.

--- a/lib/features/settings/data/settings_manager.dart
+++ b/lib/features/settings/data/settings_manager.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
+
+/// The UI-facing state holder for the profile preferences. Every mutation
+/// writes through the repository and then notifies; reads come straight back
+/// off the repository, so the two never drift.
+class SettingsManager extends ChangeNotifier {
+  final SettingsRepository _repository;
+
+  SettingsManager(this._repository);
+
+  double? get heightCm => _repository.heightCm;
+
+  MeasurementSystem get measurementSystem => _repository.measurementSystem;
+
+  Future<void> setHeightCm(double? centimetres) async {
+    await _repository.setHeightCm(centimetres);
+    notifyListeners();
+  }
+
+  Future<void> setMeasurementSystem(MeasurementSystem system) async {
+    await _repository.setMeasurementSystem(system);
+    notifyListeners();
+  }
+
+  /// For callers that wrote through the repository without going through this
+  /// manager — a backup restore or a clear.
+  Future<void> refresh() async {
+    notifyListeners();
+  }
+}

--- a/lib/features/settings/data/settings_repository.dart
+++ b/lib/features/settings/data/settings_repository.dart
@@ -1,0 +1,20 @@
+import 'package:food_locker/core/units.dart';
+
+/// Persistence for the single-value preferences that sit outside the two data
+/// stores — the ones that are a current answer rather than a dated series.
+///
+/// Reads are synchronous so a page can render a preference without an await;
+/// implementations keep the values in memory and write through on change.
+abstract class SettingsRepository {
+  /// The stored height in centimetres, or null when it was never answered.
+  /// Absence is a real state: nothing may stand a default body in for it.
+  double? get heightCm;
+
+  /// Null clears the height back to unanswered.
+  Future<void> setHeightCm(double? centimetres);
+
+  /// The system heights are shown and entered in. Metric until chosen.
+  MeasurementSystem get measurementSystem;
+
+  Future<void> setMeasurementSystem(MeasurementSystem system);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,10 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
+import 'package:food_locker/features/settings/data/preferences_settings_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/settings/data/settings_manager.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
@@ -14,6 +17,7 @@ import 'package:food_locker/ui/theme.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -32,14 +36,20 @@ void main() async {
   final biteManager = BiteManager(biteRepository);
   await biteManager.initialize();
 
+  final settingsRepository =
+      PreferencesSettingsRepository(await SharedPreferences.getInstance());
+  final settingsManager = SettingsManager(settingsRepository);
+
   runApp(
     MultiProvider(
       providers: [
         Provider<WeightRepository>.value(value: weightRepository),
         Provider<BiteRepository>.value(value: biteRepository),
+        Provider<SettingsRepository>.value(value: settingsRepository),
         Provider<SerializationService>(create: (_) => SerializationService()),
         ChangeNotifierProvider<WeightManager>.value(value: weightManager),
         ChangeNotifierProvider<BiteManager>.value(value: biteManager),
+        ChangeNotifierProvider<SettingsManager>.value(value: settingsManager),
       ],
       child: const MainApp(),
     ),

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:food_locker/core/units.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/settings/data/settings_manager.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
+import 'package:food_locker/ui/widgets/height_dialog.dart';
 import 'package:provider/provider.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -19,23 +23,59 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final settings = context.watch<SettingsManager>();
 
     return Scaffold(
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _buildHeader(theme, 'Data Management'),
-          Card(
-            elevation: 0,
-            color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.2),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-              side: BorderSide(
-                color: theme.colorScheme.outline.withValues(alpha: 0.1),
-                width: 1,
-              ),
+          _buildHeader(theme, 'Profile'),
+          _buildCard(
+            theme,
+            Column(
+              children: [
+                ListTile(
+                  leading: Icon(Icons.height, color: theme.colorScheme.primary),
+                  title: const Text('Height', style: TextStyle(fontWeight: FontWeight.bold)),
+                  subtitle: Text(
+                    settings.heightCm == null
+                        ? 'Not set'
+                        : formatHeight(settings.heightCm!, settings.measurementSystem),
+                  ),
+                  onTap: _editHeight,
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  leading: Icon(Icons.straighten, color: theme.colorScheme.primary),
+                  title: const Text('Units', style: TextStyle(fontWeight: FontWeight.bold)),
+                  subtitle: const Text('How heights are shown and entered.'),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                  child: SegmentedButton<MeasurementSystem>(
+                    segments: const [
+                      ButtonSegment(
+                        value: MeasurementSystem.metric,
+                        label: Text('Metric'),
+                      ),
+                      ButtonSegment(
+                        value: MeasurementSystem.imperial,
+                        label: Text('Imperial'),
+                      ),
+                    ],
+                    selected: {settings.measurementSystem},
+                    onSelectionChanged: (selection) =>
+                        settings.setMeasurementSystem(selection.first),
+                  ),
+                ),
+              ],
             ),
-            child: Column(
+          ),
+          const SizedBox(height: 24),
+          _buildHeader(theme, 'Data Management'),
+          _buildCard(
+            theme,
+            Column(
               children: [
                 ListTile(
                   enabled: !_busy,
@@ -71,7 +111,7 @@ class _SettingsPageState extends State<SettingsPage> {
               enabled: !_busy,
               leading: Icon(Icons.delete_forever, color: theme.colorScheme.error),
               title: const Text('Clear All Data', style: TextStyle(fontWeight: FontWeight.bold)),
-              subtitle: const Text('Permanently delete all weight and bite data.'),
+              subtitle: const Text('Permanently delete all weight, bite and profile data.'),
               onTap: _clearAllData,
             ),
           ),
@@ -111,6 +151,7 @@ class _SettingsPageState extends State<SettingsPage> {
     final service = context.read<SerializationService>();
     final weightManager = context.read<WeightManager>();
     final biteManager = context.read<BiteManager>();
+    final settingsManager = context.read<SettingsManager>();
     var progressShown = false;
 
     try {
@@ -132,6 +173,7 @@ class _SettingsPageState extends State<SettingsPage> {
         // refreshing when it becomes visible.
         await weightManager.refresh();
         await biteManager.refresh();
+        await settingsManager.refresh();
         messenger.showSnackBar(
           const SnackBar(content: Text('Data imported successfully')),
         );
@@ -157,8 +199,8 @@ class _SettingsPageState extends State<SettingsPage> {
           title: const Text('Replace all data?'),
           content: Text(
             'Importing "$fileName" permanently replaces your weight history, '
-            'and the bite log and pacing settings when the backup contains '
-            'them. This cannot be undone.',
+            'and the bite log, pacing settings and height when the backup '
+            'contains them. This cannot be undone.',
           ),
           actions: [
             TextButton(
@@ -183,8 +225,10 @@ class _SettingsPageState extends State<SettingsPage> {
     final service = context.read<SerializationService>();
     final weightRepo = context.read<WeightRepository>();
     final biteRepo = context.read<BiteRepository>();
+    final settingsRepo = context.read<SettingsRepository>();
     final weightManager = context.read<WeightManager>();
     final biteManager = context.read<BiteManager>();
+    final settingsManager = context.read<SettingsManager>();
 
     if (!await _confirmClear() || !mounted) return;
 
@@ -192,7 +236,7 @@ class _SettingsPageState extends State<SettingsPage> {
     messenger.showSnackBar(_progressSnackBar('Clearing data...'));
 
     try {
-      await service.clearAllData(weightRepo, biteRepo);
+      await service.clearAllData(weightRepo, biteRepo, settingsRepo: settingsRepo);
       messenger.removeCurrentSnackBar();
       messenger.showSnackBar(const SnackBar(content: Text('All data cleared')));
     } catch (e) {
@@ -204,6 +248,7 @@ class _SettingsPageState extends State<SettingsPage> {
       // deleted something, so they are re-read either way.
       await weightManager.refresh();
       await biteManager.refresh();
+      await settingsManager.refresh();
       if (mounted) setState(() => _busy = false);
     }
   }
@@ -220,9 +265,9 @@ class _SettingsPageState extends State<SettingsPage> {
         return AlertDialog(
           title: const Text('Clear all data?'),
           content: const Text(
-            'This permanently deletes your weight history, the bite log and '
-            'your pacing settings. It cannot be undone — export a backup first '
-            'if you might want any of it back.',
+            'This permanently deletes your weight history, the bite log, your '
+            'pacing settings and your height. It cannot be undone — export a '
+            'backup first if you might want any of it back.',
           ),
           actions: [
             TextButton(
@@ -240,6 +285,37 @@ class _SettingsPageState extends State<SettingsPage> {
     );
 
     return confirmed ?? false;
+  }
+
+  /// Opens the height editor in the active system and stores whatever it
+  /// returns. Dismissing it changes nothing.
+  Future<void> _editHeight() async {
+    final settings = context.read<SettingsManager>();
+
+    final heightCm = await showDialog<double>(
+      context: context,
+      builder: (context) => HeightDialog(
+        initialHeightCm: settings.heightCm,
+        system: settings.measurementSystem,
+      ),
+    );
+
+    if (heightCm != null) await settings.setHeightCm(heightCm);
+  }
+
+  Widget _buildCard(ThemeData theme, Widget child) {
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.2),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: theme.colorScheme.outline.withValues(alpha: 0.1),
+          width: 1,
+        ),
+      ),
+      child: child,
+    );
   }
 
   Widget _buildHeader(ThemeData theme, String title) {

--- a/lib/ui/widgets/height_dialog.dart
+++ b/lib/ui/widgets/height_dialog.dart
@@ -46,7 +46,7 @@ class _HeightDialogState extends State<HeightDialog> {
     final height = widget.initialHeightCm;
     if (height != null) {
       _centimetresController.text = formatLengthValue(height);
-      final split = centimetresToFeetInches(height);
+      final split = roundedFeetInches(height, 1);
       _feetController.text = '${split.feet}';
       _inchesController.text = formatLengthValue(split.inches);
     }

--- a/lib/ui/widgets/height_dialog.dart
+++ b/lib/ui/widgets/height_dialog.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:food_locker/core/units.dart';
+
+/// Captures a height, in the system the user reads the rest of the app in.
+/// Pops the height in centimetres, or null when it is dismissed.
+///
+/// Imperial takes feet and inches as two fields because nobody types their
+/// height as a decimal number of feet.
+class HeightDialog extends StatefulWidget {
+  /// Rejects typos like a stray decimal point while still admitting every real
+  /// human height.
+  static const double minHeightCm = 50;
+  static const double maxHeightCm = 272;
+
+  static const Key centimetresFieldKey = Key('height-centimetres-field');
+  static const Key feetFieldKey = Key('height-feet-field');
+  static const Key inchesFieldKey = Key('height-inches-field');
+
+  final double? initialHeightCm;
+  final MeasurementSystem system;
+
+  const HeightDialog({
+    super.key,
+    required this.initialHeightCm,
+    required this.system,
+  });
+
+  @override
+  State<HeightDialog> createState() => _HeightDialogState();
+}
+
+class _HeightDialogState extends State<HeightDialog> {
+  final TextEditingController _centimetresController = TextEditingController();
+  final TextEditingController _feetController = TextEditingController();
+  final TextEditingController _inchesController = TextEditingController();
+
+  late final String _initialCentimetresText;
+  late final String _initialFeetText;
+  late final String _initialInchesText;
+
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final height = widget.initialHeightCm;
+    if (height != null) {
+      _centimetresController.text = formatLengthValue(height);
+      final split = centimetresToFeetInches(height);
+      _feetController.text = '${split.feet}';
+      _inchesController.text = formatLengthValue(split.inches);
+    }
+    _initialCentimetresText = _centimetresController.text;
+    _initialFeetText = _feetController.text;
+    _initialInchesText = _inchesController.text;
+  }
+
+  @override
+  void dispose() {
+    _centimetresController.dispose();
+    _feetController.dispose();
+    _inchesController.dispose();
+    super.dispose();
+  }
+
+  bool get _isMetric => widget.system == MeasurementSystem.metric;
+
+  /// Whether every field still holds exactly what it was opened with. A
+  /// cm → ft/in → cm round trip is lossy, so an untouched dialog returns the
+  /// stored value rather than a re-derived one.
+  bool get _untouched {
+    if (_isMetric) {
+      return _centimetresController.text == _initialCentimetresText;
+    }
+    return _feetController.text == _initialFeetText &&
+        _inchesController.text == _initialInchesText;
+  }
+
+  void _submit() {
+    final stored = widget.initialHeightCm;
+    if (stored != null && _untouched) {
+      Navigator.of(context).pop(stored);
+      return;
+    }
+
+    final parsed = _isMetric ? _metricHeightCm() : _imperialHeightCm();
+    if (parsed == null) {
+      setState(() {});
+      return;
+    }
+
+    Navigator.of(context).pop(parsed);
+  }
+
+  /// The entered height in centimetres, or null with [_error] set to a message
+  /// phrased in the unit that was actually typed.
+  double? _metricHeightCm() {
+    final centimetres = _parseNumber(_centimetresController.text);
+    if (centimetres == null) {
+      _error = 'Enter your height in centimetres';
+      return null;
+    }
+    if (!_isPlausible(centimetres)) {
+      _error = 'Enter a height between '
+          '${formatLengthValue(HeightDialog.minHeightCm)} and '
+          '${formatLengthValue(HeightDialog.maxHeightCm)} cm';
+      return null;
+    }
+    _error = null;
+    return centimetres;
+  }
+
+  double? _imperialHeightCm() {
+    final feet = int.tryParse(_feetController.text.trim());
+    // An empty inches field reads as a round number of feet rather than an
+    // error, so "6 feet" can be typed as one number.
+    final inches = _inchesController.text.trim().isEmpty
+        ? 0.0
+        : _parseNumber(_inchesController.text);
+
+    if (feet == null || inches == null || feet < 0 || inches < 0) {
+      _error = 'Enter your height in feet and inches';
+      return null;
+    }
+    // A silent roll-over into the next foot would store a height nobody typed.
+    if (inches >= inchesPerFoot) {
+      _error = 'Inches must be less than $inchesPerFoot';
+      return null;
+    }
+
+    final centimetres = feetInchesToCentimetres(feet, inches);
+    if (!_isPlausible(centimetres)) {
+      _error = 'Enter a height between '
+          '${formatHeight(HeightDialog.minHeightCm, MeasurementSystem.imperial)}'
+          ' and '
+          '${formatHeight(HeightDialog.maxHeightCm, MeasurementSystem.imperial)}';
+      return null;
+    }
+    _error = null;
+    return centimetres;
+  }
+
+  bool _isPlausible(double centimetres) =>
+      centimetres >= HeightDialog.minHeightCm &&
+      centimetres <= HeightDialog.maxHeightCm;
+
+  double? _parseNumber(String raw) =>
+      double.tryParse(raw.trim().replaceAll(',', '.'));
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      title: const Text('Height'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (_isMetric) _metricField() else _imperialFields(),
+          if (_error != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _error!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Widget _metricField() {
+    return TextField(
+      key: HeightDialog.centimetresFieldKey,
+      controller: _centimetresController,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      decoration: const InputDecoration(
+        labelText: 'Height (cm)',
+        hintText: 'e.g. 178',
+        border: OutlineInputBorder(),
+      ),
+      autofocus: true,
+      onSubmitted: (_) => _submit(),
+    );
+  }
+
+  Widget _imperialFields() {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            key: HeightDialog.feetFieldKey,
+            controller: _feetController,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              labelText: 'Feet',
+              hintText: 'e.g. 5',
+              border: OutlineInputBorder(),
+            ),
+            autofocus: true,
+            onSubmitted: (_) => _submit(),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: TextField(
+            key: HeightDialog.inchesFieldKey,
+            controller: _inchesController,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Inches',
+              hintText: 'e.g. 10',
+              border: OutlineInputBorder(),
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/core/units_test.dart
+++ b/test/core/units_test.dart
@@ -43,6 +43,23 @@ void main() {
     });
   });
 
+  group('roundedFeetInches', () {
+    test('rounds the inches to the places asked for', () {
+      final split = roundedFeetInches(177.8, 1);
+
+      expect(split.feet, 5);
+      expect(split.inches, 10);
+    });
+
+    test('a height just under a foot boundary carries instead of reading 12', () {
+      // 182.8 cm is 5' 11.97", which rounds to twelve inches at one decimal.
+      final split = roundedFeetInches(182.8, 1);
+
+      expect(split.feet, 6);
+      expect(split.inches, 0);
+    });
+  });
+
   group('formatHeight', () {
     test('metric drops a trailing zero but keeps a real decimal', () {
       expect(formatHeight(178, MeasurementSystem.metric), '178 cm');

--- a/test/core/units_test.dart
+++ b/test/core/units_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/units.dart';
+
+void main() {
+  group('inch conversions', () {
+    test('an inch is exactly 2.54 cm, both ways', () {
+      expect(inchesToCentimetres(1), 2.54);
+      expect(centimetresToInches(2.54), 1);
+    });
+
+    test('a centimetre survives a round trip', () {
+      expect(centimetresToInches(inchesToCentimetres(70.5)), closeTo(70.5, 1e-9));
+      expect(inchesToCentimetres(centimetresToInches(178)), closeTo(178, 1e-9));
+    });
+  });
+
+  group('feet and inches', () {
+    test('splits centimetres into whole feet and the remainder', () {
+      final split = centimetresToFeetInches(177.8);
+
+      expect(split.feet, 5);
+      expect(split.inches, closeTo(10, 1e-9));
+    });
+
+    test('a height under a foot has no feet', () {
+      final split = centimetresToFeetInches(20.32);
+
+      expect(split.feet, 0);
+      expect(split.inches, closeTo(8, 1e-9));
+    });
+
+    test('recombines into the centimetres it came from', () {
+      final split = centimetresToFeetInches(183.4);
+
+      expect(
+        feetInchesToCentimetres(split.feet, split.inches),
+        closeTo(183.4, 1e-9),
+      );
+    });
+
+    test('five foot ten is 177.8 cm', () {
+      expect(feetInchesToCentimetres(5, 10), closeTo(177.8, 1e-9));
+    });
+  });
+
+  group('formatHeight', () {
+    test('metric drops a trailing zero but keeps a real decimal', () {
+      expect(formatHeight(178, MeasurementSystem.metric), '178 cm');
+      expect(formatHeight(177.5, MeasurementSystem.metric), '177.5 cm');
+    });
+
+    test('imperial reads as feet and whole inches', () {
+      expect(formatHeight(177.8, MeasurementSystem.imperial), "5' 10\"");
+    });
+
+    test('inches rounding up to twelve carry into the next foot', () {
+      // 182.7 cm is 5' 11.93", which must not print as 5' 12".
+      expect(formatHeight(182.7, MeasurementSystem.imperial), "6' 0\"");
+    });
+  });
+
+  group('formatLengthValue', () {
+    test('trims a whole number and rounds to one decimal', () {
+      expect(formatLengthValue(178), '178');
+      expect(formatLengthValue(177.66), '177.7');
+      expect(formatLengthValue(0), '0');
+    });
+  });
+}

--- a/test/features/settings/data/preferences_settings_repository_test.dart
+++ b/test/features/settings/data/preferences_settings_repository_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/features/settings/data/preferences_settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The real persistence path for the profile preferences, on mocked
+/// `shared_preferences` — the store the app ships with, unlike the in-memory
+/// one the other tests lean on.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<PreferencesSettingsRepository> repositoryWith(
+    Map<String, Object> initialValues,
+  ) async {
+    SharedPreferences.setMockInitialValues(initialValues);
+    return PreferencesSettingsRepository(await SharedPreferences.getInstance());
+  }
+
+  test('a fresh install has no height and shows metric', () async {
+    final repository = await repositoryWith({});
+
+    expect(repository.heightCm, isNull);
+    expect(repository.measurementSystem, MeasurementSystem.metric);
+  });
+
+  test('a stored height is read back', () async {
+    final repository = await repositoryWith({});
+
+    await repository.setHeightCm(178.5);
+
+    expect(repository.heightCm, 178.5);
+  });
+
+  test('null removes the key rather than storing a zero', () async {
+    final repository = await repositoryWith({
+      PreferencesSettingsRepository.heightKey: 178.5,
+    });
+
+    await repository.setHeightCm(null);
+
+    expect(repository.heightCm, isNull);
+  });
+
+  test('the measurement system round-trips', () async {
+    final repository = await repositoryWith({});
+
+    await repository.setMeasurementSystem(MeasurementSystem.imperial);
+
+    expect(repository.measurementSystem, MeasurementSystem.imperial);
+  });
+
+  test('an unrecognised stored system falls back to metric', () async {
+    final repository = await repositoryWith({
+      PreferencesSettingsRepository.measurementSystemKey: 'nautical',
+    });
+
+    expect(repository.measurementSystem, MeasurementSystem.metric);
+  });
+}

--- a/test/features/settings/data/profile_backup_codec_test.dart
+++ b/test/features/settings/data/profile_backup_codec_test.dart
@@ -1,0 +1,70 @@
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/features/settings/data/profile_backup_codec.dart';
+
+/// The profile entry's contract: a height round-trips, an archive without the
+/// entry says so with null, and an archive carrying an entry is a snapshot even
+/// when the height in it is blank.
+void main() {
+  const codec = ProfileBackupCodec();
+
+  Archive archiveWith(double? heightCm) =>
+      Archive()..addFile(codec.toArchiveFile(heightCm));
+
+  group('generateProfileCsv', () {
+    test('names the column and carries the height', () {
+      final csv = codec.generateProfileCsv(178.5);
+
+      expect(csv, contains(ProfileBackupCodec.heightColumn));
+      expect(csv, contains('178.5'));
+    });
+  });
+
+  group('fromArchive', () {
+    test('reads back the exported height', () {
+      final profile = codec.fromArchive(archiveWith(178.5));
+
+      expect(profile, isNotNull);
+      expect(profile!.heightCm, 178.5);
+    });
+
+    test('an unset height exports and reads back as unset', () {
+      final profile = codec.fromArchive(archiveWith(null));
+
+      expect(profile, isNotNull);
+      expect(profile!.heightCm, isNull);
+    });
+
+    test('an archive without a profile entry returns null', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile('weight.csv', 4, 'date'.codeUnits));
+
+      expect(codec.fromArchive(archive), isNull);
+    });
+
+    test('an empty profile entry is still a snapshot', () {
+      final archive = Archive()
+        ..addFile(ArchiveFile(ProfileBackupCodec.profileFileName, 0, <int>[]));
+
+      final profile = codec.fromArchive(archive);
+
+      expect(profile, isNotNull);
+      expect(profile!.heightCm, isNull);
+    });
+  });
+
+  group('parseProfileCsv', () {
+    test('drops a value that is not a number', () {
+      expect(codec.parseProfileCsv('height_cm\r\ntall').heightCm, isNull);
+    });
+
+    test('drops a non-positive height', () {
+      expect(codec.parseProfileCsv('height_cm\r\n0').heightCm, isNull);
+      expect(codec.parseProfileCsv('height_cm\r\n-12').heightCm, isNull);
+    });
+
+    test('reads a whole-number height', () {
+      expect(codec.parseProfileCsv('height_cm\r\n178').heightCm, 178.0);
+    });
+  });
+}

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -187,7 +187,7 @@ void main() {
         Weight(date: DateTime(2023, 10, 28), value: 75.0),
       ]);
 
-      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup);
+      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup, settingsRepo: InMemorySettingsRepository());
 
       final restored = repo.getAllWeights();
       expect(restored.map((w) => w.value), containsAll([75.5, 75.0]));
@@ -206,7 +206,7 @@ void main() {
         Weight(date: DateTime(2023, 10, 28), value: 75.0),
       ]);
 
-      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup);
+      await service.restoreFromBackup(repo, _RecordingBiteRepository(), backup, settingsRepo: InMemorySettingsRepository());
 
       // clear must come first, then one save per restored weight.
       expect(repo.operations, ['clear', 'save', 'save']);
@@ -220,6 +220,7 @@ void main() {
         repo,
         _RecordingBiteRepository(),
         codec.encode([]),
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(repo.getAllWeights(), isEmpty);
@@ -237,6 +238,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       // clear must come first, then one log per restored bite.
@@ -257,6 +259,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(biteRepo.loggedMs, [1000]);
@@ -274,6 +277,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       // The bite log is a real (empty) snapshot: cleared, nothing logged.
@@ -291,6 +295,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(biteRepo.operations, isEmpty);
@@ -313,6 +318,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       // clear must come first, then one set per restored version.
@@ -340,6 +346,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(biteRepo.savedConfigs, hasLength(1));
@@ -363,6 +370,7 @@ void main() {
         InMemoryWeightRepository(),
         biteRepo,
         backup,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(biteRepo.configOperations, isEmpty);
@@ -395,6 +403,7 @@ void main() {
         fileName: 'backup.zip',
         onConfirm: (_) async => false,
         onRestoreStart: () => restoreStarted = true,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(restored, isFalse);
@@ -418,6 +427,7 @@ void main() {
         fileName: 'backup.zip',
         onConfirm: (_) async => true,
         onRestoreStart: () => restoreStarted = true,
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(restored, isTrue);
@@ -445,6 +455,7 @@ void main() {
           expect(weightRepo.operations, isEmpty);
           return true;
         },
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(asked, ['food_locker_20260101120000.zip']);
@@ -458,6 +469,7 @@ void main() {
         _RecordingBiteRepository(),
         fullBackup(),
         fileName: 'backup.zip',
+        settingsRepo: InMemorySettingsRepository(),
       );
 
       expect(restored, isTrue);
@@ -480,7 +492,7 @@ void main() {
       biteRepo.operations.clear();
       biteRepo.configOperations.clear();
 
-      await service.clearAllData(weightRepo, biteRepo);
+      await service.clearAllData(weightRepo, biteRepo, settingsRepo: InMemorySettingsRepository());
 
       expect(weightRepo.operations, ['clear']);
       expect(weightRepo.getAllWeights(), isEmpty);
@@ -504,7 +516,7 @@ void main() {
         const PacingConfig(id: 0, effectiveMs: 1, b1S: 40, b2S: 90),
       );
 
-      await service.clearAllData(weightRepo, biteRepo);
+      await service.clearAllData(weightRepo, biteRepo, settingsRepo: InMemorySettingsRepository());
 
       expect(weightRepo.getAllWeights(), isEmpty);
       expect(

--- a/test/features/settings/data/serialization_service_test.dart
+++ b/test/features/settings/data/serialization_service_test.dart
@@ -6,7 +6,9 @@ import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
 import 'package:food_locker/features/bite/data/drift_bite_repository.dart';
 import 'package:food_locker/features/settings/data/bite_backup_codec.dart';
+import 'package:food_locker/features/settings/data/in_memory_settings_repository.dart';
 import 'package:food_locker/features/settings/data/pacing_config_backup_codec.dart';
+import 'package:food_locker/features/settings/data/profile_backup_codec.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
 import 'package:food_locker/features/settings/data/weight_backup_codec.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
@@ -515,6 +517,81 @@ void main() {
       expect(config!.b1S, defaultPacingConfig.b1S);
       expect(config.b2S, defaultPacingConfig.b2S);
       expect(await biteRepo.allPacingConfigs(), hasLength(1));
+    });
+  });
+
+  group('SerializationService profile entry', () {
+    final service = SerializationService();
+
+    List<int> backupWithHeight(double? heightCm) => service.encodeBackup(
+          [Weight(date: DateTime(2026, 1, 1), value: 75.5)],
+          const [],
+          const [],
+          heightCm: heightCm,
+        );
+
+    test('the exported archive carries the height', () {
+      final archive = ZipDecoder().decodeBytes(backupWithHeight(178.5));
+
+      final profile = const ProfileBackupCodec().fromArchive(archive);
+      expect(profile, isNotNull);
+      expect(profile!.heightCm, 178.5);
+    });
+
+    test('a restore replaces the stored height', () async {
+      final settingsRepo = InMemorySettingsRepository(heightCm: 165);
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        _RecordingBiteRepository(),
+        backupWithHeight(178.5),
+        settingsRepo: settingsRepo,
+      );
+
+      expect(settingsRepo.heightCm, 178.5);
+    });
+
+    test('a backup taken before a height was entered restores as unset',
+        () async {
+      final settingsRepo = InMemorySettingsRepository(heightCm: 165);
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        _RecordingBiteRepository(),
+        backupWithHeight(null),
+        settingsRepo: settingsRepo,
+      );
+
+      expect(settingsRepo.heightCm, isNull);
+    });
+
+    test('an archive without a profile entry leaves the height alone',
+        () async {
+      final settingsRepo = InMemorySettingsRepository(heightCm: 165);
+      // An older backup: weights only, no profile entry to speak of.
+      final backup = const WeightBackupCodec()
+          .encode([Weight(date: DateTime(2026, 1, 1), value: 75.5)]);
+
+      await service.restoreFromBackup(
+        InMemoryWeightRepository(),
+        _RecordingBiteRepository(),
+        backup,
+        settingsRepo: settingsRepo,
+      );
+
+      expect(settingsRepo.heightCm, 165);
+    });
+
+    test('a clear takes the height with it', () async {
+      final settingsRepo = InMemorySettingsRepository(heightCm: 178.5);
+
+      await service.clearAllData(
+        InMemoryWeightRepository(),
+        _RecordingBiteRepository(),
+        settingsRepo: settingsRepo,
+      );
+
+      expect(settingsRepo.heightCm, isNull);
     });
   });
 }

--- a/test/features/settings/data/settings_manager_test.dart
+++ b/test/features/settings/data/settings_manager_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/features/settings/data/in_memory_settings_repository.dart';
+import 'package:food_locker/features/settings/data/settings_manager.dart';
+
+void main() {
+  test('an unanswered height reads as null, with no default standing in for it',
+      () {
+    final manager = SettingsManager(InMemorySettingsRepository());
+
+    expect(manager.heightCm, isNull);
+    expect(manager.measurementSystem, MeasurementSystem.metric);
+  });
+
+  test('a stored height is written through and announced', () async {
+    final repository = InMemorySettingsRepository();
+    final manager = SettingsManager(repository);
+    var notifications = 0;
+    manager.addListener(() => notifications++);
+
+    await manager.setHeightCm(178.5);
+
+    expect(repository.heightCm, 178.5);
+    expect(manager.heightCm, 178.5);
+    expect(notifications, 1);
+  });
+
+  test('null clears the height back to unanswered', () async {
+    final repository = InMemorySettingsRepository(heightCm: 178.5);
+    final manager = SettingsManager(repository);
+
+    await manager.setHeightCm(null);
+
+    expect(repository.heightCm, isNull);
+    expect(manager.heightCm, isNull);
+  });
+
+  test('the measurement system is written through and announced', () async {
+    final repository = InMemorySettingsRepository();
+    final manager = SettingsManager(repository);
+    var notifications = 0;
+    manager.addListener(() => notifications++);
+
+    await manager.setMeasurementSystem(MeasurementSystem.imperial);
+
+    expect(repository.measurementSystem, MeasurementSystem.imperial);
+    expect(manager.measurementSystem, MeasurementSystem.imperial);
+    expect(notifications, 1);
+  });
+
+  test('refresh announces a height written behind the manager', () async {
+    final repository = InMemorySettingsRepository();
+    final manager = SettingsManager(repository);
+    var notifications = 0;
+    manager.addListener(() => notifications++);
+
+    // Stands in for a restore, which writes through the repository.
+    await repository.setHeightCm(180);
+    await manager.refresh();
+
+    expect(manager.heightCm, 180);
+    expect(notifications, 1);
+  });
+}

--- a/test/ui/app_shell_test.dart
+++ b/test/ui/app_shell_test.dart
@@ -4,7 +4,10 @@ import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/settings/data/in_memory_settings_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/settings/data/settings_manager.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
@@ -17,15 +20,20 @@ void main() {
     final weightManager = WeightManager(weightRepository);
     await weightManager.initialize();
     final biteManager = BiteManager(biteRepository);
+    final settingsRepository = InMemorySettingsRepository();
 
     await tester.pumpWidget(
       MultiProvider(
         providers: [
           Provider<WeightRepository>.value(value: weightRepository),
           Provider<BiteRepository>.value(value: biteRepository),
+          Provider<SettingsRepository>.value(value: settingsRepository),
           Provider<SerializationService>(create: (_) => SerializationService()),
           ChangeNotifierProvider<WeightManager>.value(value: weightManager),
           ChangeNotifierProvider<BiteManager>.value(value: biteManager),
+          ChangeNotifierProvider<SettingsManager>.value(
+            value: SettingsManager(settingsRepository),
+          ),
         ],
         child: const MaterialApp(home: AppShell()),
       ),

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -2,16 +2,21 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/units.dart';
 import 'package:food_locker/features/bite/data/bite_analytics.dart';
 import 'package:food_locker/features/bite/data/bite_database.dart';
 import 'package:food_locker/features/bite/data/bite_manager.dart';
 import 'package:food_locker/features/bite/data/bite_repository.dart';
+import 'package:food_locker/features/settings/data/in_memory_settings_repository.dart';
 import 'package:food_locker/features/settings/data/serialization_service.dart';
+import 'package:food_locker/features/settings/data/settings_manager.dart';
+import 'package:food_locker/features/settings/data/settings_repository.dart';
 import 'package:food_locker/features/weight/data/in_memory_weight_repository.dart';
 import 'package:food_locker/features/weight/data/weight.dart';
 import 'package:food_locker/features/weight/data/weight_manager.dart';
 import 'package:food_locker/features/weight/data/weight_repository.dart';
 import 'package:food_locker/ui/pages/settings_page.dart';
+import 'package:food_locker/ui/widgets/height_dialog.dart';
 import 'package:provider/provider.dart';
 
 /// Backup feedback on [SettingsPage]: work in flight says so, only work
@@ -25,9 +30,12 @@ void main() {
     BiteManager? biteManager,
     WeightRepository? weightRepo,
     BiteRepository? biteRepo,
+    SettingsRepository? settingsRepo,
+    SettingsManager? settingsManager,
   }) {
     final weights = weightRepo ?? InMemoryWeightRepository();
     final bites = biteRepo ?? _FakeBiteRepository();
+    final settings = settingsRepo ?? InMemorySettingsRepository();
     return tester.pumpWidget(
       MaterialApp(
         home: MultiProvider(
@@ -35,11 +43,15 @@ void main() {
             Provider<SerializationService>.value(value: service),
             Provider<WeightRepository>.value(value: weights),
             Provider<BiteRepository>.value(value: bites),
+            Provider<SettingsRepository>.value(value: settings),
             ChangeNotifierProvider<WeightManager>.value(
               value: weightManager ?? WeightManager(weights),
             ),
             ChangeNotifierProvider<BiteManager>.value(
               value: biteManager ?? _biteManager(bites),
+            ),
+            ChangeNotifierProvider<SettingsManager>.value(
+              value: settingsManager ?? SettingsManager(settings),
             ),
           ],
           child: const SettingsPage(),
@@ -62,13 +74,93 @@ void main() {
     await tester.pump();
   }
 
-  /// Taps Clear All Data and answers the confirmation dialog it raises.
+  /// Taps Clear All Data and answers the confirmation dialog it raises. The
+  /// action sits at the bottom of a scrolling page, so it is brought into view
+  /// first.
   Future<void> tapClear(WidgetTester tester, {required bool confirm}) async {
+    await tester.ensureVisible(find.text('Clear All Data'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Clear All Data'));
     await tester.pumpAndSettle();
     await tester.tap(find.text(confirm ? 'Clear' : 'Cancel'));
     await tester.pump();
   }
+
+  group('profile', () {
+    testWidgets('an unanswered height says so rather than showing a default',
+        (tester) async {
+      await pumpPage(tester, SerializationService());
+
+      expect(find.text('Not set'), findsOneWidget);
+    });
+
+    testWidgets('a stored height shows in the active system', (tester) async {
+      await pumpPage(
+        tester,
+        SerializationService(),
+        settingsRepo: InMemorySettingsRepository(heightCm: 177.8),
+      );
+
+      expect(find.text('177.8 cm'), findsOneWidget);
+
+      await tester.tap(find.text('Imperial'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("5' 10\""), findsOneWidget);
+    });
+
+    testWidgets('the height dialog stores what it returns', (tester) async {
+      final settingsRepo = InMemorySettingsRepository();
+      await pumpPage(
+        tester,
+        SerializationService(),
+        settingsRepo: settingsRepo,
+      );
+
+      await tester.tap(find.text('Height'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(HeightDialog.centimetresFieldKey),
+        '178',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(settingsRepo.heightCm, 178);
+      expect(find.text('178 cm'), findsOneWidget);
+    });
+
+    testWidgets('the chosen measurement system is stored', (tester) async {
+      final settingsRepo = InMemorySettingsRepository();
+      await pumpPage(
+        tester,
+        SerializationService(),
+        settingsRepo: settingsRepo,
+      );
+
+      await tester.tap(find.text('Imperial'));
+      await tester.pumpAndSettle();
+
+      expect(settingsRepo.measurementSystem, MeasurementSystem.imperial);
+    });
+
+    testWidgets('a clear leaves no height on the page', (tester) async {
+      final settingsRepo = InMemorySettingsRepository(heightCm: 177.8);
+      await pumpPage(
+        tester,
+        SerializationService(),
+        settingsRepo: settingsRepo,
+      );
+
+      expect(find.text('177.8 cm'), findsOneWidget);
+
+      await tapClear(tester, confirm: true);
+      await pumpToast(tester);
+
+      expect(settingsRepo.heightCm, isNull);
+      expect(find.text('Not set'), findsOneWidget);
+    });
+  });
 
   group('import', () {
     testWidgets('asks before restoring, naming the file it would replace',
@@ -198,6 +290,8 @@ void main() {
       await weightRepo.saveWeight(Weight(date: DateTime.now(), value: 71.5));
       await pumpPage(tester, SerializationService(), weightRepo: weightRepo);
 
+      await tester.ensureVisible(find.text('Clear All Data'));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Clear All Data'));
       await tester.pumpAndSettle();
 
@@ -396,8 +490,9 @@ class _FakeSerializationService extends SerializationService {
   @override
   Future<void> clearAllData(
     WeightRepository weightRepo,
-    BiteRepository biteRepo,
-  ) async {
+    BiteRepository biteRepo, {
+    SettingsRepository? settingsRepo,
+  }) async {
     await onClear?.call();
     await _work.future;
   }

--- a/test/ui/pages/settings_page_test.dart
+++ b/test/ui/pages/settings_page_test.dart
@@ -491,7 +491,7 @@ class _FakeSerializationService extends SerializationService {
   Future<void> clearAllData(
     WeightRepository weightRepo,
     BiteRepository biteRepo, {
-    SettingsRepository? settingsRepo,
+    required SettingsRepository settingsRepo,
   }) async {
     await onClear?.call();
     await _work.future;

--- a/test/ui/widgets/height_dialog_test.dart
+++ b/test/ui/widgets/height_dialog_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:food_locker/core/units.dart';
+import 'package:food_locker/ui/widgets/height_dialog.dart';
+
+/// What the height editor is allowed to hand back: centimetres, unchanged when
+/// nothing was typed, and nothing at all while the input is implausible.
+void main() {
+  double? popped;
+  bool closed = false;
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    double? initialHeightCm,
+    MeasurementSystem system = MeasurementSystem.metric,
+  }) async {
+    popped = null;
+    closed = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () async {
+                popped = await showDialog<double>(
+                  context: context,
+                  builder: (_) => HeightDialog(
+                    initialHeightCm: initialHeightCm,
+                    system: system,
+                  ),
+                );
+                closed = true;
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> save(WidgetTester tester) async {
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+  }
+
+  group('metric', () {
+    testWidgets('stores what was typed in centimetres', (tester) async {
+      await openDialog(tester);
+
+      await tester.enterText(find.byKey(HeightDialog.centimetresFieldKey), '178');
+      await save(tester);
+
+      expect(popped, 178);
+    });
+
+    testWidgets('accepts a decimal', (tester) async {
+      await openDialog(tester);
+
+      await tester.enterText(
+        find.byKey(HeightDialog.centimetresFieldKey),
+        '177.5',
+      );
+      await save(tester);
+
+      expect(popped, 177.5);
+    });
+
+    testWidgets('an untouched field returns the stored value unchanged',
+        (tester) async {
+      await openDialog(tester, initialHeightCm: 178.23);
+
+      await save(tester);
+
+      expect(popped, 178.23);
+    });
+
+    testWidgets('rejects an implausible height', (tester) async {
+      await openDialog(tester);
+
+      await tester.enterText(find.byKey(HeightDialog.centimetresFieldKey), '10');
+      await save(tester);
+
+      expect(find.textContaining('between'), findsOneWidget);
+      expect(closed, isFalse);
+    });
+
+    testWidgets('rejects something that is not a number', (tester) async {
+      await openDialog(tester);
+
+      await tester.enterText(
+        find.byKey(HeightDialog.centimetresFieldKey),
+        'tall',
+      );
+      await save(tester);
+
+      expect(find.text('Enter your height in centimetres'), findsOneWidget);
+      expect(closed, isFalse);
+    });
+  });
+
+  group('imperial', () {
+    testWidgets('converts feet and inches to centimetres', (tester) async {
+      await openDialog(tester, system: MeasurementSystem.imperial);
+
+      await tester.enterText(find.byKey(HeightDialog.feetFieldKey), '5');
+      await tester.enterText(find.byKey(HeightDialog.inchesFieldKey), '10');
+      await save(tester);
+
+      expect(popped, closeTo(177.8, 1e-9));
+    });
+
+    testWidgets('an empty inches field reads as a round number of feet',
+        (tester) async {
+      await openDialog(tester, system: MeasurementSystem.imperial);
+
+      await tester.enterText(find.byKey(HeightDialog.feetFieldKey), '6');
+      await save(tester);
+
+      expect(popped, closeTo(182.88, 1e-9));
+    });
+
+    testWidgets('untouched fields return the stored centimetres, undrifted',
+        (tester) async {
+      // 178.23 cm has no exact feet-and-inches form, so a re-derived value
+      // would come back slightly different.
+      await openDialog(
+        tester,
+        initialHeightCm: 178.23,
+        system: MeasurementSystem.imperial,
+      );
+
+      await save(tester);
+
+      expect(popped, 178.23);
+    });
+
+    testWidgets('rejects twelve inches rather than rolling over a foot',
+        (tester) async {
+      await openDialog(tester, system: MeasurementSystem.imperial);
+
+      await tester.enterText(find.byKey(HeightDialog.feetFieldKey), '5');
+      await tester.enterText(find.byKey(HeightDialog.inchesFieldKey), '12');
+      await save(tester);
+
+      expect(find.text('Inches must be less than 12'), findsOneWidget);
+      expect(closed, isFalse);
+    });
+
+    testWidgets('rejects an implausible height', (tester) async {
+      await openDialog(tester, system: MeasurementSystem.imperial);
+
+      await tester.enterText(find.byKey(HeightDialog.feetFieldKey), '1');
+      await tester.enterText(find.byKey(HeightDialog.inchesFieldKey), '2');
+      await save(tester);
+
+      expect(find.textContaining('between'), findsOneWidget);
+      expect(closed, isFalse);
+    });
+  });
+
+  testWidgets('cancelling stores nothing', (tester) async {
+    await openDialog(tester, initialHeightCm: 178);
+
+    await tester.enterText(find.byKey(HeightDialog.centimetresFieldKey), '150');
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(closed, isTrue);
+    expect(popped, isNull);
+  });
+}

--- a/test/ui/widgets/height_dialog_test.dart
+++ b/test/ui/widgets/height_dialog_test.dart
@@ -139,6 +139,28 @@ void main() {
       expect(popped, 178.23);
     });
 
+    testWidgets('a height that rounds to twelve inches pre-fills as the next foot',
+        (tester) async {
+      // 182.8 cm is 5' 11.97": pre-filling it as 5 ft / 12 in would show a
+      // height the dialog itself rejects.
+      await openDialog(
+        tester,
+        initialHeightCm: 182.8,
+        system: MeasurementSystem.imperial,
+      );
+
+      String textOf(Key key) =>
+          tester.widget<TextField>(find.byKey(key)).controller!.text;
+
+      expect(textOf(HeightDialog.feetFieldKey), '6');
+      expect(textOf(HeightDialog.inchesFieldKey), '0');
+
+      await tester.enterText(find.byKey(HeightDialog.feetFieldKey), '5');
+      await save(tester);
+
+      expect(popped, closeTo(152.4, 1e-9));
+    });
+
     testWidgets('rejects twelve inches rather than rolling over a foot',
         (tester) async {
       await openDialog(tester, system: MeasurementSystem.imperial);


### PR DESCRIPTION
## What changed

The app's first preference store, plus a Profile section on Settings that captures a height.

- **`lib/core/units.dart`** — the inch defined once (`2.54 cm`, exact), cm↔in and cm↔ft/in conversions, the `MeasurementSystem` enum, and the display formatters (`178 cm`, `5' 10"`). `roundedFeetInches` is the single place a rounded-up twelfth inch carries into the next foot, shared by the display and the input fields.
- **`lib/features/settings/data/`** — `SettingsRepository` (interface) with `PreferencesSettingsRepository` (`shared_preferences`, the dependency that was in `pubspec.yaml` but unused in `lib/`) and `InMemorySettingsRepository` for tests, plus a `SettingsManager extends ChangeNotifier` that writes through the repository and notifies, like the other managers. Both are provided in `lib/main.dart`.
- **`lib/ui/widgets/height_dialog.dart`** — one cm field in metric, two fields (feet + inches) in imperial, with validation phrased in the unit that was typed.
- **`lib/ui/pages/settings_page.dart`** — a Profile section above Data Management: a Height tile showing the value in the active system or "Not set", and a Metric/Imperial control.
- **`ProfileBackupCodec`** — a `profile.csv` entry (`height_cm`) in the backup zip, coordinated by `SerializationService` alongside the existing three.

## How the issue's requirements are met

**Storage**
- `height_cm` double in `shared_preferences`, behind a repository interface and a manager, provided from `main.dart`.
- Unset is a real state: consumers get `null`; nothing substitutes a default height. The page renders "Not set", and `setHeightCm(null)` removes the key rather than storing a zero.
- Inches↔cm helper in `lib/core/`, with `2.54` written once.

**Input**
- Metric: one cm field, decimals allowed but not required (`178`, `177.5`).
- Imperial: feet and inches as two fields; `12`-or-more inches is a validation error, never a silent roll-over into the next foot.
- Editing doesn't drift the stored value: when no field was touched, the dialog returns the stored centimetres verbatim rather than a value re-derived through a lossy ft/in round trip. Covered by tests in both systems.
- Validation runs against what was typed, so metric says "between 50 and 272 cm" and imperial says `between 1' 8" and 8' 11"`. Zero, negative and unparseable input are errors.

**Backup**
- `profile.csv` codec coordinated by `SerializationService`; an archive without the entry leaves the stored height untouched, an archive with it replaces the height (including restoring "unset" from a backup taken before a height was entered).
- `clearAllData` clears the height too, and `settingsRepo` is a required parameter on every destructive path so a caller cannot skip it.

## Decisions made along the way

- **The measurement system is introduced here** (`metric`/`imperial`, one switch), since this issue landed before #120. #120's kg/lbs display preference should read the same `MeasurementSystem` off `SettingsRepository` rather than adding a second preference.
- **A Metric/Imperial control ships with the Height tile.** The issue specifies imperial input but no way to reach it; without a control, imperial would be dead code.
- **The measurement system is not backed up.** `profile.csv` carries only `height_cm`, as the issue specifies — the system is how this device displays figures, not a fact about the user.
- **A height counts as data worth exporting.** Export previously returned "nothing to export" when both stores were empty; a stored height now makes an export non-empty, because unlike the seeded pacing thresholds it is something the user entered.
- **A `ProfileBackup` type rather than a bare `double?`** decoded from the archive, so "the archive says no height" stays distinguishable from "the archive has no profile entry" — the same null-vs-empty contract the bite and pacing codecs rely on.
- No model change, no Hive `typeId`, no Drift table or `schemaVersion` bump — the height has no history.

## Verification

**Flutter is not installed in this environment, so `flutter analyze` and `flutter test` were not run locally** — per `CLAUDE.md`, the toolchain was deliberately not installed and verification is deferred to the `flutter_ci.yml` checks on this PR. The diff was kept small and self-reviewed instead.

Tests added:
- `test/core/units_test.dart` — conversions and round trips at the boundaries, the ft/in split, and the foot-boundary carry that would otherwise read `5' 12"`.
- `test/features/settings/data/settings_manager_test.dart` — unset reads as null, mutations write through and notify, `refresh` picks up a write made behind the manager.
- `test/features/settings/data/preferences_settings_repository_test.dart` — the real `shared_preferences` path: fresh install, round trip, null removing the key, unrecognised stored system falling back to metric.
- `test/features/settings/data/profile_backup_codec_test.dart` — present / absent / empty `profile.csv`, and non-numeric or non-positive values.
- `test/features/settings/data/serialization_service_test.dart` — the height exported, restored, restored-as-unset, left alone by an archive without the entry, and cleared by `clearAllData`.
- `test/ui/widgets/height_dialog_test.dart` — metric and imperial input, the undrifted untouched-field path in both, the foot-boundary pre-fill, 12-plus inches, out-of-range and unparseable input, cancel.
- `test/ui/pages/settings_page_test.dart` — "Not set", the height shown in the active system, the dialog storing what it returns, the system being stored, and a clear leaving no height on the page.

`CLAUDE.md` gains a short note on the new preference store and the fourth backup codec.

A second commit addresses an independent review of this PR: the imperial pre-fill could render `12` inches for a height within a fifth of a millimetre below a foot boundary (fixed, with tests), and `settingsRepo` went from optional to required on the destructive serialization paths.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfFWBNz6Axxwc8RdoP7ekY